### PR TITLE
Add pdfplumber sample extractor in graph_pdf

### DIFF
--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -50,7 +50,7 @@ endobj
 endobj
 7 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260316100018+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316100018+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260316104144+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316104144+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -61,10 +61,10 @@ endobj
 endobj
 9 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 979
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1144
 >>
 stream
-GatU0?'C^2'Rf^Wg]nqTcE<=dJF/P)5O,=m?-@>^UL]W*L^gVls1UE8/BmNK44@%LS/cQe%ei6(_&kDp>mbNa6@VIT:^A.o\31YF,tu4:@i07D.1)"X:cjXbYq$8Gn3).MKm.U[NX&Z^Ah`2CJ1mE]>^h?rV8n6V/l$H-ha@/@_@NgdU%GHEAjRmuTatqIk<NcXs6B62%N0Np?='o%rdM2t*SBODr=iL<f0?(E_![j3Gb.9Xp^g[lGUi.eNX$WqHbP:7e4[G$h>kq'DfhPBmoHd6A@`*aj(5?mqq'+*j4p<Zi18]5hD'LXP3l4"ZI6'L+^lmq$g\MOZI9Cf(.#+aBr=^h8"eKM=[sh138=0G^%HAD=sQ5K3O7&SS]DM'ZQ'J;-!d4-2Ymd+$nj&n5Hg$3&]c-U9S,<E8GJr8'/JDd'_#e^o4D9HjB,\oY/DT@8@!:@k?&`iM.;#cPS0ru29mt)gI[nY;e4#3'4_0_8[lKR/lfPo8MStoknhThUMWqC.;f_TET>&+1ejHsG4F?I]tJs\\]o@/30D6qS1mZnp_+Y-,M.6a\`*d2k1E">mUS#Epidj7JK6'+XaoXaYco0K0_UfdEE'bA[tJa#_0B'!Ns[51U`L7)Tk,[!<8j(+\/ppF9ub8]Vt1me\si`?Tl>(HGl"l1KN>1$Fa9HE8OZh+puQ-RkG5d$)AE]H`7T(0\WW+GBQG=CVb<u;cpgRsMHo$/b>p;7[7FJ5d%Y2&h*FD2>0nk,nl95*'!asP&r/&bQI;U9b79Y:#bLUAca&\>1t&fsbNT4J3PhGI/f]nAH;G/+P+qJM;D`9c@dkis)E1eRGa0#'S$3b-3@ld3FnM\fqp2cZiW"uHfDC>*\A\8k/6q*0T3,JEAM9+.j+0'h;UXuNRgUZ*PIoAPTkUm,D<2_>g@Qr^@D#aN-sG26qL()HB[O3S4D/B^->I8$nRC/qC0BleC9gsdCIICa!>;4U=o~>endstream
+Gatm:;01GN&:WeDlpDh?2i2#N,Fe=^'Z`"'8P5DoZbQqCcF,]8K_"TDP%Eu<fU'g(P(D`D-geCTrWE@Or$1oXSH7LuiHe+H:fom`$+p8(pFobDI*5?U?:F?8J\#D\M*%]_+Cqu6K+E0`n$_^FT#+T?')iM+(?u)2T']DVL"r`:p]Hi^_",h'LJW<bN2`%F.(G"%^(EUK]Dq2B".ou>JR@;3p%;p:?hgiS9)THU^uuk:06.eP&S"!Fi$Pu)nYQ*;pDGXtH6L3*1aQH?ejhR6%n>`[L\Z$MT$3P-d="C4f@QQ<[W?l#V0B*1:KtOhPnFVIEkTdeY2PjNqmG:]p83PBf'G<n'&U+VCRrPZlM.\bY`eMgeu@U'IKqurTr8H\61YhsG$GbR^@>BjY[L]*Egmca`]:,3Y'H0HYdG^i`(Xc:QZ1mXQ>uTdV9NQb'T`^*5]6h%i`Y">Q#*lI7(a+#8)>q=Gsuig<rujM%lkUB]`g!3f.3i.bj;<#Smr#S,Y+`Ue)Ns>--3c6l\eS#=nB"*mDq;Dl<4Qm[WBVd%>>QE7?!Gh#/3*I8.Ye0b*cRE_(Qu9EWZpX]HlKUILl%$;>/H[H3:Ff-E$6/8NE)@1LZ9la(\q.:q%H(MDb"GaeEfS`Td`[>`6uMi'NQ:8]m=#kWA-oSM70[G,BYM(O,'X3:q7T;uHA5K>*7Apf>7Ra;f#j)@gHb@oU@u+pVUW__e<"N,%"K;OXP;$*C"jW5^9cE"c6]])m`<L]6NBBQc0uhj4l.9T/7bb6b:R?hNqOM3=>"W01NV4*)R8d:(tS^dF0R<C`hTM0_e@1:gau`?V`q?H'Gte:4U'>D@4>B5q0JY2Tp7NZ!!'E0Q8EIBSTYg#+M=:UF(A.NEHTTu'YZ.!p.sS,pCGIF3((>7llb\pE<p(K$P!!oH/sK;%0Z+QB4"%Gl&s_6!km?<be7eq4aA4_SeM6AqI0(m$5NM&LV`_S[:AKA-J$#.k%lrP.0?OSsX?TtJMmUNF!,mJ8<d_rl2g'kdFuT=!D8-=LRj/SSB)_pdTMF*mrZ"6jZV#,MWEn[kZn:<.Z!/`n(=3n@d2pMBEM;/8D]W3pb&4=ul,^@0W,H&;Edb-S1M=@\j@B(m=b3nE>%5+^$f)FWff!;MJUHi~>endstream
 endobj
 10 0 obj
 <<
@@ -85,11 +85,11 @@ xref
 0000000852 00000 n 
 0000001113 00000 n 
 0000001178 00000 n 
-0000002247 00000 n 
+0000002413 00000 n 
 trailer
 <<
 /ID 
-[<e824ec6dd54523af70d56a62b6e72ee0><e824ec6dd54523af70d56a62b6e72ee0>]
+[<ac3dc2991d253cb7c601b28cec1685e2><ac3dc2991d253cb7c601b28cec1685e2>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 7 0 R
@@ -97,5 +97,5 @@ trailer
 /Size 11
 >>
 startxref
-2823
+2989
 %%EOF

--- a/graph_pdf/sample_generator.py
+++ b/graph_pdf/sample_generator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Sequence, Tuple
+from typing import List, Sequence, Tuple, Union
 
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
@@ -31,14 +31,52 @@ def _draw_watermark(c: canvas.Canvas, width: float, height: float) -> None:
     c.restoreState()
 
 
-def _draw_body_text(c: canvas.Canvas, width: float, start_y: float, lines: Sequence[str]) -> None:
+LineItem = Union[str, Tuple[str, int]]
+
+
+def _draw_body_text(c: canvas.Canvas, width: float, start_y: float, lines: Sequence[LineItem]) -> None:
     c.setFillColor(colors.black)
     c.setFont("Helvetica", 11)
     x = 36
     y = start_y
     for line in lines:
-        c.drawString(x, y, line)
+        text = line
+        indent = 0
+        if isinstance(line, tuple):
+            text, indent = line
+        c.drawString(x + indent, y, text)
         y -= 16
+
+
+def _draw_wrapped_table_row(
+    c: canvas.Canvas,
+    x0: float,
+    y: float,
+    lines: Sequence[str],
+    font_size: int,
+    column_positions: Sequence[int],
+    line_height: float,
+) -> float:
+    c.setFont("Helvetica", font_size)
+    y_cursor = y
+    max_lines = 1
+    split_lines = [line.split("\n") for line in lines]
+
+    for row_line in split_lines:
+        if len(row_line) > max_lines:
+            max_lines = len(row_line)
+
+    base_y = y
+    for line_idx in range(max_lines):
+        # Cell 0
+        c.drawString(x0 + 6, y_cursor, split_lines[0][line_idx] if line_idx < len(split_lines[0]) else "")
+        # Cell 1
+        c.drawString(x0 + column_positions[0] + 6, y_cursor, split_lines[1][line_idx] if line_idx < len(split_lines[1]) else "")
+        # Cell 2
+        c.drawString(x0 + column_positions[1] + 6, y_cursor, split_lines[2][line_idx] if line_idx < len(split_lines[2]) else "")
+        y_cursor -= line_height
+
+    return base_y - (max_lines - 1) * line_height
 
 
 def _draw_table(
@@ -46,7 +84,7 @@ def _draw_table(
     x0: float,
     y0: float,
     rows: Sequence[Tuple[str, str, str]],
-    row_height: float = 22,
+    row_height: float = 24,
     column_positions: Sequence[int] = (140, 260),
 ) -> None:
     """
@@ -78,9 +116,15 @@ def _draw_table(
     c.setFont("Helvetica", 9)
     y = y0 - row_height - 14
     for row in rows:
-        c.drawString(x0 + 6, y, row[0])
-        c.drawString(x0 + column_positions[0] + 6, y, row[1])
-        c.drawString(x0 + column_positions[1] + 6, y, row[2])
+        y = _draw_wrapped_table_row(
+            c,
+            x0=x0,
+            y=y,
+            lines=row,
+            font_size=8,
+            column_positions=column_positions,
+            line_height=10,
+        )
         y -= row_height
 
 
@@ -101,8 +145,8 @@ def create_demo_pdf(path: Path) -> None:
     ]
 
     right_rows = [
-        ("Alpha", "OK", "DONE"),
-        ("Beta", "WARN", "REVIEW"),
+        ("Alpha", "OK", "DONE\nline 1"),
+        ("Beta", "WARN", "REVIEW\nline 2"),
         ("Gamma", "FAIL", "PENDING"),
     ]
 
@@ -111,9 +155,13 @@ def create_demo_pdf(path: Path) -> None:
         width,
         start_y=height - 70,
         lines=[
+            "Chapter 1. Document Structure",
             "PDF extraction sample for body cleanup and structured table parsing.",
             "This page contains header, footer, watermark, and tables near the left and right edges.",
             "The tables are drawn with top/bottom and inner lines only; no outer vertical lines.",
+            ("This section has nested indentation:", 0),
+            ("- level 1: overview", 12),
+            ("- level 2: detail", 24),
             "Body text here is cleaned for ingestion by GraphRAG or similar index pipeline.",
         ],
     )

--- a/graph_pdf/verify.py
+++ b/graph_pdf/verify.py
@@ -35,11 +35,23 @@ def run_checks() -> int:
     if "Graph PDF Demo Footer" in txt_text:
         raise AssertionError("footer text was not removed")
 
-    # 테이블 2개 + 헤더/본문 추출 확인
+    # 챕터, 들여쓰기 본문, 다중 행 테이블 셀, 표 추출 확인
     if result["summary"]["table_count"] < 2:
         raise AssertionError("table count is too low")
 
-    for required in ["Widget", "Keyboard", "Alpha", "Beta", "PDF extraction sample"]:
+    required_text = [
+        "Chapter 1. Document Structure",
+        "- level 1: overview",
+        "- level 2: detail",
+        "line 1",
+        "line 2",
+        "Widget",
+        "Keyboard",
+        "Alpha",
+        "Beta",
+        "PDF extraction sample",
+    ]
+    for required in required_text:
         if required not in txt_text:
             raise AssertionError(f"missing expected token: {required}")
 


### PR DESCRIPTION
## Summary
- Add pdfplumber 기반 PDF 추출 데모 파이프라인을 graph_pdf/에 추가했습니다.
- 본문/헤더/푸터/워터마크 제외 정제 로직과 표(양끝 정렬, 좌우 경계선 없는 표 포함) 추출을 검증했습니다.
- 본문 다중 들여쓰기, 멀티라인 장 제목, 멀티라인 표 텍스트 케이스를 샘플 및 검증 플로우에 반영했습니다.
- 이미지 추출을 별도 파일로 저장해 멀티모달 후처리에 사용할 수 있도록 구성했습니다.

## Test status
- python graph_pdf/run_demo.py
- python graph_pdf/verify.py

## Files
- graph_pdf/.gitignore
- graph_pdf/README.md
- graph_pdf/sample_generator.py
- graph_pdf/extractor.py
- graph_pdf/run_demo.py
- graph_pdf/verify.py
- graph_pdf/requirements.txt
- graph_pdf/sample.pdf