### PR TITLE
Split demo text and table markdown outputs

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -85,22 +85,49 @@ def _extract_body_text(
     page: "pdfplumber.page.Page",
     header_margin: float,
     footer_margin: float,
+    excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
 ) -> str:
-    body_bbox = (0, footer_margin, page.width, page.height - header_margin)
-    body_page = _filter_page_for_extraction(page).crop(body_bbox)
-    raw = body_page.extract_text(x_tolerance=1.5, y_tolerance=2) or ""
-    lines = []
-    for line in raw.splitlines():
-        fixed = _repair_watermark_bleed(line.strip())
-        if not fixed:
+    body_top = footer_margin
+    body_bottom = page.height - header_margin
+    body_page = _filter_page_for_extraction(page)
+
+    def _clean_lines(raw: str) -> List[str]:
+        lines = []
+        for line in (raw or "").splitlines():
+            fixed = _repair_watermark_bleed(line.strip())
+            if not fixed:
+                continue
+            if _is_layout_artifact(fixed):
+                continue
+            if _is_watermark_line(fixed):
+                continue
+            if re.fullmatch(r"^[A-Za-z]$", fixed):
+                continue
+            lines.append(fixed)
+        return lines
+
+    excluded = []
+    for x0, top, x1, bottom in excluded_bboxes:
+        if bottom <= body_top or top >= body_bottom:
             continue
-        if _is_layout_artifact(fixed):
+        excluded.append((max(body_top, top), min(body_bottom, bottom)))
+    excluded.sort()
+
+    slices: List[Tuple[float, float]] = []
+    cursor = body_top
+    for top, bottom in excluded:
+        if top > cursor:
+            slices.append((cursor, top))
+        cursor = max(cursor, bottom)
+    if cursor < body_bottom:
+        slices.append((cursor, body_bottom))
+
+    lines: List[str] = []
+    for top, bottom in slices:
+        if bottom - top < 4:
             continue
-        if _is_watermark_line(fixed):
-            continue
-        if re.fullmatch(r"^[A-Za-z]$", fixed):
-            continue
-        lines.append(fixed)
+        raw = body_page.crop((0, top, page.width, bottom)).extract_text(x_tolerance=1.5, y_tolerance=2) or ""
+        lines.extend(_clean_lines(raw))
 
     return "\n".join(lines)
 
@@ -573,6 +600,22 @@ def _append_output_table(output_tables: List[str], page_no: int, table_no: int, 
         output_tables.append(f"### Page {page_no} table {table_no}\n{table_text}")
 
 
+def _body_excluded_bboxes(
+    pending_table: Optional[TableRows],
+    tables: Sequence[TableChunk],
+    body_top: float,
+) -> List[Tuple[float, float, float, float]]:
+    excluded = [bbox for _rows, bbox in tables]
+    if not pending_table or not tables:
+        return excluded
+
+    first_rows, first_bbox = tables[0]
+    if len(pending_table[0]) == 3 and first_rows and all(len(row) == 2 for row in first_rows):
+        x0, _top, x1, bottom = first_bbox
+        excluded[0] = (x0, body_top, x1, bottom)
+    return excluded
+
+
 def _extract_embedded_images(pdf_path: Path, out_image_dir: Path, stem: str) -> List[Path]:
     out_image_dir.mkdir(parents=True, exist_ok=True)
 
@@ -615,10 +658,16 @@ def extract_pdf_to_outputs(
     with pdfplumber.open(str(pdf_path)) as pdf:
         for page_idx, page in enumerate(pdf.pages, start=1):
             tables = _extract_tables(page)
+            full_page_text = _extract_body_text(
+                page,
+                header_margin=header_margin,
+                footer_margin=footer_margin,
+            )
             page_text = _extract_body_text(
                 page,
                 header_margin=header_margin,
                 footer_margin=footer_margin,
+                excluded_bboxes=_body_excluded_bboxes(pending_table, tables, footer_margin),
             )
             if page_text.strip():
                 output_text.append(f"### Page {page_idx}\n{page_text}")
@@ -628,7 +677,7 @@ def extract_pdf_to_outputs(
                     merged_missing_first = _maybe_merge_missing_first_column_chunk(
                         pending_table,
                         table_rows,
-                        page_text,
+                        full_page_text,
                     )
                     if merged_missing_first is not None:
                         pending_table = merged_missing_first
@@ -646,13 +695,14 @@ def extract_pdf_to_outputs(
         _flush_pending()
 
     markdown = "\n\n".join(output_text)
-    if output_tables:
-        markdown = markdown + "\n\n" + "\n\n".join(output_tables)
+    table_markdown = "\n\n".join(output_tables)
 
     text_file = out_md_dir / f"{stem}.txt"
     md_file = out_md_dir / f"{stem}.md"
+    table_md_file = out_md_dir / f"{stem}_table.md"
     text_file.write_text(markdown, encoding="utf-8")
     md_file.write_text(markdown, encoding="utf-8")
+    table_md_file.write_text(table_markdown, encoding="utf-8")
 
     image_files = _extract_embedded_images(pdf_path=pdf_path, out_image_dir=out_image_dir, stem=stem)
 
@@ -660,6 +710,7 @@ def extract_pdf_to_outputs(
         "pdf": str(pdf_path),
         "text_file": str(text_file),
         "md_file": str(md_file),
+        "table_md_file": str(table_md_file),
         "images": [str(p) for p in image_files],
         "table_count": len(output_tables),
     }
@@ -668,8 +719,10 @@ def extract_pdf_to_outputs(
 
     return {
         "markdown": markdown,
+        "table_markdown": table_markdown,
         "text_file": text_file,
         "md_file": md_file,
+        "table_md_file": table_md_file,
         "image_files": image_files,
         "summary": summary,
     }

--- a/graph_pdf/fixtures/demo_document.json
+++ b/graph_pdf/fixtures/demo_document.json
@@ -88,7 +88,8 @@
       "rows": [
         ["Docs", "READY", "Finalize\n- sample\n- archive"],
         ["QA", "TODO", "Confirm\n- edge case\n- fallback"],
-        ["Ops", "OK", "Archive path\n- cleanup\n- index refresh"]
+        ["Ops", "OK", "Archive path\n- cleanup\n- index refresh"],
+        ["Support", "REVIEW", "Escalation owner confirmed.\nRegional fallback documented.\nLaunch blackout window approved."]
       ]
     }
   ],

--- a/graph_pdf/run_demo.py
+++ b/graph_pdf/run_demo.py
@@ -24,6 +24,7 @@ def main() -> None:
     print("[demo] PDF:", pdf_path)
     print("[demo] text output:", result["text_file"])
     print("[demo] markdown output:", result["md_file"])
+    print("[demo] table markdown output:", result["table_md_file"])
     print("[demo] summary:", result["summary"])
 
 

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -64,7 +64,7 @@ endobj
 endobj
 8 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260316155253+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316155253+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260316155627+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316155627+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -112,7 +112,7 @@ xref
 trailer
 <<
 /ID 
-[<2e944b51fa01dfbe4577a77ddc247797><2e944b51fa01dfbe4577a77ddc247797>]
+[<9c2068c94c554d36263431fca2a3c0c8><9c2068c94c554d36263431fca2a3c0c8>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 8 0 R

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -64,7 +64,7 @@ endobj
 endobj
 8 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260316154225+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316154225+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260316155253+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316155253+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -89,10 +89,10 @@ GasargJZfd&:N^loU+GdN9.\CQ@t>o'br&L5G58=1Z#Ag8!\_ZYMYWsBaqlk70*H1*OUr4I9M.u#Tm/s
 endobj
 12 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2131
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2259
 >>
 stream
-Gat=,8U&oI&AJ$Ci2A9*\M(M(ELc1A06S=@HA"g[64<l'5[&>\I0U^ffHujVji)e-%l<)O#.#R@1&OVecZY)j+%p]qSY.5sb;Do_-qDH"oO3"\)hd":GsH0GWS<02M3F0hW%(HIgnD\WM>Jm9]=LI5A1,`r"F!8J6ON:.7Z\7XCrn>Dq$ep*I7$O;)^0EgoN77dXbB.F?GXb@cp40,"Fh_8#:__2Xp4R-W$9Q_/=AKRi=/*+gX&'CUF)He>J@&lP4h2T6OZ2;EBl$/nd`iU,fq8WqcWnerK[tsKc!);"hGlC@J4N/S$NU[OTAAb$m#]=dFPP5=PLNT&^4mhafD@R4:`ft;,0sY%W)J!&eEpO%M*eR5ZL6mon#l@rO9]86/Ub.+2=F:7@Z2GJmSEa;00"Q^JQ`>-lYCM&\:G#)V$HlU8#efW^K^T1eEh(o@U8E:):b)VM$Wd-@)2I=]CYDZ?Q$Ap@IsTWt1hhT.Y&BaF/%/I/i^F2"&]"p2UJVG"@PB.u(caEfGqCGiEo5P8':)C/fU%^_Ld7/nqWT!*g/LS%7fD3Pp1K#9O2U-!<qf.nc&#UorWX!F4uO?6/Lq:$m,rlA(oSpH,Ub4$)6V3P3VA$@]F(XQuD#BeO=\C!Ws\T$&%[G&.hWYPef0XcJd%p;C`:V+l$`?C[dMGU/G^h@fPkd@LhP6r]'^2Anft>GZ^WZ:7>a5O)A>"f(JVgmo;e71n'9%N_jim/n/O7_0&^&O)P1SCkK5b+MiI!95=B5b9mNnjSqn%G*Y"22l?*6X.AfU`_U=,L^gFhB=H)/U`;s:hk$(Z7="LKKNYIVn<]?Y^'q'V*Sf:!9Q;:aAY`XHW=TDQ-LuD%`KJE'>d@eS$cf?>hi2'Ze\/odNW*h8JC/p[t.7(Ki7(a+a'f/Z1NGiTL8T[;\L-5$C-@H[7RlQ<(%U)haU1;7nj9sP)5YA60/+T>AV0niY/$H!FVIA+s'3F>\oLsi1dkqA#Eh7,<D^o"2TC="[nH[DiGW=6(!Gk'_!mq8/#B^#@44O,mGqPl80JT'>Raq0%T>I%($fV"]>p\>O;M1eF*Z\\0F%QXItM.!aiak+IahgEj=@,#mGG^J\oAkgMgsE:pGW20EH9C$?!EpI5Q\%oEdhGUMJTCa[XgEQKf;5EX2<F=?_mh8:Nj4>EO\NB`]h>]Z&1/a"9DS+bNq)J;-]=\no1tMQSA&_or.Z`uV\!&$XNB:(K?-W$G)4\BtC*2_&Lu+<#>8'U5,`-f!\^+SgRNY6:.31+=Is2U5&['b:;L*(t"LR,Jcg5u6QaAPV(T7#%;"e`+u#64N+>c$6jS^065sNp[('cCP$OI4%".&:qD]A@O8SAKCL:"OMA6"MA9/+W84+:i=[6>s/4)CojVk6-EZbS`q/H!KuX>d9fi$K*8mTTV)"SJAe)g$"ZEUfno&L!J%aqkNP6^4976AG\HkO29OA]O+%/o7LSM<TLlU':aq!*PN%8=4TNF'7d-<!0ohF3NfmJMAn(UVh,;!FD.`IgA=&aO:AG/AHItOrB4?qcg's&TqA;biPVJsQ8@4[lB44b+DQk6HiC(#I=]W)1*mu/r-/P!i%t:5-'cs<Bd'Kis8#'Xr*cnL-X;.pl><&@[>pVR+\O$El7cC#3C#LVpF)HM)?DFUk_3!mT9HFN;;=nU6N!uofqnjhHjaJi/X.LGeZHQ'LQ]fS:OEM9-3#J'<E@)j]=_NunZDk,ddtq[_1qocFT2YCIn@A%`P?o7nVg`O3X5IVPi)o0pojQ/V3-NWNrSGY)-]_,jfX,TDg0fO)\GHf'=+?"rN!JX4`99EA3D""HBCh$[3=g)/i^3dQs-GOB/8]!?NE$_o=Ci-GPdqQJ?<_!QqCe0YQ[70Pp?FQs;3-'BbJV!DEjiT($KhFbP6ZVtHCTX(:'I^MB*SF?n&0l5!C1#%a4KVI_DN.G5b2;4"b#Z4Q`aK[nZ\S9SB]@=:?OaTWUg,=4V5iXIU65>4/+fRo)P[?4j<CL1Qs3-l>&u@pA`aQUp9PFIIl?6EBjCdSo4OgVh'&u<@b'?6]jXB85'-)WrhhNC_aRg.EmJFnSD&DZB?@?-&sK=OE)LgnEj%=9r[O`+CKpZopOb[8srF.H8[W\;]QZ@FS7APe>7-~>endstream
+Gat%$=``=U&:XAW^nZ4Ck"X6ADJZ5=H=FqB[*qO$KI"JI^]:0ApXaV/;=["$R>`/Rpp_+U]AGA01&O\gmq.L)*t*16SY.5sM\SkT-qB17FL=)b%773n4<QP4e8<+P`(A*D<0\b5CshUE`8(XR?!a:!Z5)S!Jm0GFOi#k5&Z!>f)tFA?Hp`g!h[rc)7`_,G*L<Ki.j7cNQgj-UW$bA(Jffi=SdGsWX'WImWlXc[91GE=n=$$:I:s\B;4W]8XhC[dOQJj",DMi0d%dESG`1Z>P2qagh5("gr4NqP$djUN1NYubrT(S9DVfNoQLpP"Yi((o%W./)B.LUG0S9+R2gH,Q[C=&q@[%OjS>.t#7,f9)g>X/L#cOaOY$N!pl1f,#I*a6d(ru(m;%Y0uR@r136e7d0mr)0af#m,NC4r`dO[aDY5uCKj79-'qT%$>oU=7bur(\$F:L-;U*ZB<mPZ^tNF(EV`_sQXQ:R>.T(S<<t%ZL;E');Id$#&+bE#n$QKPcheX]GpZou>N/\)YlE_jI6uS>Sj,f,d9KIcQYQMtXpi_:sgANfsS#B*e!8&mHT]dE'HKa\agsi3`W&Yrd8S\<GNc\"d"XG)G)D^rl*/I"UbO*lBK&fZLImF#(eLZnB?]]CpTSC<Ug.l_o1M=#asnC0Bak]F@hDfDFsg.9_X",!"cpERtchBYQi$24.fN&L?.3b1EM*ZrD1#cLjpdg,r0%RB`D5U3Y)i&")><JVtNnm@%htT.3'#CgKSB:ojnPF-?/<:HN"P7@;I[f/ejLN3"a$)o5^RTJj1[dsbc_+tT2mI>#jABlXDh<Km^tnpoDRnlG+om\TM'%8-3lE6gO5Sf6&1UEXKRFDWaF.!AFT&6?sNX?DaYig/;^D$Qen(("30e3SHJ2H\F!U"&=)86tLd/q"fIkg6TcV?m_EKhfP9aqS)C.&)Z#hZcYP92,d$)AC^mP0*l=[b6=f`CEhJ"2Hu=7,/<9\D/23a[LKmL0!J496<qn$\Guc$HO@Uh[20JKJX4-;o%j0,)q*jmWG!WLD]ZfR&AnZ)?J.$;mBN>j.JP#BTS*:gM.d#YC8u\_Ca/X@gR"B&U4AK#-Fl1TIk>6-D@.$+AoZ4BbSe:!]j@9*CbS):VdL`d76QK9:lbp5.[Ht*dq!.BrK<S,.HK+KB4=<L%=s?^(koQQU\b!_d.*'IGDVL'f&l[$Qr^NV2GOEU$.Xpg/#B>oXG_*m0.;`dHR;."I5e)OYD*s(e+]$%C/9`TV1?k4VAM@!6Gc4Gq#t6OXVG>Z#OsJWd"N"j]G-%`!e:*$Uu>4=6?X>Nl]T?Z<BBe:8n.+WYo_5^oLJFl=_de%/'r,gUDc58.k&i7#(SJ?I$HN*Wc*GR=LcC.O9Wd%*C0eE2Z9Wc&EI'>G)D5g_oMk9TVBGQi<El%MF`/K7;g@!XaQt,a8IDB1Ju>#QW<_SYnUOisE6C^dZ/]\l#%?\b%+3'.rEp]f*HIJ5-[jRhS@ZmK"GR3<3iHb;`&l2G;oNRYg"`RSpmZD.`BlaY#G0SalebFMEARcGU4?PoC\hn/*R?PVJs?,[*dE[4j)(2HZ'4E2(J%/?9biLGB-3M:Z@TK0Lc.N<d$AE42$D1g7?Q0^$$l>4G4pKeq6+<O0T..n$UP'OK9F/\K:"S/X.1T;/LWacP``9HFLe.=+!.7f#(6I5)(?\Xs9%lA%m'/@/:,Kd7<fUn*0$%S!=EQm`5`()eL5-<8X@F>Pd:(gk_FcRF1JIpDcr8[%iK;a35*ebD+lqk6TbJrf<S@q0-&q`R%8fKHk?HUh_A4@WI_X2UoKJp#Q&m]S5qrsb58&(Hl%dJkOcQ.?pNQ5ulD)W4T6qmp<&nOtE*lcBcMPm%.gfa%RhNqlCbX";s(EY/YX7kJU3DaP-0\.?#`9PZ4-8\\1`%<.au!.<9p-87Lrn?SRS$bX1uK>RrpI:;EEe`DMF*5P#`@=JGjl;/:W_frWJ9P_p#7s(YM)W9+jJ0>X1o:_Z)Q;13C:>7V@BhS2q4cIhM$&\[R&f'miZ#'4$cuhYZM2mAJ?iBrflCVIC*V*tFNPpk2NrG,`WlKWUnKcY.AkW;sFq4S1mm_&a@]1$dTI5YZ"\CjKafP^IJ@/bfb\eup>r#6Z^ZaA^*,bIuBuEeFOef>ekJGP[bm&CPB3.6s*=d#NP9_Am?_C+h8%,=VoA?$drp&=`-X-p&r(k%rVYb7>N!;bgQ2Z6JL"sPO4l\9@WYL&7Ok7r/L-%pQ?24)j"@I4Z@5-*Ns&TI8^A~>endstream
 endobj
 xref
 0 13
@@ -112,7 +112,7 @@ xref
 trailer
 <<
 /ID 
-[<12d57f31bd5c38d8a0874fddb922dcc4><12d57f31bd5c38d8a0874fddb922dcc4>]
+[<2e944b51fa01dfbe4577a77ddc247797><2e944b51fa01dfbe4577a77ddc247797>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 8 0 R
@@ -120,5 +120,5 @@ trailer
 /Size 13
 >>
 startxref
-7838
+7966
 %%EOF

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -21,26 +21,29 @@ class TableExtractionFormattingTests(unittest.TestCase):
         return pdf_path
 
     def _extract_result(self) -> dict:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            pdf_path = root / "sample.pdf"
-            md_dir = root / "md"
-            image_dir = root / "images"
-            create_demo_pdf(pdf_path)
-            result = extract_pdf_to_outputs(
-                pdf_path=pdf_path,
-                out_md_dir=md_dir,
-                out_image_dir=image_dir,
-                stem="sample",
-            )
-            return result
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        pdf_path = root / "sample.pdf"
+        md_dir = root / "md"
+        image_dir = root / "images"
+        create_demo_pdf(pdf_path)
+        return extract_pdf_to_outputs(
+            pdf_path=pdf_path,
+            out_md_dir=md_dir,
+            out_image_dir=image_dir,
+            stem="sample",
+        )
 
     def _extract_markdown(self) -> str:
         return self._extract_result()["markdown"]
 
+    def _extract_table_markdown(self) -> str:
+        return self._extract_result()["table_markdown"]
+
     def test_fixture_roundtrip_matches_expected_tables(self) -> None:
         fixture = load_demo_fixture()
-        markdown = self._extract_markdown()
+        markdown = self._extract_table_markdown()
         extracted_tables = _extract_markdown_tables(markdown)
         extracted_by_index = {idx: rows for idx, rows in enumerate(extracted_tables)}
 
@@ -64,7 +67,7 @@ class TableExtractionFormattingTests(unittest.TestCase):
         return blocks
 
     def test_table_output_uses_markdown_tables(self) -> None:
-        markdown = self._extract_markdown()
+        markdown = self._extract_table_markdown()
         self.assertIn("### Page 1 table 1", markdown)
         self.assertIn("| Item | Qty | Price |", markdown)
         self.assertIn("| --- | --- | --- |", markdown)
@@ -72,20 +75,24 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertIn("<br>", markdown)
 
     def test_watermark_fragments_do_not_remain_in_table_cells(self) -> None:
-        markdown = self._extract_markdown()
+        markdown = self._extract_table_markdown()
         self.assertNotIn("FID", markdown)
         self.assertNotIn("I Qty", markdown)
         self.assertNotIn("N <br>", markdown)
         self.assertNotIn("O <br>", markdown)
 
     def test_wrapped_cell_text_is_collapsed_but_bullets_remain_split(self) -> None:
-        markdown = self._extract_markdown()
+        markdown = self._extract_table_markdown()
         self.assertIn("| Laptop<br>- line 1 | 12 | $120 |", markdown)
         self.assertIn(
             "Docking station compatibility review package for extended desktop deployment approval",
             markdown,
         )
         self.assertIn("| Docs | READY | Finalize<br>- sample<br>- archive |", markdown)
+        self.assertIn(
+            "Escalation owner confirmed.<br>Regional fallback documented.<br>Launch blackout window approved.",
+            markdown,
+        )
 
     def test_punctuation_ends_logical_cell_line(self) -> None:
         cell = (
@@ -104,7 +111,7 @@ class TableExtractionFormattingTests(unittest.TestCase):
         )
 
     def test_spanning_stage_table_merges_into_one_block(self) -> None:
-        markdown = self._extract_markdown()
+        markdown = self._extract_table_markdown()
         blocks = self._table_blocks(markdown)
         self.assertEqual(3, len(blocks))
         stage_block = next((block for block in blocks if "Phase A" in block), "")
@@ -113,6 +120,24 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertIn("Phase C", stage_block)
         self.assertIn("Finance", stage_block)
         self.assertNotIn("### Page 2 table 3", markdown)
+
+    def test_demo_markdown_contains_only_body_text(self) -> None:
+        result = self._extract_result()
+        markdown = result["markdown"]
+        self.assertIn("Chapter 1: Deep Structure Verification", markdown)
+        self.assertNotIn("### Page 1 table 1", markdown)
+        self.assertNotIn("| Item | Qty | Price |", markdown)
+        self.assertNotIn("Phase A", markdown)
+        self.assertNotIn("Finalize<br>- sample<br>- archive", markdown)
+        self.assertEqual(markdown, result["md_file"].read_text(encoding="utf-8"))
+
+    def test_demo_table_markdown_is_written_to_separate_file(self) -> None:
+        result = self._extract_result()
+        table_markdown = result["table_markdown"]
+        table_md_file = result["table_md_file"]
+        self.assertEqual(table_markdown, table_md_file.read_text(encoding="utf-8"))
+        self.assertTrue(table_md_file.name.endswith("_table.md"))
+        self.assertIn("### Page 1 table 1", table_markdown)
 
     def test_stage_table_repeats_header_after_page_break(self) -> None:
         pdf_path = self._build_pdf()

--- a/graph_pdf/verify.py
+++ b/graph_pdf/verify.py
@@ -114,6 +114,7 @@ def run_checks() -> int:
     )
 
     markdown_text = result["markdown"]
+    table_markdown = result["table_markdown"]
     txt_text = result["text_file"].read_text(encoding="utf-8")
     lower_text = txt_text.lower()
     normalized_text = _normalize(txt_text)
@@ -141,7 +142,10 @@ def run_checks() -> int:
         if _normalize(token) not in normalized_text:
             raise AssertionError(f"missing expected body text: {token}")
 
-    extracted_tables = _extract_markdown_tables(markdown_text)
+    if re.search(r"^### Page \d+ table \d+$", markdown_text, flags=re.MULTILINE):
+        raise AssertionError("body markdown still contains embedded table blocks")
+
+    extracted_tables = _extract_markdown_tables(table_markdown)
     demo_tables = {
         table["id"]: (table["columns"], table["rows"])
         for table in fixture["tables"]


### PR DESCRIPTION
## Summary
- add a non-bullet multi-line example row to table 3 for punctuation-based line preservation
- write extracted body text to demo.md and extracted tables to demo_table.md
- keep table content out of body markdown while preserving stage table continuation merging

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 run_demo.py