### PR TITLE
Finalize Korean fallback font path handling tweaks

### DIFF
--- a/graph_excel/read_pdf.py
+++ b/graph_excel/read_pdf.py
@@ -57,7 +57,12 @@ _KOREAN_FONT_HINTS = (
 _RECONSTRUCTION_KOREAN_FONT = None
 
 
-def _get_registry_korean_font_candidates(font_markers):
+def _get_registry_korean_font_candidates(font_markers=None, font_name_markers=None):
+    if font_markers is None and font_name_markers is not None:
+        font_markers = font_name_markers
+    if font_markers is None:
+        return tuple()
+
     if os.name != "nt":
         return tuple()
 


### PR DESCRIPTION
## Summary
- Finalize the current Korean fallback font path handling adjustments in `graph_excel/read_pdf.py`.
- Keep changes scoped to path lookup behavior used during PDF reconstruction.

## Files changed
- `graph_excel/read_pdf.py`

## Validation
- Not run (small path-handling follow-up patch).
