### PR TITLE
Refactor: Config-Driven Pipeline & CLI Support

### DIFF
--- a/graph_3gpp/graph_pipeline.py
+++ b/graph_3gpp/graph_pipeline.py
@@ -1,6 +1,8 @@
 import os
 import json
 import logging
+import argparse
+import sys
 from typing import List, Dict, Any
 from uuid import uuid4
 
@@ -26,10 +28,20 @@ NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "password")
 LLM_API_BASE = os.getenv("LLM_API_BASE", "http://localhost:8000/v1")
 LLM_API_KEY = os.getenv("LLM_API_KEY", "EMPTY")
 LLM_MODEL = os.getenv("LLM_MODEL", "meta-llama/Meta-Llama-3-8B-Instruct")
+LLM_TIMEOUT = float(os.getenv("LLM_TIMEOUT", "60.0"))
 
 # Chunking Configuration
 CHUNK_SIZE = int(os.getenv("CHUNK_SIZE", 256))
 CHUNK_OVERLAP = int(os.getenv("CHUNK_OVERLAP", 20))
+
+# Ontology Configuration
+ONTOLOGY_PATH = os.getenv("ONTOLOGY_PATH", "ontology.json")
+
+# Prompt Configuration
+TRIPLE_EXTRACTION_PROMPT = os.getenv(
+    "TRIPLE_EXTRACTION_PROMPT",
+    "Extract triples from the text.\nONTOLOGY:\n{ontology}\nText:\n{text}\nJSON Output:"
+)
 
 class GraphPipeline:
     def __init__(self):
@@ -45,15 +57,15 @@ class GraphPipeline:
             api_key=LLM_API_KEY,
             model=LLM_MODEL,
             is_chat_model=True,
-            timeout=60.0
+            timeout=LLM_TIMEOUT
         )
 
     def _load_ontology(self) -> str:
-        ontology_path = "ontology.json"
-        if os.path.exists(ontology_path):
-            with open(ontology_path, 'r') as f:
+        if os.path.exists(ONTOLOGY_PATH):
+            with open(ONTOLOGY_PATH, 'r') as f:
                 data = json.load(f)
                 return json.dumps(data, indent=2)
+        logger.warning(f"Ontology file {ONTOLOGY_PATH} not found. Using generic schema.")
         return "Generic (Subject, Predicate, Object)"
 
     def close(self):
@@ -71,7 +83,7 @@ class GraphPipeline:
         chunks = []
         for node in nodes:
             chunks.append({
-                "chunk_id": str(uuid4()), # Generating a unique ID for the chunk
+                "chunk_id": str(uuid4()), 
                 "text": node.get_content(),
                 "source": file_path
             })
@@ -84,19 +96,10 @@ class GraphPipeline:
         text = chunk["text"]
         chunk_id = chunk["chunk_id"]
 
-        prompt = (
-            "You are a 3GPP Knowledge Graph expert. Extract knowledge triples from the text "
-            "strictly following the provided ONTOLOGY.\n\n"
-            "ONTOLOGY:\n"
-            f"{self.ontology}\n\n"
-            "Instructions:\n"
-            "1. Only use Node Labels and Relationship Types defined in the ONTOLOGY.\n"
-            "2. If a relationship is not explicitly in the ontology but is critical, use the most similar type.\n"
-            "3. Return strictly a JSON object with a key 'triples'.\n"
-            "4. Each triple must have: 'head' (node name), 'head_label', 'type' (relationship), 'tail' (node name), 'tail_label'.\n\n"
-            f"Text:\n{text}\n\n"
-            "JSON Output:"
-        )
+        # Format the prompt using the configured template
+        # Handling escaped newlines if they come from .env
+        prompt_template = TRIPLE_EXTRACTION_PROMPT.replace("\\n", "\n")
+        prompt = prompt_template.format(ontology=self.ontology, text=text)
 
         try:
             response = self.llm.complete(prompt)
@@ -140,7 +143,6 @@ class GraphPipeline:
                 t_label = triple.get('tail_label', 'Entity').replace(" ", "_")
                 rel_type = triple.get('type', 'RELATED_TO').upper().replace(" ", "_").replace("-", "_")
                 
-                # Cypher query with dynamic labels (using string formatting for labels as they are not parameters)
                 dynamic_query = (
                     f"MERGE (h:`{h_label}` {{name: $head}}) "
                     f"MERGE (t:`{t_label}` {{name: $tail}}) "
@@ -176,11 +178,22 @@ class GraphPipeline:
         finally:
             self.close()
 
-if __name__ == "__main__":
+def main():
+    parser = argparse.ArgumentParser(description="3GPP Graph Pipeline")
+    parser.add_argument("file", help="Path to the document to process")
+    
+    if len(sys.argv) < 2:
+        parser.print_help()
+        sys.exit(1)
+        
+    args = parser.parse_args()
+    
+    if not os.path.exists(args.file):
+        logger.error(f"File not found: {args.file}")
+        sys.exit(1)
+        
     pipeline = GraphPipeline()
-    # Ensure sample_3gpp.txt exists
-    sample_file = "sample_3gpp.txt"
-    if os.path.exists(sample_file):
-        pipeline.run(sample_file)
-    else:
-        logger.error(f"File {sample_file} not found.")
+    pipeline.run(args.file)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR refactors the graph pipeline and ontology discovery scripts to be fully configuration-driven via  files (including prompts) and adds CLI argument support for input files.\n\n### Key Changes:\n- **Configuration:** Moved prompts, timeouts, and paths to .\n- **CLI:**  and  now accept input files as arguments.\n- **Hardcoding Removed:** Eliminated hardcoded strings to improve flexibility and maintainability.