### PR TITLE
fix: prevent sample table overlap in graph_pdf fixture

### DIFF
--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -50,7 +50,7 @@ endobj
 endobj
 7 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260316111947+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316111947+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260316112905+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316112905+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -61,17 +61,17 @@ endobj
 endobj
 9 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2466
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2464
 >>
 stream
-Gatm=>Begk%Y"/U^dB0kFsV3a=8C+$0C)QgE?/o&Y@DPtZ0#nYP[3t60BOV/Z9WX.o]/CX!['Z,K)mY7K)kp*o=Lq$0'7,!c%'f$07cR@#j->M2*VD+KNapkJ\VP1a$qP"R_f3U"CJ4fo8OCM)BLN7iDN\cr)8JXW\`j,eWpiZAtp.4#FPN$o,j#AM)(je6-3.URDZ=-d#09!o-`b`+$JOh,o1pVeG.hl*N^gP7[5h2(2LI*m`qIVC'c&rLpG)*C4K2uRnXFg]W*JbpW"#g@5*\ncH-<rP"7_>:>fck.?A]@3#`8a59'Ige84DTW3*Dp\@*fAVAVVjaEiFZa^ot%MUf:nXt>Rg`p'I=8:;>G-oeY<f1j_hk#8cWS`IE<3ou$9fo)TCa?E8M_V3Xc]!T+=.7Htr@ED>ANPB+VS'WPirOV4:hENmnFq?;N5#FA#BAP#6c\.(E_+N9ViD/Qdq^i'WBfZ^O"34TYa-BKI3dhmR1Z=S;#G1^M0mb\?MB(/SO>OW+Q@Z4=S4qsnbn:59s5L:F>s7%e!N\>/!'**?%q*VZR6-#L/4fn:ZtTr4!.Xof(aP3IFIFP$^kW+i=:uf8!un9o?gk1:0<ag,\*%r;X+#JHoU.`9iKQ>"gns5#[:j[g0^b8g*PV2]Zfj?XUVBB#/;o4TG>YCIC`qneqb@!H]#QU`mte:)imXXWjEP@UT59`dH=3Q\/!J&&ZTHf9D9BS[(b&.X$H[dXK-rGo':j;I>u@f0`9:\\l5WTunSKIVYqk:eVLCu8&.@$1h;3s*8u,&`8SY<H"Ba:9\UBSd4Di5=p1LumKKrfn(0^<38OrnR@[jM#'<';RS`/]^\g#1'dF??+<?4,`@h_GgfBOPDW\3)-gB[WkIuV]r2j>"$2(.@3GNH%3G3`a=k+JpY]u[YdjRa12;X#tCYNl7Z5c\ECeVfHJoa.`W3InR&6nu.&I\EebYnbt.(@3iZPLbo)ke-56Ln0\*):/50g:bG+GK.#EImAVuBpMjelE(@']p!H)^!VHa!_mFV'k`MTrV5+rLH+72hT!]jj\r]Q_'>ZN,jo6uYK:b%OklH6D8,6VCPbWCYq[Q[2<+R[GhRa`*KTABJ;gY0MGbi9[6L<9>,ec^dC8f0nHLKZ]UmW'XXrN6<"MNB<Pg[fk1JoL=g.O0XF6+fX$%=NL*P_n7qPl^/6T1MjNp9ZPpNaZEi/'NJ3NQOlBS9Z69I'S0\Fq72m"1&YK`![?<5*6c7o40e?Ah:&=Vud4fI@ZCslnjL`MqSC%?)/*4:g)2YFg$q+;9*?JFZ)(bt&ao=W9p`WKrg!fjr3Ka8C9`9cl;ClPmeN;ukf1le-8#b8u.0dRd8k9hf]q+0T(C&9loDEdr#DP%i@nr_9[a_V+:M0oZP&JI-:,7[p)3a>6m>rD?4EWhD#V."2B,[ak#SRC!KY]9?=PDqgJWr"KSbgkBRR_%]%7E<pd`\b7Cq8<q-@p'Sq*]k]p*'IdE]bL$["HLp+;,TT0P5;2m/;j\WTVd[/!$*Qd33$uXU:TTFmU?TE@Vd;m^!%ij7\`EBLpND(cA":iofY10(bA:A"pq%:OO/4;VX=%j^a<90A3.sFe\,a,Tl(i)2Mf;R>bAh[ShWaeWrY@W4WRUN3h(h`Y#b^O2"Pfo=aJ"ALT=JYqTR]h=.]C-)HNY\dELDORnZQ"4$;5RIDa0_8=;HiC\uOZmr-_U?e[mdH"+1QQgL6Qa.\K!m-E!)JR7L0lhqQ\Yo5;CqMBcsQq"h0c0ZNn"<gB-&1FDAYY9tjhadHo:i^p>/gP]eecn+5n)oc+,I)>gO&s*P?@<pcPn@ZX5Z(4-@%!Vp*2eZY-.,d'7R0pWK0_4$L1Ph:V9JV!LU(`&%o:'_EFkR*\Mp7_7KVnpY0V%TkeMMDLTC<qg\VrDCR,V3fjIZN"-N#?[iW/SCf]'Y:#f'VQbfA_#%omU.B,5uqjZu8lN*L>ffP)XC-TS)H[m7MmfBc=;.kN$5N[tC%k\KOUCD)KPK6,UPoK`JDZY8QkGbBFeXjL]3#khkB]t8Ms.r?kEutdoeuktF*::`-;@n$]T'iHCnQ+KE*VEMn7m!A+i2p/!q1s`"n?V6nGf*V$b\bSr'/WHHc#O-c67_$QPM(L)j:!#f0FcZP5[K9gYIj:WNmK_%NC=>od0S3/mAArL/p59:7<eO'jMQdd$&rhJT.abWXGGh,gYp*Mol'&cALVWG)P(7J1o84#LurEIe5(1oGUZ['?f!P/W2VACGo@pt".d/P1q!>^;i1OVBP6b6nSrOJ79Q%^917gfQ8l\ceauSN`LLd67o`I"!E&UMLurCcm]1$O4R'%X>q6^9GF4Lt-$Ub:rB4:7(:*656n3N]OnJ58d>*jT,_H/<5o0eSG9QIE1DXLKpI5)e_>1u#*[Nl#2*<,G-\FuF%?P/d(i9&Vq6m4d<mjNd,h=6i+E8Lj<c#rKjB2!(o$-M$-iX?(K:Q3~>endstream
+Gatm=>B_#F%Y"/U^dB0kFsRYZ2p#u]Hs*)QNpCAJIAJfc2"fXi1U=(\q?:f+Yq1jGH[9_,:]Q.Z!'pTq(^0VhREoFNE3XrBCBfa8@Ke<O7^0CTX2RY<,h2\/$NrqL4#U!)dhF-j-MXn[52Rd9CuF:C)D5T(_`t!=UcO-/PYE<pXg`$oIt5N,Yk[aEP%\Hl4=Jkg,r8ZR$9I^1^\eC!q*t\b=,CLTf+iaQ]9ZJ4Ehgbq!6^@,5.>0$jHYB0?:9og!]<4dG4i9Gr4]=+=`qb"`aLQ\f\X^TZ'IpD"]""%k#3>ih/P=iCjn;7iMk[7R8>tXhf3L1&5?g8cm.i_H6cSJWQNh^%bdf$3ub)qU*fPAFJ@^GAmO#2LRM#t%X!rLjjkk.SB4Oe"\/2gap'cD[aUN'/IO!W;@cETH7JhT"5JQ58a&'XC\Ib,c?=hb&b1_+Bfu,R3IN5:ljVINOpZCo"5If\-qMg$O<-C4kWLPPHIh?(W1=6m/3`RADiEA58Xj@k#(r`1mC!FFrT@]0#Aftc3;aSRh<Fe+Xpndpg&oFD;1/FS5+T5/31V?eJ;H1D@1qLRruM@N,V5L`#p/T0_%W,f8=b<keX*K6f=.)JpP[et]7Ets^-DJ<*;shK*.Dd(o?0T[3Wp;o9:ZRM3ji7:>MRW`Urld7;UE%SeH@dl$bcKcrd!&QRDe!=U=eG6A[0MLd"Xd<.%BkE8g2b4Oh5phYbBhf>s9u@Qr55nru;8>ju+PImB!n3>%<E:a&H"USl"J%7(cu?_Je2o)$N8V<Sb*s&abfRPo1jHXWA-`D27<J72GC"/IL1%mE6%B[>e:'c!r%C#p>(A\cPQu69B=ES$V=9*/A*2X`@FMkX^G**-#>dMtj6^YZKE]r"VGUc#u%1'I,I_iI6"4YQVD(H<XpQYQ2AX[ftjb'mER?1C11R*1K3gA1Q2gNfNc=XY`%g[cp17[b-&&X!"Y^g(kIrRFXuGa[WYoog-OAaSh(\IR!4+@b*VNRb^3$`e`+pX<?'=KSSF+31[b1K.R.!WmMPoNW/bD?`+n'KYR=?<ZWfab3]KV$/HtK0:QiHL*M`Fem)n[:&ij:9QH)O.H.EApZLLL#GuW+T&0N'g:YW;ThNu8J0o31`Z@V,es",nXB=t<;?=53O9\TK(thmih^k1*VmBpIlH*0**#Vg@)(UFdj(_A%=Q(f6YBk6Q+na!@=V*SloP-X`HP?(pdp4,gRq`f,lgUCpO4DkE`GI!Giur'&IU;<kDFXuWHW:S+59-/7=[$;M-I4Mo5#%&@a&AK(ht(Y9M(Z"!o5]eWEO:!tjqHbU2$j<(hMac(MIg8j[N2eG>P(Ab.:!k4:0RirjNj3V[F4X[(9;6so'`r6**>.lr@E.g[8>OIBV"4#"Q"u_$HWkn3+jHG>:)C98o.cJp>06]N`)]^Consj>ToYGeLRnEFfppf5TQm%0X/dOfjF"omqP;3eI0AR\ek1\'09XV/>PFP9_:;j`[#lPjm*0lV+IGXHitbg<IIm.9:S:B)'8l?<;(<2j2=B/gCi>](uiKd8@!Q0:P=ZrMrG=]/JFZaE?OO-C.p?aPTgPL7O'%Ln()X1l-k/W[VEp+RNJPVf>>o!&81ACk5`,7I4!NH,j+<:25#`(VrOeTZ[(cuH8V?cF&0iAV+9>$lICDKhpVi$J"^<0r"''RG9<oq%5I=)^">96N/3^TK3mn;?,"'Ns*nknD<-Q(H<rEIl5gc8@UFV^%J2EB?gk1sR0]WuU7W8>MJ;^pdG3SE7hDD:"G(##"O".Xr-a5_#UQtCm6ZspiindGIf=RV&kaVFGkKhYeb9Y_)0%PD'ZDm7QMEP]E@Uue&q/;<"@TXT(_kG,=Q\d=b"TQ4'LhtHGS33#/">4`HR$[R,d:VAqY^&I%]l"C\@TGf]t^8SAgu-"%2Qo>&F$oSl`ghTH;.`':n!id$kC653;Xjp8[Y\Whe\?Y&(k.5hGIfbr<R?0!JW_L#L$h@3Zj=X0mCQ\E03[2D/`^H6lnt(h"Vt:'A+6b:H`!eHMZLXE(Gt_Td-0.QS&lo4VhG->uU,NlGXN:&9eSTp/:X0X)@rtHE<U2*DdgHeh#d-`'PhrRC>i%i@AC"2J2dl)CM,&[0$7l,N7S&m(a$M#*)0?#&HLHY=45u?$J\+kaT$#+p[(?KP@[a;fX3d\n%kS4a\^S0]KEl7^p%VQa4lf`:0SiE+8kD2mgo:O>pp5:9Y"m;I`p!o/'A1-b;p_jQj(;[i$I@e/$FoNKO!e:1$0L9#(CjidWK41\YX3*8J:W/+^>?1`gLj'7<W!=*HaMfg`>J-,gf7FWZWWSjq\QMO*q!ILU'3\K&/tN8uJ)1TB[.a^VfFD4;bJhW[P]_rmd*,<JI$"lb+d&5MX[i&,-uaA2/]rXXVPLKcl5FL#\,7a+X4P@>FQbLA9!FrU%]W#mO(,X)iVP%g#fO*2ak74g8GGoQQkG(>eV!kdWc`W~>endstream
 endobj
 10 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1756
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1757
 >>
 stream
-Gat=,gJ[&k&:N^lqN9ScN9,D2@g8<k.Vb?%e5kt3@OmHT=j"lF1RYH(f#<Kf7&JV2#YMS]Vf/IZ6Qj;h@QqsNi560[mg,!\Q>7U7OMLE.DO5"0fqI];EC4Ct6r&_>i[i%dj;C/4_YGQJ[i>*gEsFY*Q1-/r'iS2\d<<\NFE12(q[Jkk_".457ZtV*q5W)5.TXAh.d6+(TDSe;p7hlj<OD*3.I_]9GCEJ1A5$,2T\QdB\[qq"#R3#r:u5.c/HD\13V7jZCXFobT/N(V@??S!OC)_H+G*7B4SZl>Lsg]2c3JtB>tng2a[&m*m@8[(XX.Bg'[^ng2A1t)XntcAe=.Mj/T5s)V\PP)H^L?L4B8IE.=8FL$28,^qeTeqEgnT1dtV@ET,HD#`qX_f[^qVX._Kpq2ROe!o*V]-;DIAo9kS4UP1=H502I%[4@g8u9[95$&%R:\$)XrT'k"_Sa$?4$@=ApC<nFjXl<1U"Vp7jN#:)HiA1W\=a[Of\BEjZriGD^E[f/DtdZ?"8!loeQG*hm^I2>6+=TV&0W$Ymj"bi^Z:h3^bN>A=/&`Uk+4Us9h806h0&q'!6"j(5<(1;4Vn_q[IkF:3ZbKnf7'<f.K8pt0I*sWkXLXD>&V%e>&#%Ud]b<`HA\m>hW5@A?-W$_/c=ha+.</=#nNp?'&VV_R6k/dt"o4p=3=NU$YYo^-#)UTcd[LM>GkK'p^fu!06VqpSqEo7\6FJ2ZnX[5+2=@=e-VPN!MDT&=aB0=@SDEm@9*P9[P6k/DR(X5hT]5CU&=e6%+j,6l-+:Mle+AIjrE2L;+6gGch=CK8d7U'X5hD]cMXp31>0#N]ZeoA-Md_lkY=@KuoZ/G`&0p]eE*#ClOrdqHm`a8s^!DYkOKoe`cHTi(mH_8nULUQ'_%0N-P>9)>!C0f_95#qmN37fb/RHVmdl8SUGQBDc\Ykh78R)3*&6ag;#p^)3Lhp2GDHK^+1,4Y#W_ikgJ7H273FV&&KS/>=SEOpsr=K`4o,TF_43f(Zc;Qm0h,blmNPs!2Z\R$<;HdC`O1eFPFNH.PZKjf59T.NfCB^m:f:@K=:+u`O#[:1E7/'f<GSoZ=&&"=UFZ'+Yq.Rh$@&+7HRkf<9D%?=Fts#"8fW','Ee'29si=)#JBs=ZOYpa5l&*/^ZfW;_Hb/;uuNNsE<XRc:GQ%QqV3KrK:jGm]VLK7H7qnpGFb`D!e)AoNnY^?2i"Dj0O31akL<1(lpq32*+.M6F=<82McSffWP<V,7A.8Geh.Qcbf[qgJ6a$!3E'3$j[U`37JCbZ%U;]6p^`1X^X'C84[M\uYidNG@GO;G"<Z2B2d1%!V?gGY%(lKXVsNslQ4c4bnOB&"dpf/N>"imHBalG!R=kU<$Rp*gH@<FY;@`Bnn7U`mh'bk!:n"<#P$<f3c@l5+KRRG+I(WNB*jhoKhMif:YM@`m%e?bCe?$AH24cN*g+#0/39Zq[[bbEcZpK?gMS-ru0Qb4S=hi/N*O:rh<][*XS9QIqHa1:97#bL9O5ZBpcSSE-GMYM::jNqW/2+NIPS-eGCrmV__G%c>1c#@G#^bCs^Oi1;H&HJ%nD(VmjcdPROt47Q)=s)%nl`V?Rt1G67EO13_"J'WB'[bW+aH1TM^%g1T)H!8Rfq32(.)Z/"_Ddip'GT+q:plku8N87'*\\WRf0"N8a=VS1iOS3);Z[B9.n>CB`p!LKqpnK.S9Lc]f"&Y!pAQ<T.NZ"43-E1=JJ]Ys.Y48s8U9@n%iTrecFJ"6~>endstream
+Gat=,gN)%,&:O:Sm%`<qBnG>=IWOL.c&=#FCe\R=#a#\;)?a"NFJ=/2(Dk6$+u&&;a"k"0m+L,rO<tP!&$_a,#OlU7Qa[)g!ilcl1eM2!#9QuZZ/)+BZZ/?K2^D^h;W98[E[Yrjf"q/P7<_u2EcVUIXHW-$UGYtOd*lmQ)>%rG(&JG@s1mpo'1UEu)Yp,[N[e)I7Olc,N@4`+c+[u/?UZL$8qGlHh1n]V&o5WM!7dB8:]2$t<\RXk1Z`IJd/n9uQ\,M?hM@0uIG/);Lng1SK)@qS"pnO$'#6/e;3Ds:nNL(AjD#UN=q7:(C@D*_D(UarW(`3rEfj`tCniX`gMAb>45O_=V_sf,H^L?\5#n[g.5b;CKKHOY4I`jRr8sG^g2bF('4X,V>2Lqk:02F)7F2OdVfi2l?3(g-.L(4Rp9s[1=mma6$KNQdU22j0jR(XmO=P"3?j\Di"4iqG$ku,E(Is&D9T;-6SkT"clC>kPLh'#<N.nMo\`hcdc!Z\C]IV1Df"Yip(6`<)i:ntRm]q,JlXOUS8&,602$D-dW:Ud_auk`id@q%%@f.(X0B*sl;FEs6"J7`&61P1O95qFfJ,f?<e'3ZoX&%>k'<f.L9RUBL^PDsPO-;"G.OfHi#%UdeX22"IHEDoo%p3$cl3[D_Q7r(T'quG&Vn,+Ll?s@_T"K/*^P8N$8q)DaBtspfKgo`l)p8!5P@M:MKfp!n\C5BX^h[&A6E(/nL%ZXoLg2iT7Cfn_MFf2@GZM?0^,)lQG+fG'>1/lnL84Nfe#KQp4;i=n(TEK](sWOTQ6$(b9R4WFRm$UMA&o/"=R-0o>;LNU"6[mm@F$[o3*SZdiX-L'U>P=i#_:nOb860Y(I3:p_:^X)YCgiqVpFN\j@S@W-_c(UGnY;dlFkn,^j3W2OmT4#l^%.I1-!=bBn>,1Db#uI*m.YX5'4[+/%K3uF#=E[FoB3Jj;!&('<j/X2hhg!k>iQDSN&9$0/fjI0kSOcEHMh*bJ]=`l:%6*UDR&cicp,5.jl\.kR)S]:Pr"e<\O#rkDQ;r9rA#OE_l5%AU&Ti/RD[#nM86_n/f39YZ:Y4@O+)bcgQ(/HRL=L2E_IX/`dYqM?^7*gl6q@N#,Aq*2gaSCW/b?GMhu"T>A\0)6AqJ@Q>`D;9fk^aBQWf=a>F[LL6r<a_+jtb4A,(%16b09TG=!4,QlESZE\>LQ2%2(c.tp0M[I5C\bmOCls</Ssh?4SBaBRPSVCj&Sf?cfClnG+<B"4rVjeNBB;gP^%2*eFZ?qlT#Z]pW`j\rN@A8LS,j$I/Ws%Ad!^ZU%O5NG$pmL!&[HDt$eF6<I`B!ep?\nuRk87;lBUNC$no:X&;>7=gaG0A:["(^X0EBrr#BCCPJmrP887%Q&nA*n(,A-&"$pO2?;P>ZaERr5;RBW-T?-QGe>D>$D8#N<7TM;YGMMj-;jK?(_)q:`:mso7)8M?^i]*ck[VaNAg!Y7[cio[M`@2Bfq*&KsI,^a0eF<l@QKAh(M-Kd+e&\kJ4F8A%#<A3p8MSB4b$VILNp,i!eVcO_7U38<jo3C$`8u>:ca(J[*>bkuJ;7H>ikqohHiP,f--_U0[1i".s6iOp\@D<6o2un.Y(mP>2h0.ukdT@lhg,)D2!YQd&njRh(/e=pAF*+d^PNg:&njOg&Q2d@13P$FeJ@?4S*5mZA6I475fSFrcg(Ml5+L&@f6d8?&WW0A1DpWO/OVU2Pgtc*3bDcWRA:%P(8_q4]"t<C21>-a%;5\A>st<g~>endstream
 endobj
 xref
 0 11
@@ -85,11 +85,11 @@ xref
 0000000852 00000 n 
 0000001113 00000 n 
 0000001178 00000 n 
-0000003735 00000 n 
+0000003733 00000 n 
 trailer
 <<
 /ID 
-[<a6d9bad603dc58b1b21f551ea30667f2><a6d9bad603dc58b1b21f551ea30667f2>]
+[<64dca4b881ad35f2340a167d4c97cd49><64dca4b881ad35f2340a167d4c97cd49>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 7 0 R
@@ -97,5 +97,5 @@ trailer
 /Size 11
 >>
 startxref
-5583
+5582
 %%EOF

--- a/graph_pdf/sample_generator.py
+++ b/graph_pdf/sample_generator.py
@@ -309,13 +309,13 @@ def create_demo_pdf(path: Path) -> None:
 
     _draw_table(
         c,
-        x0=334,
+        x0=356,
         y0=325,
         header=("Group", "State", "Comment"),
         rows=right_rows,
         row_height=44,
-        column_positions=(84, 160),
-        table_width_tail=140.0,
+        column_positions=(70, 140),
+        table_width_tail=100.0,
     )
 
     # Spanning table starts on page 1 (header + first part).
@@ -369,7 +369,7 @@ def create_demo_pdf(path: Path) -> None:
     # A compact table near bottom keeps another size variant.
     _draw_table(
         c,
-        x0=360,
+        x0=392,
         y0=290,
         header=("Area", "Status", "Action"),
         rows=[
@@ -385,8 +385,8 @@ def create_demo_pdf(path: Path) -> None:
             ),
         ],
         row_height=40,
-        column_positions=(90, 170),
-        table_width_tail=110.0,
+        column_positions=(72, 130),
+        table_width_tail=90.0,
     )
 
     c.save()


### PR DESCRIPTION
## Summary\n- Rebase this fix onto latest .\n- Adjust demo table placement in  so page-1 and related tables do not overlap in rendered sample PDF.\n\n## Scope\n- \n- \n\n## Validation\n- \n- 