### PR TITLE
Use punctuation-aware table cell normalization

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -143,6 +143,10 @@ def _is_bullet_line(line: str) -> bool:
     return bool(re.match(r"^(?:[-*•]|[0-9]+[.)])\s+", line))
 
 
+def _ends_sentence(line: str) -> bool:
+    return bool(re.search(r"[.!?;:。！？]$" , str(line or "").strip()))
+
+
 def _normalize_cell_lines(cell: str) -> List[str]:
     raw_lines = [part.strip() for part in str(cell or "").splitlines()]
     lines = _remove_watermark_fragment_lines(raw_lines)
@@ -166,6 +170,8 @@ def _normalize_cell_lines(cell: str) -> List[str]:
         if logical_lines and _is_bullet_line(logical_lines[-1]) and not buffer:
             logical_lines[-1] = f"{logical_lines[-1]} {line}".strip()
             continue
+        if buffer and _ends_sentence(buffer[-1]):
+            _flush_buffer()
         buffer.append(line)
 
     _flush_buffer()

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -64,7 +64,7 @@ endobj
 endobj
 8 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260316154125+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316154125+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260316154225+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316154225+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -112,7 +112,7 @@ xref
 trailer
 <<
 /ID 
-[<98f8be010e85d9b1400962444ac81a4d><98f8be010e85d9b1400962444ac81a4d>]
+[<12d57f31bd5c38d8a0874fddb922dcc4><12d57f31bd5c38d8a0874fddb922dcc4>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 8 0 R

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -64,7 +64,7 @@ endobj
 endobj
 8 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260316153502+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316153502+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260316154125+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316154125+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -112,7 +112,7 @@ xref
 trailer
 <<
 /ID 
-[<250f456e6d53720c34d742801114c514><250f456e6d53720c34d742801114c514>]
+[<98f8be010e85d9b1400962444ac81a4d><98f8be010e85d9b1400962444ac81a4d>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 8 0 R

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pdfplumber
 
-from extractor import extract_pdf_to_outputs
+from extractor import _normalize_cell_lines, extract_pdf_to_outputs
 from verify import _extract_markdown_tables
 from sample_fixture import load_demo_fixture
 from sample_generator import create_demo_pdf
@@ -86,6 +86,22 @@ class TableExtractionFormattingTests(unittest.TestCase):
             markdown,
         )
         self.assertIn("| Docs | READY | Finalize<br>- sample<br>- archive |", markdown)
+
+    def test_punctuation_ends_logical_cell_line(self) -> None:
+        cell = (
+            "First sentence ends here.\n"
+            "Second sentence starts here.\n"
+            "Wrapped continuation without punctuation\n"
+            "still belongs together"
+        )
+        self.assertEqual(
+            [
+                "First sentence ends here.",
+                "Second sentence starts here.",
+                "Wrapped continuation without punctuation still belongs together",
+            ],
+            _normalize_cell_lines(cell),
+        )
 
     def test_spanning_stage_table_merges_into_one_block(self) -> None:
         markdown = self._extract_markdown()


### PR DESCRIPTION
## Summary
- make table cell line normalization punctuation-aware in addition to existing bullet handling
- add extractor test coverage for sentence-ending punctuation driven line breaks
- include the current sample PDF artifact from the updated roundtrip flow

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 run_demo.py
