### PR TITLE
Add Feature node type to ontology

### DIFF
--- a/graph_3gpp/knowledge.txt
+++ b/graph_3gpp/knowledge.txt
@@ -4,6 +4,7 @@ ProtocolMessage: Message for network operations.
 Timer: Time-based event triggering actions.
 Procedure: Sequence of network operations or steps.
 UserState: Current state or mode of a user/device.
+Feature: High-level functional capability or service enhancement (e.g., Network Slicing, URLLC).
 
 # Relationships (Allowed Verbs)
 SENDS, RECEIVES, TRIGGERED_BY, TRANSITIONS_TO, CONTAINS, EXPIRES_DURING, HAS_VALUE, CONFIGURES, HAS_CONFIGURATIONS, REQUIRES, STARTS, STOPS

--- a/graph_3gpp/node_types.json
+++ b/graph_3gpp/node_types.json
@@ -23,5 +23,10 @@
     "label": "UserState",
     "description": "The specific operating mode or connection status of a User Equipment (UE) or its context in the core network.",
     "examples": ["RRC_IDLE", "RRC_CONNECTED", "RRC_INACTIVE", "CM-IDLE", "CM-CONNECTED"]
+  },
+  {
+    "label": "Feature",
+    "description": "A high-level functional capability or service enhancement introduced in 3GPP specifications, often spanning multiple procedures and nodes.",
+    "examples": ["Network Slicing", "URLLC", "Massive MIMO", "RedCap", "Dual Connectivity", "VoNR"]
   }
 ]


### PR DESCRIPTION
# Add Feature Node Type to 3GPP Ontology

## Description
This PR introduces a new `Feature` node type to the 3GPP knowledge graph ontology. While "Procedures" cover specific signaling sequences, "Features" represent high-level functional capabilities (e.g., Network Slicing, URLLC) that often span multiple procedures and nodes.

## Changes
- **node_types.json**: Added `Feature` node type with description and examples (URLLC, RedCap, etc.).
- **knowledge.txt**: Updated the human-readable node type list to include `Feature` for consistency.

## Why this is needed
Separating "Feature" from "Procedure" allows for better architectural modeling of 3GPP capabilities and simplifies queries related to specific network services and high-level enhancements.
