### PR TITLE
Fix graph_pdf body extraction regression from word-fragment reconstruction

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -25,32 +25,66 @@ def _repair_watermark_bleed(text: str) -> str:
     return text.strip()
 
 
-def _extract_body_text(page: pdfplumber.page.PageObject, header_margin: float, footer_margin: float) -> str:
+def _is_layout_artifact(text: str) -> bool:
+    normalized = _normalize_text(text).lower()
+    if not normalized:
+        return True
+
+    if "confidential" in normalized:
+        return True
+
+    if "graph pdf demo header" in normalized:
+        return True
+
+    if "chapter 1: deep structure verification" in normalized:
+        return False
+
+    if re.search(r"^page \d+\s*/\s*\d+$", normalized):
+        return True
+
+    header_markers = (
+        "prepared for table + text extraction tests",
+        "header checks:",
+        "header line",
+        "header line 1",
+        "header line 2",
+        "header line 3",
+    )
+    footer_markers = (
+        "graph pdf demo footer / left",
+        "footer details: keep header/footer clean",
+        "footer note: ignore this for body extraction",
+        "footer line 1:",
+        "footer line 2:",
+        "footer line 3:",
+        "footer line marker:",
+        "footer page marker:",
+    )
+    return any(marker in normalized for marker in (*header_markers, *footer_markers))
+
+
+def _extract_body_text(
+    page: "pdfplumber.page.Page",
+    header_margin: float,
+    footer_margin: float,
+) -> str:
     body_bbox = (0, footer_margin, page.width, page.height - header_margin)
     body_page = page.crop(body_bbox)
     raw = body_page.extract_text(x_tolerance=1.5, y_tolerance=2) or ""
     lines = []
     for line in raw.splitlines():
         fixed = _repair_watermark_bleed(line.strip())
-        if fixed and not re.fullmatch(r"^[A-Za-z]$", fixed):
-            lines.append(fixed)
+        if not fixed:
+            continue
+        if _is_layout_artifact(fixed):
+            continue
+        if _is_watermark_line(fixed):
+            continue
+        if re.fullmatch(r"^[A-Za-z]$", fixed):
+            continue
+        lines.append(fixed)
 
-    # Remove line-level watermark fragments that appear as many consecutive single letters.
-    filtered = []
-    i = 0
-    while i < len(lines):
-        if re.fullmatch(r"^[A-Za-z]$", lines[i]):
-            run_start = i
-            while i < len(lines) and re.fullmatch(r"^[A-Za-z]$", lines[i]):
-                i += 1
-            run_len = i - run_start
-            if run_len < 6:
-                filtered.extend(lines[run_start:i])
-        else:
-            filtered.append(lines[i])
-            i += 1
-
-    return "\n".join(ln for ln in filtered if not _is_watermark_line(ln))
+    return "\n".join(lines)
 
 
 def _merge_cells(table: Sequence[Sequence[str]]) -> List[List[str]]:
@@ -334,11 +368,15 @@ def extract_pdf_to_outputs(
 
     with pdfplumber.open(str(pdf_path)) as pdf:
         for page_idx, page in enumerate(pdf.pages, start=1):
-            page_text = _extract_body_text(page, header_margin=header_margin, footer_margin=footer_margin)
+            tables = _extract_tables(page)
+            page_text = _extract_body_text(
+                page,
+                header_margin=header_margin,
+                footer_margin=footer_margin,
+            )
             if page_text.strip():
                 output_text.append(f"### Page {page_idx}\n{page_text}")
 
-            tables = _extract_tables(page)
             if tables:
                 for table_rows, _bbox in tables:
                     if pending_table is not None and _is_continuation_chunk(pending_table, table_rows):

--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -69,7 +69,19 @@ def _extract_body_text(
     footer_margin: float,
 ) -> str:
     body_bbox = (0, footer_margin, page.width, page.height - header_margin)
-    body_page = page.crop(body_bbox)
+
+    def _is_body_char(obj: dict) -> bool:
+        if obj.get("object_type") != "char":
+            return True
+
+        size = float(obj.get("size", 0))
+        color = obj.get("non_stroking_color") or obj.get("stroking_color")
+        is_gray_watermark = size >= 40 and isinstance(color, tuple) and len(color) >= 3 and all(
+            abs(float(c) - 0.501961) <= 0.02 for c in color
+        )
+        return not is_gray_watermark
+
+    body_page = page.filter(_is_body_char).crop(body_bbox)
     raw = body_page.extract_text(x_tolerance=1.5, y_tolerance=2) or ""
     lines = []
     for line in raw.splitlines():

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -50,7 +50,7 @@ endobj
 endobj
 7 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260316111059+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316111059+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260316111947+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316111947+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -61,17 +61,17 @@ endobj
 endobj
 9 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2322
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2466
 >>
 stream
-Gatm<>?BiU%Y!SBkb0*NSP=)!DVh%s%&Xu3TsN5F=u_ecMs^)"*LP'S?e$_7&=MBrqD8Xm8_0e;WH9kI!<4eF]5.JmB5hn1J;#[]!/ma0b\lB[Fqbc"[64!]JIr/.)l_%qMGhMnI'%t[CW3n#gg==&KkMb0.em8I;s8MUeH1'-<i,Qrbl/!VIi_E!k=3S,&fk%_%L]7Di/dZq0//3s#/L7rQU<''I-udhYc8rUVD6iZFO-9TW@&5iaE]KLP:aAR)="4:&>&;W50A"0k@t+\8sE*S3:6lu%f#$UaoV1,^o^]IjL\i6hK?\V1%;42:Z4m$%T^TTPD/+`[G^F\4`QudPJZ)5FSQ@t74T&od(OKaE5I694O"OXN,tY*kBkX,*_hiK'e+dEIkbJ/Q4LHQ!6a4':P]eNi(:e"m_WV*VeLZfT-c5un<\WbJeV+K9sYOdF5Nc"9-^7ppn2L#r:TLCk2PrLG&qi=B@ZJ>_j6^pNM],%\ikLKnP4FfS`4@WYJ1N]>n1Wri")N]79+@K!d*W1f%76.eO-85<OIHmofKgh2u$A'lac4&qSaMoURZ7!;":B=P!Qr@Y:D^I!R81sWeljQV.u+ipGdD$=J+gC@b"KG'!I(N=l.FY>g;+Pquq!R5-<Qe'EDGhg%RQQqC*"N3M`(V8eYV2!4@%e2*A&-=q%<*o8Quc#,q!8WATamO#2ADYr<,"!\N-*6dZ&5W=)TPA\4m?e)Np[kf&\OCNXVVW\3#)gH#08IiFmEBdgef/p&$.dhVcUTO5f`4U6\MqcUSGSL6(8P'D08$!pXI-Ep7%?DqN(*P3]+d_l.>V?=fi@WS*cFMq$i>?J+fZsHj-<kS02ht,JLH(IUdcdSI37_LUTg\_F)H:0BYiU+XpLH`g*b?sMMoR\D]gkrF-^OGtF/;,8X?bIJN_Q^&)3to7>3lg8`G/K2Z7hXRO3S3D_)R0nljQIPH+'fK3h1s#[R(W?9Fq)OVX/;o-11'hc\uHD^Hf+]YT0-@g`e'PP(8;@i!b`^6mAbnZQ5o%\,O<m?N4I8sEO@$$`c,HnD932BS0dLONZ<=8]s;/a`6K(1g7oJ@7(r/5Q\Z$5%>/L=IT6V-qqAQi)+8PujUB&Q9Dq%j#bb_*l<[J/9>40E#OKgu>a(([HI05WZ_@E4RP+hA6FD5JNY)G%S*+?HYqVj)!XQ&eU(DlbR2EX9+Nl.%oL8g0>oLbl*X#7)n!F_cl.-!$eU5=,n$IN0fZ7C;04ON$\XJShek,!Kn4r%C7.sj;=Kmns>:+6t&QlVJXM+94*2Q9FfN_"`\3rBoXOgk=)I+R-JU4Bb6cUsKB7H+^2+U15eI*]\\ek/VVKBb^4JI&dR(22O$%qHP&hbJKPU;BQKd/"6cg$G".\AD$FW)>&HE6CBY9p7?lFJ@CM_W/,Z&rGe17ngiN><ldS$brFCkN8F0MlVD_4hWXO=2.NM0u^sh4SZg(>6,D_l7m]mTg-WFQ#cp5br;Zl3ok13HK;Ug7q0+VrMM^B1:nFHF68($W"g.V8k-2\9bPQ0>'Gojlo!+Y[Umr$9)eCF[u'c@D!?PL7Jng1.e_!p/s9_G#:K!CnZhsC:0Y`h23&Z[#JDYlPJ8?06?[VmZNB.%@@_"`5#2CUYiKAV?:<Q#]VbS5VW_"AQjcV]n\gkASCPe\Y)Dn@t9d>IeI_>i_(ZlE;@Q!jnFnN1?*0i.#M^M/G$BgG,kCC&9ZN2"@T[U(_kG,=QXTR`4X-&\$"i9gRI];?Wh8^mPSpO&]]4&X0\:"g9FuLrpoL:k3e\p29UgPCp5=bJ]P:=>IRm7b9]$[BcO/I1,ousi,"lF-.KMS5M7(p%p5NPml7bV>mkT5!(5V8",bl2MnO9u#otbR)^J<OgRAs*Z%paXfD`hI"SR]oAtH/,T)M)e!H[9cB$Vc'E9!MA9Q4He#d^)O*R;e*ccE?%gpmqq3!TgN)mR`r?;u?01V4jBBOdq.M6VhuMZr#HS\R4[H@0Q6g""(e9EV_?H'`oo!>Z_r,P:?(Z,kKS*aotgD;RDk$_;rNe\D(VnY+"pPX`-pisX799;3HTFuZaVrs/BJ;%%327XJ#9c)=)_VKj(/o0$:#T<%)+\$R,QWXk#%T#O<LMl)79g$14O%KHIVE";EZR9JJ;Pqq6TLf0s!EJ!pW%W^30b]^XsE[/jde:\di4H1!M]\(:qrI(a86od#fN5R3^1SO(]?XB%mmjgf+#6!6Im0B<q4Zc70'#Zf$+Iq4Ia2)?2a\M91<1%UlDt#7(_62`7d1I6iMJ7Sl;u9rcXN]9_rV;RF$:fJ<1(@.F^"r3Q/bpAbhFbHG#2n]pUQRF^~>endstream
+Gatm=>Begk%Y"/U^dB0kFsV3a=8C+$0C)QgE?/o&Y@DPtZ0#nYP[3t60BOV/Z9WX.o]/CX!['Z,K)mY7K)kp*o=Lq$0'7,!c%'f$07cR@#j->M2*VD+KNapkJ\VP1a$qP"R_f3U"CJ4fo8OCM)BLN7iDN\cr)8JXW\`j,eWpiZAtp.4#FPN$o,j#AM)(je6-3.URDZ=-d#09!o-`b`+$JOh,o1pVeG.hl*N^gP7[5h2(2LI*m`qIVC'c&rLpG)*C4K2uRnXFg]W*JbpW"#g@5*\ncH-<rP"7_>:>fck.?A]@3#`8a59'Ige84DTW3*Dp\@*fAVAVVjaEiFZa^ot%MUf:nXt>Rg`p'I=8:;>G-oeY<f1j_hk#8cWS`IE<3ou$9fo)TCa?E8M_V3Xc]!T+=.7Htr@ED>ANPB+VS'WPirOV4:hENmnFq?;N5#FA#BAP#6c\.(E_+N9ViD/Qdq^i'WBfZ^O"34TYa-BKI3dhmR1Z=S;#G1^M0mb\?MB(/SO>OW+Q@Z4=S4qsnbn:59s5L:F>s7%e!N\>/!'**?%q*VZR6-#L/4fn:ZtTr4!.Xof(aP3IFIFP$^kW+i=:uf8!un9o?gk1:0<ag,\*%r;X+#JHoU.`9iKQ>"gns5#[:j[g0^b8g*PV2]Zfj?XUVBB#/;o4TG>YCIC`qneqb@!H]#QU`mte:)imXXWjEP@UT59`dH=3Q\/!J&&ZTHf9D9BS[(b&.X$H[dXK-rGo':j;I>u@f0`9:\\l5WTunSKIVYqk:eVLCu8&.@$1h;3s*8u,&`8SY<H"Ba:9\UBSd4Di5=p1LumKKrfn(0^<38OrnR@[jM#'<';RS`/]^\g#1'dF??+<?4,`@h_GgfBOPDW\3)-gB[WkIuV]r2j>"$2(.@3GNH%3G3`a=k+JpY]u[YdjRa12;X#tCYNl7Z5c\ECeVfHJoa.`W3InR&6nu.&I\EebYnbt.(@3iZPLbo)ke-56Ln0\*):/50g:bG+GK.#EImAVuBpMjelE(@']p!H)^!VHa!_mFV'k`MTrV5+rLH+72hT!]jj\r]Q_'>ZN,jo6uYK:b%OklH6D8,6VCPbWCYq[Q[2<+R[GhRa`*KTABJ;gY0MGbi9[6L<9>,ec^dC8f0nHLKZ]UmW'XXrN6<"MNB<Pg[fk1JoL=g.O0XF6+fX$%=NL*P_n7qPl^/6T1MjNp9ZPpNaZEi/'NJ3NQOlBS9Z69I'S0\Fq72m"1&YK`![?<5*6c7o40e?Ah:&=Vud4fI@ZCslnjL`MqSC%?)/*4:g)2YFg$q+;9*?JFZ)(bt&ao=W9p`WKrg!fjr3Ka8C9`9cl;ClPmeN;ukf1le-8#b8u.0dRd8k9hf]q+0T(C&9loDEdr#DP%i@nr_9[a_V+:M0oZP&JI-:,7[p)3a>6m>rD?4EWhD#V."2B,[ak#SRC!KY]9?=PDqgJWr"KSbgkBRR_%]%7E<pd`\b7Cq8<q-@p'Sq*]k]p*'IdE]bL$["HLp+;,TT0P5;2m/;j\WTVd[/!$*Qd33$uXU:TTFmU?TE@Vd;m^!%ij7\`EBLpND(cA":iofY10(bA:A"pq%:OO/4;VX=%j^a<90A3.sFe\,a,Tl(i)2Mf;R>bAh[ShWaeWrY@W4WRUN3h(h`Y#b^O2"Pfo=aJ"ALT=JYqTR]h=.]C-)HNY\dELDORnZQ"4$;5RIDa0_8=;HiC\uOZmr-_U?e[mdH"+1QQgL6Qa.\K!m-E!)JR7L0lhqQ\Yo5;CqMBcsQq"h0c0ZNn"<gB-&1FDAYY9tjhadHo:i^p>/gP]eecn+5n)oc+,I)>gO&s*P?@<pcPn@ZX5Z(4-@%!Vp*2eZY-.,d'7R0pWK0_4$L1Ph:V9JV!LU(`&%o:'_EFkR*\Mp7_7KVnpY0V%TkeMMDLTC<qg\VrDCR,V3fjIZN"-N#?[iW/SCf]'Y:#f'VQbfA_#%omU.B,5uqjZu8lN*L>ffP)XC-TS)H[m7MmfBc=;.kN$5N[tC%k\KOUCD)KPK6,UPoK`JDZY8QkGbBFeXjL]3#khkB]t8Ms.r?kEutdoeuktF*::`-;@n$]T'iHCnQ+KE*VEMn7m!A+i2p/!q1s`"n?V6nGf*V$b\bSr'/WHHc#O-c67_$QPM(L)j:!#f0FcZP5[K9gYIj:WNmK_%NC=>od0S3/mAArL/p59:7<eO'jMQdd$&rhJT.abWXGGh,gYp*Mol'&cALVWG)P(7J1o84#LurEIe5(1oGUZ['?f!P/W2VACGo@pt".d/P1q!>^;i1OVBP6b6nSrOJ79Q%^917gfQ8l\ceauSN`LLd67o`I"!E&UMLurCcm]1$O4R'%X>q6^9GF4Lt-$Ub:rB4:7(:*656n3N]OnJ58d>*jT,_H/<5o0eSG9QIE1DXLKpI5)e_>1u#*[Nl#2*<,G-\FuF%?P/d(i9&Vq6m4d<mjNd,h=6i+E8Lj<c#rKjB2!(o$-M$-iX?(K:Q3~>endstream
 endobj
 10 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1611
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1756
 >>
 stream
-Gat=+>>sQ?'Ro4HS4D9C`c?G7DsXcGGD7QYOQfF\'jF77A1<dTG10gU,KWOZ7,"=:"Qb#$qT`A)JJ<TirG6e1%h#n[,sX4fXFTA'%Z<FDZoC^\L0C3pL"%S_'9#gESMVjj.WJZ'kFWLFDW'j*/_mR:_XEGl9O5J"q^lG7aAFh](KgSEMdK7"P1TDhYDR1r@P+[W!_o#ko/G%_LBdZT[*bEYpjLN,l(a,=RcJ!tdoX+mOMN5R!Tn^"AAt.rfaPM,\EiFIE[aN+;RM-h_j[J'3Vn<A-Xq'GV8dR0iJt$^E,V&q]p!K[2!t'W"]((o@:Ln$>WJnEN/H*IjE[")F)T*@Q?R#e"B/90G[%1^+G*afe:fhn$6U#LOnM"P8Wf0]8`98k/=F]S_qgEkH>pieTgbi'MCba)nk&,P9JPg(!>d26q!YPrKT];+<FTqhRrgs=)+n]B@Vkmcs2XMnRnnMb^0KP9=nV0!fb.MtZQrAWkmJRP.<Hq,2F&d^Z"HD@T[h]Y;)+`<KkJOiN#O6_EQ?&&V*]954dG9=^!jS=R,P>oBt8t"S!Em]"4PU+cj>]]=EB_u*U</i_fBB=%om;e))cNr/M%e39W^%IF9%/Ck&T98PYWZNii%e\Q;oQG+(W!)j[-,_9@S-8q-s13s0"K6&$?2YXgLSIXA3jb6;ZaH#d>ABERSZX2R_hTUG8\>,M/J()U"7aB%!pD(j2>VTM/DmkH(E8m:Zce@S`=Hf@Lg(#(=>@1ZL-ZEWi<7QRS.t(L03Pg@t"o:8]`%M[]bKlKtNuecsrMmP=s4C/Y1dp"oDShX&_F83ZaaiJlVHKs<[^fiA!gBC%/DIO8Hg5rD</a2W0N%Za@if(gRLX+M7a1l64[(Dl[Z&t@E;S<mQ@X+ND)P\0$q,kn0t(\4ZuEjP?-WG1P(B@HgdR)HBEc]dof-Y&_uS#<_U+Sd'@^Y]78G#fWJ*_*E!nd/JgK9I4]ER]^<6D3F[+BDGh<f4KSKQfe:X%4I?+jb6i&@j3%8n1REL?6J1=)n"\GdB/7Jcj=@=YhOtIZYI[^)Ic])LC'l*d4"e&^Cr$BcMqHC\bmOCp9mXi2jgqBc`rTJX4H08@<$/mtS[&KUur/rHMt2M`R$_#sA62*=f7(H#/k@WfngT3$p3>&],)mR2h#X%m:+VbYZe$L(J#9$9ts&>N;B)`nQagm(Ht7bT_>'_".ecf@UZ(_A_GL-0I8*E<P<5f*OP=_nKci#^$E[F:L^r)iBI\[$.1+OdR!g/Ht[R=t`=BV0^T157MI97rg\Bk;T]'9O+do-W@Hj"?rf>SuY`#WZm*>d.00CGh]?#4Df?])0A0kZ8`Cue5Rg]Z"mM/R`=NKCi1lA13]e`/iE3/0/$YQa^.`&jeVHfZZ>WLnE6:k6&okSPME7PI!SgXEVUXsBCHA,EkQFO"$H)"<?/@enW@\t^8E!Bf"=`"s*GA4-I.'@I+H5-lf$=cc!M%j-ad1FGM`9;I!mm@DLiG-Ca%/GAA17`RrX17":ELrKL!^HI!&?;CiGu[X5/o,bj4I%A1[42Mu0"@E(I[n8,!o6p6O3jL^$.<;>Z0TG3uGm#Yc$?C(Ra/Pn3-eTAQ!BGrfDcZi:$\FuAp~>endstream
+Gat=,gJ[&k&:N^lqN9ScN9,D2@g8<k.Vb?%e5kt3@OmHT=j"lF1RYH(f#<Kf7&JV2#YMS]Vf/IZ6Qj;h@QqsNi560[mg,!\Q>7U7OMLE.DO5"0fqI];EC4Ct6r&_>i[i%dj;C/4_YGQJ[i>*gEsFY*Q1-/r'iS2\d<<\NFE12(q[Jkk_".457ZtV*q5W)5.TXAh.d6+(TDSe;p7hlj<OD*3.I_]9GCEJ1A5$,2T\QdB\[qq"#R3#r:u5.c/HD\13V7jZCXFobT/N(V@??S!OC)_H+G*7B4SZl>Lsg]2c3JtB>tng2a[&m*m@8[(XX.Bg'[^ng2A1t)XntcAe=.Mj/T5s)V\PP)H^L?L4B8IE.=8FL$28,^qeTeqEgnT1dtV@ET,HD#`qX_f[^qVX._Kpq2ROe!o*V]-;DIAo9kS4UP1=H502I%[4@g8u9[95$&%R:\$)XrT'k"_Sa$?4$@=ApC<nFjXl<1U"Vp7jN#:)HiA1W\=a[Of\BEjZriGD^E[f/DtdZ?"8!loeQG*hm^I2>6+=TV&0W$Ymj"bi^Z:h3^bN>A=/&`Uk+4Us9h806h0&q'!6"j(5<(1;4Vn_q[IkF:3ZbKnf7'<f.K8pt0I*sWkXLXD>&V%e>&#%Ud]b<`HA\m>hW5@A?-W$_/c=ha+.</=#nNp?'&VV_R6k/dt"o4p=3=NU$YYo^-#)UTcd[LM>GkK'p^fu!06VqpSqEo7\6FJ2ZnX[5+2=@=e-VPN!MDT&=aB0=@SDEm@9*P9[P6k/DR(X5hT]5CU&=e6%+j,6l-+:Mle+AIjrE2L;+6gGch=CK8d7U'X5hD]cMXp31>0#N]ZeoA-Md_lkY=@KuoZ/G`&0p]eE*#ClOrdqHm`a8s^!DYkOKoe`cHTi(mH_8nULUQ'_%0N-P>9)>!C0f_95#qmN37fb/RHVmdl8SUGQBDc\Ykh78R)3*&6ag;#p^)3Lhp2GDHK^+1,4Y#W_ikgJ7H273FV&&KS/>=SEOpsr=K`4o,TF_43f(Zc;Qm0h,blmNPs!2Z\R$<;HdC`O1eFPFNH.PZKjf59T.NfCB^m:f:@K=:+u`O#[:1E7/'f<GSoZ=&&"=UFZ'+Yq.Rh$@&+7HRkf<9D%?=Fts#"8fW','Ee'29si=)#JBs=ZOYpa5l&*/^ZfW;_Hb/;uuNNsE<XRc:GQ%QqV3KrK:jGm]VLK7H7qnpGFb`D!e)AoNnY^?2i"Dj0O31akL<1(lpq32*+.M6F=<82McSffWP<V,7A.8Geh.Qcbf[qgJ6a$!3E'3$j[U`37JCbZ%U;]6p^`1X^X'C84[M\uYidNG@GO;G"<Z2B2d1%!V?gGY%(lKXVsNslQ4c4bnOB&"dpf/N>"imHBalG!R=kU<$Rp*gH@<FY;@`Bnn7U`mh'bk!:n"<#P$<f3c@l5+KRRG+I(WNB*jhoKhMif:YM@`m%e?bCe?$AH24cN*g+#0/39Zq[[bbEcZpK?gMS-ru0Qb4S=hi/N*O:rh<][*XS9QIqHa1:97#bL9O5ZBpcSSE-GMYM::jNqW/2+NIPS-eGCrmV__G%c>1c#@G#^bCs^Oi1;H&HJ%nD(VmjcdPROt47Q)=s)%nl`V?Rt1G67EO13_"J'WB'[bW+aH1TM^%g1T)H!8Rfq32(.)Z/"_Ddip'GT+q:plku8N87'*\\WRf0"N8a=VS1iOS3);Z[B9.n>CB`p!LKqpnK.S9Lc]f"&Y!pAQ<T.NZ"43-E1=JJ]Ys.Y48s8U9@n%iTrecFJ"6~>endstream
 endobj
 xref
 0 11
@@ -85,11 +85,11 @@ xref
 0000000852 00000 n 
 0000001113 00000 n 
 0000001178 00000 n 
-0000003591 00000 n 
+0000003735 00000 n 
 trailer
 <<
 /ID 
-[<18c16ccd0b338705e2dcf2c530d0f6a3><18c16ccd0b338705e2dcf2c530d0f6a3>]
+[<a6d9bad603dc58b1b21f551ea30667f2><a6d9bad603dc58b1b21f551ea30667f2>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 7 0 R
@@ -97,5 +97,5 @@ trailer
 /Size 11
 >>
 startxref
-5294
+5583
 %%EOF


### PR DESCRIPTION
## Summary
- Restore body text extraction to a stable `extract_text` path after a regression that introduced character-spread corruption.
- Keep layout-artifact filtering (`header`, `footer`, `watermark`) while preserving valid chapter/body content.
- Rebuild table extraction flow to keep previous handling order and still emit all detected tables for verification.

## Scope
- `graph_pdf/extractor.py`
- `graph_pdf/sample.pdf` (테스트 생성물 결과 반영)

## Validation
- `python graph_pdf/run_demo.py`
- `python graph_pdf/verify.py`
