### PR TITLE
feat: add .env support for model download

### DIFF
--- a/A2A/.dockerignore
+++ b/A2A/.dockerignore
@@ -1,0 +1,5 @@
+venv/
+__pycache__/
+.git/
+.DS_Store
+output/

--- a/A2A/.env.example
+++ b/A2A/.env.example
@@ -1,0 +1,5 @@
+# Hugging Face Mirror Endpoint
+HF_ENDPOINT=https://hf-mirror.com
+
+# Hugging Face Token (optional)
+# HF_TOKEN=your_token_here

--- a/A2A/.gitignore
+++ b/A2A/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 .DS_Store
 output/
+.env

--- a/A2A/requirements.txt
+++ b/A2A/requirements.txt
@@ -7,3 +7,4 @@ huggingface_hub
 requests
 python-a2a
 uvicorn
+python-dotenv

--- a/A2A/scripts/download_model.py
+++ b/A2A/scripts/download_model.py
@@ -1,6 +1,7 @@
 import os
 import argparse
 from huggingface_hub import snapshot_download
+from dotenv import load_dotenv
 
 def download_model(model_id, save_dir, endpoint=None, token=None):
     """
@@ -32,4 +33,5 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     
+    load_dotenv()
     download_model(args.model_id, args.save_dir, args.endpoint, args.token)


### PR DESCRIPTION
This PR adds support for loading environment variables from a .env file using python-dotenv. It also includes an example .env file.