### PR TITLE
feat: enhance ontology metadata and strict relationship filtering

### DIFF
--- a/graph_3gpp/.env.example
+++ b/graph_3gpp/.env.example
@@ -24,16 +24,18 @@ ONTOLOGY_PATH=ontology_output.json
 ONTOLOGY_DISCOVERY_PROMPT="You are a 3GPP Ontology Architect.
 Analyze the text to discover domain entities and their interaction patterns.
 
-FIXED CATEGORIES (Node Types - DO NOT MODIFY OR ADD):
+FIXED NODE TYPES (DO NOT MODIFY OR ADD):
 - NetworkNode, ProtocolMessage, Timer, Procedure, UserState
+
+ALLOWED RELATIONSHIP TYPES:
+{relation_types}
 
 Instructions:
 1. Identify Domain Labels (e.g., 'UE', 'gNB') and map them to one of the FIXED 'node_type' categories above.
 2. DO NOT invent new node types. Use ONLY the 5 listed above.
-3. Define 'properties' for each label. DO NOT use simple types like 'string'. 
-4. INSTEAD, provide a clear, technical description of what the property represents and examples of its values from the text.
-5. Identify Relationship Patterns (e.g., 'UE' SENDS to 'gNB') and define descriptive properties for them.
-6. Relationships MUST use clear verbs in CAPITAL LETTERS.
+3. Identify Relationship Patterns (e.g., 'UE' SENDS to 'gNB') and define descriptive properties for them.
+4. You MUST ONLY use relationship types from the ALLOWED list above.
+5. Relationships MUST use CAPITAL LETTERS.
 
 Return STRICTLY a JSON object with keys 'nodes' and 'relations':
 {{
@@ -110,9 +112,10 @@ Consolidate the discovered domain entities and relationship patterns into a SING
 STRICT RULES:
 1. ONLY use the 3GPP domain (UE, gNB, AMF, UPF, etc.). 
 2. Every node MUST have a 'node_type' from the FIXED LIST: NetworkNode, ProtocolMessage, Timer, Procedure, UserState. DO NOT use any other types.
-3. DO NOT merge specific labels like 'UE' and 'gNB' into a single 'NetworkNode' entry. Keep them separate.
-4. Consolidate properties: If 'UE' has 'id' in one schema and 'state' in another, the final 'UE' must have BOTH.
-5. Ensure all Relationship Types are in CAPITAL LETTERS.
+3. ALLOWED RELATIONSHIP TYPES: {relation_types}. You MUST ONLY use these types.
+4. DO NOT merge specific labels like 'UE' and 'gNB' into a single 'NetworkNode' entry. Keep them separate.
+5. Consolidate properties: If 'UE' has 'id' in one schema and 'state' in another, the final 'UE' must have BOTH.
+6. Ensure all Relationship Types are in CAPITAL LETTERS and from the allowed list.
 
 Return STRICTLY a JSON object with keys 'nodes' and 'relations'.
 

--- a/graph_3gpp/.env.example
+++ b/graph_3gpp/.env.example
@@ -4,7 +4,7 @@ NEO4J_USER=neo4j
 NEO4J_PASSWORD=password
 
 # LLM Configuration
-LLM_API_BASE=http://192.168.1.2:8000/v1
+LLM_API_BASE=http://localhost:8000/v1
 LLM_API_KEY=EMPTY
 LLM_MODEL=models/gemma-2-2b-it
 LLM_TIMEOUT=300.0
@@ -24,18 +24,19 @@ ONTOLOGY_PATH=ontology_output.json
 ONTOLOGY_DISCOVERY_PROMPT="You are a 3GPP Ontology Architect.
 Analyze the text to discover domain entities and their interaction patterns.
 
-FIXED NODE TYPES (DO NOT MODIFY OR ADD):
-- NetworkNode, ProtocolMessage, Timer, Procedure, UserState
+FIXED NODE TYPES (Description & Examples):
+{node_types}
 
-ALLOWED RELATIONSHIP TYPES:
+ALLOWED RELATIONSHIP TYPES (Description & Examples):
 {relation_types}
 
 Instructions:
 1. Identify Domain Labels (e.g., 'UE', 'gNB') and map them to one of the FIXED 'node_type' categories above.
-2. DO NOT invent new node types. Use ONLY the 5 listed above.
-3. Identify Relationship Patterns (e.g., 'UE' SENDS to 'gNB') and define descriptive properties for them.
-4. You MUST ONLY use relationship types from the ALLOWED list above.
-5. Relationships MUST use CAPITAL LETTERS.
+2. DO NOT invent new node types. Use ONLY the categories listed above.
+3. Identify Relationship Patterns (e.g., 'UE' SENDS to 'gNB') using ONLY the ALLOWED relationship types.
+4. For both nodes and relationships, define 'properties' based on the text. 
+5. Provide technical descriptions for each discovered property.
+6. Relationship types MUST use CAPITAL LETTERS and must be exactly from the ALLOWED list.
 
 Return STRICTLY a JSON object with keys 'nodes' and 'relations':
 {{
@@ -110,10 +111,13 @@ ONTOLOGY_CONSOLIDATION_PROMPT="You are a 3GPP Ontology Architect.
 Consolidate the discovered domain entities and relationship patterns into a SINGLE UNIFIED SCHEMA with 'nodes' and 'relations' keys.
 
 STRICT RULES:
-1. ONLY use the 3GPP domain (UE, gNB, AMF, UPF, etc.). 
-2. Every node MUST have a 'node_type' from the FIXED LIST: NetworkNode, ProtocolMessage, Timer, Procedure, UserState. DO NOT use any other types.
-3. ALLOWED RELATIONSHIP TYPES: {relation_types}. You MUST ONLY use these types.
-4. DO NOT merge specific labels like 'UE' and 'gNB' into a single 'NetworkNode' entry. Keep them separate.
+1. ONLY use the 3GPP domain. 
+2. Every node MUST have a 'node_type' from the FIXED LIST:
+{node_types}
+3. ALLOWED RELATIONSHIP TYPES:
+{relation_types}
+You MUST ONLY use these types.
+4. DO NOT merge specific labels like 'UE' and 'gNB' into a single entry. Keep them separate.
 5. Consolidate properties: If 'UE' has 'id' in one schema and 'state' in another, the final 'UE' must have BOTH.
 6. Ensure all Relationship Types are in CAPITAL LETTERS and from the allowed list.
 

--- a/graph_3gpp/node_types.json
+++ b/graph_3gpp/node_types.json
@@ -1,22 +1,27 @@
 [
   {
     "label": "NetworkNode",
-    "description": "Physical or logical network entity (cell, gNB, UE)."
+    "description": "Physical or logical entities within the 3GPP network architecture. Includes user devices, base stations, and core network functions.",
+    "examples": ["UE", "gNB", "AMF", "UPF", "SMF", "Cell", "TRP", "DU", "CU"]
   },
   {
     "label": "ProtocolMessage",
-    "description": "Network message carrying operational data."
+    "description": "Specific signaling messages or information elements exchanged between network nodes. Usually part of a protocol stack like RRC, NAS, or NGAP.",
+    "examples": ["RRCSetupRequest", "SIB1", "Registration Accept", "Paging Message", "Measurement Report"]
   },
   {
     "label": "Timer",
-    "description": "Time-based event triggering actions."
+    "description": "Time-based mechanisms used to control protocol behavior, state transitions, or procedure timeouts.",
+    "examples": ["T300", "T301", "T311", "Periodic Registration Update Timer", "Inactivity Timer"]
   },
   {
     "label": "Procedure",
-    "description": "Sequence of network operations or steps."
+    "description": "A set of sequential steps or a logical workflow defined in 3GPP specifications to achieve a specific network goal.",
+    "examples": ["Random Access Procedure", "Initial Registration", "Xn Handover", "Paging Procedure", "Beam Management"]
   },
   {
     "label": "UserState",
-    "description": "Current state or mode of a user/device."
+    "description": "The specific operating mode or connection status of a User Equipment (UE) or its context in the core network.",
+    "examples": ["RRC_IDLE", "RRC_CONNECTED", "RRC_INACTIVE", "CM-IDLE", "CM-CONNECTED"]
   }
 ]

--- a/graph_3gpp/relation_types.json
+++ b/graph_3gpp/relation_types.json
@@ -1,14 +1,62 @@
 [
-  "SENDS",
-  "TRIGGERED_BY",
-  "TRANSITIONS_TO",
-  "RECEIVES",
-  "CONTAINS",
-  "EXPIRES_DURING",
-  "HAS_VALUE",
-  "CONFIGURES",
-  "HAS_CONFIGURATIONS",
-  "REQUIRES",
-  "STARTS",
-  "STOPS"
+  {
+    "type": "SENDS",
+    "description": "Transmission of a message or signal from a source node to a target node.",
+    "examples": ["UE SENDS RRCSetupRequest to gNB", "AMF SENDS Paging to gNB"]
+  },
+  {
+    "type": "RECEIVES",
+    "description": "Receipt of a message or signal by a node from another entity.",
+    "examples": ["gNB RECEIVES MeasurementReport from UE"]
+  },
+  {
+    "type": "TRIGGERED_BY",
+    "description": "An event, condition, or message that initiates a procedure, timer, or state change.",
+    "examples": ["Handover is TRIGGERED_BY signal strength drop", "T300 is TRIGGERED_BY sending RRCSetupRequest"]
+  },
+  {
+    "type": "TRANSITIONS_TO",
+    "description": "A change from one state or operating mode to another.",
+    "examples": ["UE TRANSITIONS_TO RRC_CONNECTED", "Procedure TRANSITIONS_TO Failure state"]
+  },
+  {
+    "type": "CONTAINS",
+    "description": "A hierarchical or structural relationship where one entity is a component of another.",
+    "examples": ["ServingCellConfig CONTAINS BWP configurations", "SIB1 CONTAINS CellSelectionInfo"]
+  },
+  {
+    "type": "EXPIRES_DURING",
+    "description": "A timer reaches its limit during the execution of a specific procedure or state.",
+    "examples": ["T300 EXPIRES_DURING Random Access Procedure"]
+  },
+  {
+    "type": "HAS_VALUE",
+    "description": "A property or parameter is assigned a specific setting or measurement.",
+    "examples": ["Priority HAS_VALUE 5", "Capability HAS_VALUE 'supported'"]
+  },
+  {
+    "type": "CONFIGURES",
+    "description": "One entity or configuration object sets the parameters for another.",
+    "examples": ["BWPConfiguration CONFIGURES ServingCell", "RRCReconfiguration CONFIGURES radio bearers"]
+  },
+  {
+    "type": "HAS_CONFIGURATIONS",
+    "description": "An entity possesses or is associated with one or more configuration sets.",
+    "examples": ["Cell HAS_CONFIGURATIONS for multiple BWPs"]
+  },
+  {
+    "type": "REQUIRES",
+    "description": "A dependency where one entity or feature needs another to function correctly.",
+    "examples": ["High-speed mode REQUIRES specific carrier frequency"]
+  },
+  {
+    "type": "STARTS",
+    "description": "The beginning of a procedure, timer, or operational phase.",
+    "examples": ["RACH procedure STARTS when preamble is sent", "T301 STARTS upon receipt of RRCReestablishment"]
+  },
+  {
+    "type": "STOPS",
+    "description": "The termination of a procedure, timer, or operational phase.",
+    "examples": ["T300 STOPS when RRCSetup is received", "Procedure STOPS upon success"]
+  }
 ]


### PR DESCRIPTION
# feat: Enhanced Ontology Metadata and Strict Relationship Filtering

This PR significantly improves the ontology discovery and consolidation process by introducing rich metadata for fixed types and enforcing strict relationship constraints.

## Key Improvements

### 1. Rich Technical Metadata
- **Node Type Descriptions**: Added detailed technical definitions and 3GPP-specific examples (e.g., UE, gNB, AMF) to `node_types.json`.
- **Relationship Type Descriptions**: Added semantic descriptions and example usage patterns (e.g., "UE SENDS RRCSetupRequest to gNB") to `relation_types.json`.
- **Improved LLM Guidance**: The discovery and consolidation prompts now receive this metadata, helping the LLM accurately map domain entities to base types and select appropriate relations.

### 2. Strict Relationship Enforcement
- **Filtering Logic**: Implemented code-level filtering in `ontology_discovery.py` to ensure only predefined relationship types are included in the final output.
- **Uppercase Normalization**: Enforced consistent uppercase formatting for all relationship verbs.
- **Flexible Key Support**: Added robust handling for common LLM output variations (supporting `type`, `relation`, and `relation_type` keys).

### 3. Workflow & Output Clarity
- **Standardized Output**: Renamed the primary ontology output file to `ontology_output.json` for better clarity.
- **Improved Prompts**: Refined prompts in `.env.example` with strict "DO NOT MODIFY" instructions for fixed categories and clear placeholders for metadata.

## Files Modified
- `ontology_discovery.py`: Complete overhaul of metadata loading and consolidation filtering.
- `node_types.json` & `relation_types.json`: Converted to rich metadata objects with descriptions/examples.
- `.env.example`: Updated prompts to utilize full metadata.
- `.gitignore`: Added generated ontology JSON files to ignore list.

## Verification Results
- Successfully generated `ontology_output.json` from `data/sample.txt`.
- Verified that specific labels (UE, AMF, UPF) are correctly mapped to `NetworkNode`.
- Confirmed that only allowed, uppercase relations are present in the final consolidated schema.
