### PR TITLE
Log JSON parse failures for better debugging

### DIFF
--- a/graph_3gpp/.gitignore
+++ b/graph_3gpp/.gitignore
@@ -50,3 +50,4 @@ pr_description.md
 # Generated Ontology Outputs
 ontology.json
 ontology_output.json
+json_parse_fails.log


### PR DESCRIPTION
## Description
This PR implements a mechanism to log JSON parsing failures to a dedicated log file (`json_parse_fails.log`) for better debugging and observability.

## Changes
- **.gitignore**: Added `json_parse_fails.log` to ignore tracking of local debug logs.
- **graph_pipeline.py**:
    - Added `_log_parse_failure` method to log raw text and error context to `json_parse_fails.log`.
    - Updated `_parse_json` and `extract_triples` to capture and log failures during initial and self-correction attempts.
- **ontology_discovery.py**:
    - Added `_log_parse_failure` method.
    - Updated `_parse_json` and `discover` methods to log failures during the ontology discovery and consolidation phases.

## Testing
- Verified that the `json_parse_fails.log` is created and populated when JSON parsing fails.