### PR TITLE
Guard extractor table detection against None cells

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -253,11 +253,13 @@ def _looks_like_table(table: Sequence[Sequence[str]]) -> bool:
     if max_cols < 2:
         return False
 
-    if not any(cell.strip() for cell in table[0]):
+    normalized_rows = [[str(cell or "").strip() for cell in row] for row in table]
+
+    if not any(cell for cell in normalized_rows[0]):
         return False
 
-    non_empty_cells = sum(1 for row in table for cell in row if str(cell).strip())
-    continuation_like = not _normalize_text(table[0][0]) and len(table) == 2
+    non_empty_cells = sum(1 for row in normalized_rows for cell in row if cell)
+    continuation_like = not _normalize_text(normalized_rows[0][0]) and len(normalized_rows) == 2
     min_cells = max_cols * 2
     if continuation_like:
         min_cells = max_cols + 1

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pdfplumber
 
-from extractor import _normalize_cell_lines, _parse_pages_spec, extract_pdf_to_outputs
+from extractor import _looks_like_table, _normalize_cell_lines, _parse_pages_spec, extract_pdf_to_outputs
 from verify import _extract_markdown_tables
 from sample_fixture import load_demo_fixture
 from sample_generator import create_demo_pdf
@@ -112,6 +112,13 @@ class TableExtractionFormattingTests(unittest.TestCase):
 
     def test_parse_pages_spec_supports_ranges_and_lists(self) -> None:
         self.assertEqual([1, 3, 4, 5, 8], _parse_pages_spec("1,3-5,8"))
+
+    def test_looks_like_table_tolerates_none_cells(self) -> None:
+        table = [
+            [None, "Status", "Notes"],
+            ["Docs", None, "Ready"],
+        ]
+        self.assertTrue(_looks_like_table(table))
 
     def test_extract_can_limit_to_selected_pages(self) -> None:
         tmp = tempfile.TemporaryDirectory()


### PR DESCRIPTION
## Summary
- guard raw table detection against None-valued cells returned by pdfplumber
- normalize cells inside _looks_like_table before header and non-empty checks
- add a regression test covering None cells in detected table rows

## Validation
- python3 -m unittest -q
- python3 verify.py