### PR TITLE
Refactor: Stream triples to Neo4j per chunk

### DIFF
--- a/graph_3gpp/graph_pipeline.py
+++ b/graph_3gpp/graph_pipeline.py
@@ -160,13 +160,14 @@ class GraphPipeline:
         try:
             chunks = self.chunk_document(file_path)
             
-            all_triples = []
+            triples_found = False
             for chunk in chunks:
                 triples = self.extract_triples(chunk)
-                all_triples.extend(triples)
+                if triples:
+                    self.save_to_neo4j(triples)
+                    triples_found = True
                 
-            if all_triples:
-                self.save_to_neo4j(all_triples)
+            if triples_found:
                 logger.info("Pipeline completed successfully.")
             else:
                 logger.warning("No triples were extracted.")


### PR DESCRIPTION
This PR modifies the graph pipeline to save extracted triples to Neo4j immediately after processing each chunk, rather than accumulating all triples in memory. This improves memory efficiency for large documents.