### PR TITLE
feat: Integrate LLM serving tests and switch to gemma:2b

### DIFF
--- a/A2A/README.md
+++ b/A2A/README.md
@@ -4,6 +4,14 @@
 
 This project uses `unittest` for testing.
 
+## Deployment
+
+To run the full system including the local LLM:
+
+```bash
+docker compose up -d
+```
+
 ### Prerequisites
 
 - Python 3.10+

--- a/A2A/agent.md
+++ b/A2A/agent.md
@@ -14,6 +14,7 @@ When modifying the A2A system, you MUST perform the following testing procedures
   source venv/bin/activate
   python -m unittest discover tests
   ```
+- For integration tests involving the actual LLM, ensure the environment is running via `docker compose up -d`.
 
 ### 3. CI/CD Checks
 - If you add new agents or logic, add corresponding unit tests in `tests/`.

--- a/A2A/agents/summarizer.py
+++ b/A2A/agents/summarizer.py
@@ -59,7 +59,7 @@ class SummarizerAgent(BaseAgent):
             # Ensure OLLAMA_HOST is picked up from env if set
             prompt = f"Please summarize the following project updates and status information into a concise daily briefing:\n\n{combined_text}"
 
-            response = ollama.chat(model='gemma:4b', messages=[
+            response = ollama.chat(model='gemma:2b', messages=[
                 {'role': 'user', 'content': prompt},
             ])
 

--- a/A2A/docker-compose.yml
+++ b/A2A/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       - ollama_data:/root/.ollama
     ports:
       - "11434:11434"
-    entrypoint: ["/bin/sh", "-c", "ollama serve & sleep 5 && ollama pull gemma:4b && wait"]
 
   app:
     build: .

--- a/A2A/run_local.sh
+++ b/A2A/run_local.sh
@@ -28,10 +28,10 @@ if ! command -v ollama &> /dev/null; then
 fi
 
 # 5. Check if Model exists, if not pull it
-echo "Checking for Gemma 4B model..."
-if ! ollama list | grep -q "gemma:4b"; then
-    echo "Pulling gemma:4b model (this may take a while)..."
-    ollama pull gemma:4b
+echo "Checking for Gemma 2B model..."
+if ! ollama list | grep -q "gemma:2b"; then
+    echo "Pulling gemma:2b model (this may take a while)..."
+    ollama pull gemma:2b
 fi
 
 # 6. Run the application

--- a/A2A/tests/integration/test_llm_serving.py
+++ b/A2A/tests/integration/test_llm_serving.py
@@ -1,0 +1,82 @@
+import unittest
+import ollama
+import time
+import sys
+
+class TestLLMServing(unittest.TestCase):
+    def setUp(self):
+        """
+        Check if Ollama is reachable.
+        """
+        try:
+            # Simple check to see if we can list models
+            ollama.list()
+        except Exception as e:
+            self.skipTest(f"Ollama is not reachable: {e}. Make sure 'ollama serve' is running.")
+
+    def test_01_fetch_model(self):
+        """
+        Test fetching (pulling) the Gemma model.
+        This might take time if the model is not cached.
+        """
+        model_name = "gemma:2b"
+        print(f"\n>>> [Test] Pulling model {model_name}... (This may take time)")
+        
+        # Pull the model. verify success by checking if it exists in list after pull
+        # ollama.pull streams progress, ensuring it completes without error is the goal
+        try:
+            progress_generator = ollama.pull(model_name, stream=True)
+            for progress in progress_generator:
+                status = progress.get('status', '')
+                # Print status sparingly to avoid cluttering logs, or just last status
+                if 'completed' in status or 'downloading' in status:
+                    sys.stdout.write(f"\r{status}")
+                    sys.stdout.flush()
+            print("\n>>> [Test] Model pull complete.")
+        except Exception as e:
+            self.fail(f"Failed to pull model {model_name}: {e}")
+
+        # Verify it's in the list
+        models = ollama.list()
+        # models['models'] is a list of objects usually.
+        # Check for 'model' or 'name' field. 
+        model_names = []
+        for m in models.get('models', []):
+             # Handle dict or object
+             if isinstance(m, dict):
+                 model_names.append(m.get('model') or m.get('name'))
+             else:
+                 # Assume object with attributes, access as dict might fail if not implemented fully? 
+                 # But traceback showed __getitem__, so it tries.
+                 # Updated check:
+                 model_names.append(getattr(m, 'model', getattr(m, 'name', str(m))))
+        
+        # Allow exact match or with tag
+        found = any(model_name in name for name in model_names)
+        self.assertTrue(found, f"Model {model_name} not found in ollama list after pull.")
+
+    def test_02_serve_model(self):
+        """
+        Test serving (chatting) with the Gemma model.
+        """
+        model_name = "gemma:2b"
+        prompt = "Hello, are you working correctly? Reply with 'Yes, I am operational.'"
+        
+        print(f"\n>>> [Test] Sending prompt to {model_name}...")
+        
+        try:
+            response = ollama.chat(model=model_name, messages=[
+                {'role': 'user', 'content': prompt},
+            ])
+            
+            content = response['message']['content']
+            print(f">>> [Response] {content}")
+            
+            self.assertTrue(len(content) > 0, "Received empty response from model.")
+            # We don't strictly check for the exact string as LLMs vary, but checking for non-empty is good.
+            
+        except Exception as e:
+            self.fail(f"Failed to chat with model {model_name}: {e}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds integration tests for LLM serving using Ollama, switches the model from invalid gemma:4b to gemma:2b for stability, and includes Docker deployment instructions in documentation.