### PR TITLE
Handle null-like object values in JSONL rows

### DIFF
--- a/graph_excel/insert_jsonl.py
+++ b/graph_excel/insert_jsonl.py
@@ -19,7 +19,7 @@ def _is_nullish_object(value: Any) -> bool:
     if value is None:
         return True
     if isinstance(value, str):
-        return value.strip().lower() in {"none", "null"}
+        return value.strip().lower() in {"none", "null", "n/a", "na"}
     return False
 
 
@@ -55,7 +55,7 @@ def _prepare_rows(jsonl_path: Path, skip_invalid: bool) -> List[Dict[str, Any]]:
         if _is_nullish_object(obj):
             if skip_invalid:
                 continue
-            print(f"Line {line_no} skipped: object is null/empty")
+            raise ValueError(f"Line {line_no} skipped: object is null-like")
             continue
 
         # Neo4j relationships do not accept nested property values.

--- a/graph_excel/insert_jsonl.py
+++ b/graph_excel/insert_jsonl.py
@@ -218,8 +218,11 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--skip-invalid",
-        action="store_true",
-        help="Skip lines missing required fields instead of failing.",
+        "--no-skip-invalid",
+        dest="skip_invalid",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Skip invalid lines (default: True).",
     )
     parser.add_argument(
         "--dry-run",


### PR DESCRIPTION
Add helper normalization for null-like object values and adjust skip_invalid handling in insert_jsonl row preparation.