### PR TITLE
fix: prevent ontology clearing and include relations in consolidation

### DIFF
--- a/graph_3gpp/.env.example
+++ b/graph_3gpp/.env.example
@@ -124,5 +124,5 @@ You MUST ONLY use these types.
 Return STRICTLY a JSON object with keys 'nodes' and 'relations'.
 
 Input Schemas to Consolidate:
-Nodes:\n{nodes}\n\nRelations:\n{relations}
+Nodes: {nodes} Relations: {relations}
 "

--- a/graph_3gpp/.env.example
+++ b/graph_3gpp/.env.example
@@ -124,5 +124,5 @@ You MUST ONLY use these types.
 Return STRICTLY a JSON object with keys 'nodes' and 'relations'.
 
 Input Schemas to Consolidate:
-{nodes}
+Nodes:\n{nodes}\n\nRelations:\n{relations}
 "


### PR DESCRIPTION
# Description
This PR fixes a bug where the ontology output file was being cleared during the consolidation process.

## Changes
- **Fallback Logic**: Modified _consolidate_ontology in ontology_discovery.py to return the original raw_ontology if the LLM consolidation result is empty or fails to parse. This prevents overwriting the output with an empty dictionary.
- **Relation Consolidation**: Updated the consolidation logic and prompt to include relations. Previously, only nodes were being consolidated, which led to the loss of all discovered relationship data during the consolidation step.
- **Prompt Update**: Updated .env.example to reflect the new ONTOLOGY_CONSOLIDATION_PROMPT structure which now includes placeholders for both {nodes} and {relations}.

## Verification
- Verified that ontology_discovery.py now correctly passes relations to the LLM.
- Verified that the fallback mechanism works if the LLM output is invalid.
