### PR TITLE
Add wrapped prose table fixture coverage

### DIFF
--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -56,7 +56,7 @@ endobj
 endobj
 8 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260316130708+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316130708+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260316132845+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316132845+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -81,10 +81,10 @@ Gasb]gN)%,&;KZP'Y%,kWP\6MG=gScS]N]\X;?CX87G"#$qT)LT=t\R+j.6taE5k'g)p5X/:d]8qTOSA
 endobj
 12 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1512
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1556
 >>
 stream
-Gat=+gN"Md&:O:SoV7W"Notl]RhDn`WGIh?Y?pdU7Z9`g@#CBB-""F3!0UguPb_Q-@6!mnR\%u&!\s["oA=^%nFI91mLr,h=E]ee;%CdQn9K9ocNpqhEe&B=UimVg'5K$ITdi];mc"##,5i8un*].pmNqd'adT56(s'GS'F$RsQMpm-^L6lt)'_R4)gPDi-]5(#P6sdb_OWp-87+m&?U`\28V-mPj)EjSOloT-*.3&X)[b8DBHG2kP9$$M^X-k4],PX=P;bL]Y`b2P'D2Qe4u<&potRHO`Sb(F&T-C?=5&Yj]m2g1[GWn_$016cNm\uWZWB)V=_g#D_K20YMMfFL@;U!2-mZ:+Tn4aL@T_5m,T[%f'ue].B6kT54]+:hPOIOF1?@]C<E-lZQ-dQ"RhGEk<+a)-)bqc''r@Uh,'>Cq1+V'X>e=\i>r&7o?flN8O%qX$nSp-tMSkl#]/?)J[8-KD.ShiaO.iW_*Mh.$-;C5ZRcWj(gX9M</&p9;G!>,(e%FH)2!5]f!+(%K##C+l#HAuJK.cp"QI5f:5=$e'ITch#3uOtl)*`%B7V.\5&$W\VJ@mu?[ZX%\5q:)u5A<t`H'$MdYbVbZUk1#m'"!O8ZD'Gmj#dX2RcWjjSf2qs9@a3'I[%bFM3CN<>?&(?(SK*;$Wl["=AB+:;t$Pj,:Y2%<;E=gPG[Suqt1%BW<;@sic:\]:cTIWqPRJ[m(rr'!LD7:9K%)gm6O=h=/=[2?lJtm>r5Q;g+Hai1I6\tIMjLQoJc:k=\Ae1.E;>!W(=c%%0.rO"5okcTk>Uh@oEe$MiokDV4YK%_`&S9=F(3;qMc\.e-Bl89PjX&AJ;fA!5OaY!0XL^onK2S9hLr<ogoCPbT0@mSaU!E4?iHHl)]\79QYf)9;1D:"^#El&LCcg(ja1^aCd&dSW\=%@gY*CJ99V+r67QC!k6sj!MPBek-b<j@:H$!?QA&&%7mC4YdQ^e6jO4'2*XVnY`9Vf;fkg&(k<7<)/drp'(-LGHO;`sf21\^D@UEUonbk2r_M"DM/t_4l[Rd$U9-q@>+.c6LHa;2H;[F8Uc0+$:t3s^,`TMrL\iumEUlY&(+8R4MtY%9@,.gnDH?G8K?/,c60Q^9)I$Q1NMFC5<k1+VO5BUM-44@4>VeNt=YjQsp2Bee]JRcO-X4p5c0+,+:S/GIItjcA!O\qIp:"BLoAY?o"TXjg33&3g$M_a6$^qb0=L.k'8OTsjp)IJ`Z5NJY+rF49>!C_)"=%Z$^R4<HB2,]?!VHOGP69_\.4QIIfX:PNn5U9bW?5OD*!#dq@VVp0/o)B['a59D!;enn;hnPDRm[])[smJN#mW?gY]L@/[k@I&Red"g*"H`ai7R$V=IE:?=-W/Kd:)qPMca!s'jpSr'l3N#XV^44cTqH%`d5Tbf$9_5lRbn8<Ze@CQtemVc'(ch@;kGRF"5c@F`.m7<G?UpCRH"dKf)Q(4jG'`j]n#$&eRHjF!9\Aa-rh.7_a$-ni4:cG]<<rW/MA'~>endstream
+Gat=+9lo>Q%)(h*i0^sZ>(+T:c##An:-5fHXtMrd&nSDH8I\*7S,W89,&*t@OD[.JA/O;<%g5,tarnZqD#)g+!Iih>qhGTc*&[n0AQ$D-2u'Vf8Jd'6h0;2r!-0I,h99R_C1ulN2Fk:UW5uK(a86+OVah%X;pnTe#89+XSAHOae^<hno-\@gImZem/kR0"*JpLR$rVX'><M]`B_k^2r[Q?1-3aB5l03%b<EUY;G-^@plmNQd6d%;\g>^%em=fFR]>J^qS@lpG_cG'W-gCjLI:Dh/BRdF9b6JPUC=N&#I\VN*Sh8.IX982r'?8FO"/R7/(TZC'<n;7_7,Tt7P>nZn_s-/S:rr'47g2m\UK`)>8O,Sj,\ck00r+9rOf3nhjD.!6%/Khk-<\1VNA/t_gDZ)K20Qst$Z9UX-HTb\.eaQ\=c$"@Y5C2\Y,O2EY=l?A<gO'XqCKhEl6N]O068#G1'uhboju.0.FbE@39ekH=dp;:<d_OI3]]uOb;ds(D`^+#gK+VD00+b)J:Sfa'M*4R5Z8u0W!Qm_U\')kGL/p4:M[gX-PJ?d'BZF_UlP##!KPb6OS;"I[Z[R1Ur")^P?(CU7S1Jt8*U+G.Yts.@&aJ[>KS0S0!ct*(#OHYWRVg3j=G967lfgXSBR_^@s+7N&c*]`'&kU\EI%WAqBuNr=A]C&.TAG<BqA[gD]%D'4i$+nQP6b1Q*Vo9rsW[D>R>?di)i.XB(Ngf&X;@(9=b3XAfXY2Wbl4p:42rS";.@,AW?3+?c8.=*<gghN/)\`,":N2!B<7R^e6>7SnX)6VW`O?9?r]b@JXRNO)tN_kWJq1GDZZC0&.J7fS)o_2BM&f^l`pCP&BH38$QaP8mLNO`<;AV'24P$4i:61HCbrDV'7ZLdg>Z<_SG7hYec;D8j6$)NJqq?:Y6ir-'&h]'\6(g14:qb%h#pjgh+kZKIX93`Wl?r#u-*[*9$f!aC'=ud63IW#^!1I5=r>'L>%6Vk`IPR!@<UZ4D6&f4=eYJ'JZOk6"NNt`Mo9):\9M7J#_ANS5UHss(1Mc[TT/IBb'OiqU?eV75N2Nh?J)(BOEU;=q`fTqkAq="!t$>ZWG4jpWXAUAi;"mS(2e9-qccjR+6I$7pi`bX4)7>pbB^g?I'SA$[-rafbq]Mm+TY^c+Hp)[^+]3/oYh-Hp$igL\:TfYu9\7VQ+Y0(BpPE4aSCN>cj=n]U-rRdMS>rm"srf0Xs+[[M7hjkOTJ*qq.YsX"/lV!cZ^kk<`gr-Gj<TQ*M/+33r*[euVpsCdkTOIpY^@i_Z+?pRe0GEO_WW!t2Ht`>+/_!KP8(n;\3@.!.HDL&(5U0^dCD_!u[MndWOGjWIjV[Vi=,k5#DXCWr[t[C24918sqUk#E@EC]r\[4CFS+n69`N,A_)LXV$(r92BG:U8MAgE=Rk$qu>OYMomr0of,jsZ`dIAaE[QE1aN0,*ZJ4j["Z,"LF\84\Y4Oj.)bGaBI;W,c$bAn7K6`@B'Hk1/Oj53'[r#;8k=*C]lUekg3PCa+f&Fj3@?&[4]>b4Vt/8EVq4WVDZ0indk"c~>endstream
 endobj
 xref
 0 13
@@ -104,7 +104,7 @@ xref
 trailer
 <<
 /ID 
-[<ba930ad767c72e07bfef84c6904dadf8><ba930ad767c72e07bfef84c6904dadf8>]
+[<cf5962f763c2103c869ed9199c7fb798><cf5962f763c2103c869ed9199c7fb798>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 8 0 R
@@ -112,5 +112,5 @@ trailer
 /Size 13
 >>
 startxref
-7395
+7439
 %%EOF

--- a/graph_pdf/sample_generator.py
+++ b/graph_pdf/sample_generator.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterable, List, Sequence, Tuple
 
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
+from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfgen import canvas
 
 
@@ -156,7 +157,11 @@ STAGE_ROWS: Tuple[TableRow, ...] = (
 )
 
 COMPACT_ROWS: Tuple[TableRow, ...] = (
-    ("Docs", "READY", "Finalize\n- sample\n- archive"),
+    (
+        "Docs",
+        "READY",
+        "Finalize archival checklist for downstream handoff review before publishing\n- sample\n- archive",
+    ),
     ("QA", "TODO", "Confirm\n- edge case\n- fallback"),
     ("Ops", "OK", "Archive path\n- cleanup\n- index refresh"),
 )
@@ -219,10 +224,42 @@ def _split_cell_lines(text: str) -> List[str]:
     return [line.strip() for line in lines]
 
 
+def _wrap_visual_line(text: str, max_width: float, font_name: str, font_size: float) -> List[str]:
+    words = str(text or "").split()
+    if not words:
+        return [""]
+
+    lines: List[str] = []
+    current = words[0]
+    for word in words[1:]:
+        candidate = f"{current} {word}"
+        if pdfmetrics.stringWidth(candidate, font_name, font_size) <= max_width:
+            current = candidate
+            continue
+        lines.append(current)
+        current = word
+    lines.append(current)
+    return lines
+
+
+def _layout_cell_lines(text: str, max_width: float, font_name: str, font_size: float) -> List[str]:
+    rendered: List[str] = []
+    for logical_line in _split_cell_lines(text):
+        if not logical_line:
+            rendered.append("")
+            continue
+        rendered.extend(_wrap_visual_line(logical_line, max_width, font_name, font_size))
+    return rendered or [""]
+
+
 def _estimate_row_heights(rows: Sequence[TableRow], col_widths: Sequence[float], font_size: float) -> List[float]:
     heights: List[float] = []
+    font_name = "Helvetica"
     for row in rows:
-        wrapped_lengths = [_split_cell_lines(cell) for cell in row]
+        wrapped_lengths = [
+            _layout_cell_lines(cell, max(col_width - 8.0, 24.0), font_name, font_size)
+            for cell, col_width in zip(row, col_widths)
+        ]
         lines = max(len(lines_) for lines_ in wrapped_lengths)
         content_h = lines * (font_size + 2.0)
         heights.append(max(24.0, content_h + 4.0))
@@ -560,8 +597,8 @@ class DemoPdfBuilder:
 
         for row, row_h in zip(rows, row_heights):
             wrap_texts = [
-                _split_cell_lines(cell)
-                for cell in row
+                _layout_cell_lines(cell, max(col_width - 8.0, 24.0), "Helvetica", row_font_size)
+                for cell, col_width in zip(row, col_widths)
             ]
             max_line_count = max(len(t) for t in wrap_texts)
             row_baseline_top = row_cursor - 11

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -44,7 +44,10 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertIn("Qty: 12", markdown)
         self.assertIn("Price: $120", markdown)
         self.assertIn("Area: Docs", markdown)
-        self.assertIn("Action: Finalize", markdown)
+        self.assertIn(
+            "Action: Finalize archival checklist for downstream handoff review before publishing",
+            markdown,
+        )
         self.assertIn("  - sample", markdown)
         self.assertIn("  - archive", markdown)
 


### PR DESCRIPTION
## Summary
- extend the sample PDF fixture so long prose in a table cell visually wraps within the PDF layout
- regenerate sample.pdf and update regression coverage to assert wrapped prose is reconstructed as a single logical line
- keep existing watermark and multiline extraction checks passing with the expanded fixture

## Test Plan
- python3 -m unittest tests.test_extractor -v
- python3 verify.py