### PR TITLE
Limit image extraction to selected pages

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -645,12 +645,20 @@ def _body_excluded_bboxes(
     return excluded
 
 
-def _extract_embedded_images(pdf_path: Path, out_image_dir: Path, stem: str) -> List[Path]:
+def _extract_embedded_images(
+    pdf_path: Path,
+    out_image_dir: Path,
+    stem: str,
+    pages: Optional[Sequence[int]] = None,
+) -> List[Path]:
     out_image_dir.mkdir(parents=True, exist_ok=True)
 
     image_files: List[Path] = []
+    selected_pages = set(int(page_no) for page_no in (pages or []))
     reader = PdfReader(str(pdf_path))
     for page_idx, page in enumerate(reader.pages, start=1):
+        if selected_pages and page_idx not in selected_pages:
+            continue
         for image_idx, image_file in enumerate(page.images, start=1):
             image_name = Path(image_file.name or f"image_{image_idx}").name
             suffix = Path(image_name).suffix or ".bin"
@@ -738,7 +746,12 @@ def extract_pdf_to_outputs(
     md_file.write_text(markdown, encoding="utf-8")
     table_md_file.write_text(table_markdown, encoding="utf-8")
 
-    image_files = _extract_embedded_images(pdf_path=pdf_path, out_image_dir=out_image_dir, stem=stem)
+    image_files = _extract_embedded_images(
+        pdf_path=pdf_path,
+        out_image_dir=out_image_dir,
+        stem=stem,
+        pages=pages,
+    )
 
     summary = {
         "pdf": str(pdf_path),

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -17,26 +17,22 @@ endobj
 endobj
 4 0 obj
 <<
-/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
-/ExtGState <<
-/gRLs0 <<
-/ca .13
+/BitsPerComponent 8 /ColorSpace /DeviceRGB /Filter [ /ASCII85Decode /FlateDecode ] /Height 1 /Length 16 /Subtype /Image 
+  /Type /XObject /Width 1
 >>
->> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
+stream
+Gb"ZWn/hW4rrN-~>endstream
 endobj
 5 0 obj
 <<
-/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
 /ExtGState <<
 /gRLs0 <<
 /ca .13
 >>
->> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
+/FormXob.c4a6dfcd9d5d51256cad05922c13aab3 4 0 R
+>>
 >> /Rotate 0 /Trans <<
 
 >> 
@@ -45,7 +41,7 @@ endobj
 endobj
 6 0 obj
 <<
-/Contents 12 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Contents 12 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
 /ExtGState <<
 /gRLs0 <<
 /ca .13
@@ -59,66 +55,83 @@ endobj
 endobj
 7 0 obj
 <<
-/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+/Contents 13 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
+/ExtGState <<
+/gRLs0 <<
+/ca .13
+>>
+>> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
+/FormXob.c4a6dfcd9d5d51256cad05922c13aab3 4 0 R
+>>
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 8 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260316155627+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316155627+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
-  /Subject (unspecified) /Title (untitled) /Trapped /False
+/PageMode /UseNone /Pages 10 0 R /Type /Catalog
 >>
 endobj
 9 0 obj
 <<
-/Count 3 /Kids [ 4 0 R 5 0 R 6 0 R ] /Type /Pages
+/Author (anonymous) /CreationDate (D:20260316164207+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316164207+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
 10 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 1939
+/Count 3 /Kids [ 5 0 R 6 0 R 7 0 R ] /Type /Pages
 >>
-stream
-Gat%$bBDVu&Dd46B&Q0#0hq.3n!pm_F5j&lU@r[:Oe@Ab,$>J_UVH9U7EM\tV8l(a":jl/mT^/)-4o/IdD)_6^tT#th\.+E//fX&OMKiVIT]p/g-VknS3a(_,5W3iM+*:XaKl9j>PR0jTYhZhn*].pD0u&Cd@,n2)!Q3W)3"Mh<:!+Wr!eRV:4T.6#'go!TRt_@oE$:DigW/bAD\Zj8'jm!^;KE7*)Aqu8J8sPMWp8+(m*4D8JhYC4F&jT6FCFUB"W\\me`Q.A\[PG.eY";'5,YJps\4:#PWX"&b?n^=<kNJ-Ad3')V7Y\hI6U,`WfQ2W3.*2XD/X?4KD'E+>$k=(9?O;0)l,VXCHiSUp[(_H3!Lu#kM-6%#VeO'cWF[@ikZ\#h"g!)1gCh;)Qt+0+VOuX3p,Yd\%&F;,C?u"_f$UGm6Q#8s2Y_'tTNS&r6621R.-DOB3]cK01["jQt^kTC+r!rUO[miV)4Y\Bk0i0[Tr^K@:IY8gB[HCHAD*,@u(VrNB,c._-3$ra^U>]V8#JhF(sEUgY$S5/PC"=@Yr:*.aiKl9-t@rs[4YY$nqX-!*/q,mg2f[8*n*hUS]ke0r#^@Y\9_$8?m`9b@)paG^>+JDcnKHX\QXGAYOaUh]"-*,*='Pngr%'*VpG&Hola@%:Cf>+mlE>nL%af5Ru8NrqTUQ\CMITnQEq23L'nh?(\%5cb*1V0CEFrmjq^PGM[:(U>5-b%r!KERboXrN<8B,B*H,p1e(dk\&Zn6>7I3f,XB;#W=I.Uc:+[_klZ=@XJg'c=DGn2?S\^P`pN8fY;tY=3rn9X1H!d]t^M1`=&4"7]EE.=D]D7lSBh9H1?'*"*2Y?jj5HWAqO@c0liJ\[jlc2L=`@k5^DZnAEu'MKM[QdjW8LMr,VZU2%(Ydo%$G0)[q+%HGRYGR@X39r<:c,kDN(s9f(FR.KXA7_H0f.9"g)!WJVZG28[d[=T9Msp@Nr-W="0^q^hK5Fbf&!lr!6gkEZE/SjJB1Lh7P=Dl7S39db3pVq'ubNFgL4j6/1VVlcN0d52m,cD;H(:6Ql'$d^`!n_mVMVUI=WG0b!(//63;OIb;h`"JYV;BE&;p4JE;9qSg=d:oY[/<?kb8JM"rC#h#YVN%6EZrtGpg?[4+TU^^(]DBVBbFXT;es3WpAs[1j/n5D*kVPT8mpG$am;k9tTUZ`oO<$FS`+>K"CTfP/JT@(<g=:+ia(6o94^$6UN_O/.).e95,\c[N^NJWH*!NgX55fHC=]5%GDk/ljkNqT;1I%CM(<;`dh<:j9eu:MPZeBM%QQ@[=0oF:rkmVNVr?/@8C1giKnWYuFKZoYE%+*abVfX<V,i[?detjH&?,gHTna?6gUX&_`[U)tK*H8CH/XQ(r^PU1n`,hV3UW^TNEYVDJ>!fJ]gSb<]S[!G51-A!*pGHj6eD:MJ)ogsu$I@k7h:94l7)osEb->#]qu'QX:5;.-:VKf?0Z*Y6EBq7T5'#l+Md,$;m,@!S2;^qA(YIH/lf3/D_hR1TZBJOtG)n-pH-K#UVXJ`+qaPm?acL:SNYI64$jBk[G2%"QLqISh[<DAc5b#Jo]2p!tmrhD%l*)*?J3BiEZ)MU:(9[j5GcYJ6g2l(I'Y1A4NP<"dMMUNX^.MAS>^PN?(Q<[o.+97u]2(uHppr\I_C<P[H-qn=b]PjZ1po&k\2Hg9Au?)uTtt3$QedXHB#a8lg$Zjn(-+)!J<,sfOf(W)qK9e"YlOGk"8L#hpUT-^Ni\/U>6-<lEN#fdMHU^uUa,Iiq\D-bQ8skm+)5H5)Kc`#55Hm0(,S[:A/<Z4+=M+&W`(h`<N3QecP.*ah;]DTju\$/#`1.[Cde'OHs"QVrdo-BgIYil5@:olI&:(B#.VU354R1I("YaCWI0m16E5YBmt=eB[rf'[PDGaNKelP\UV5O5?-SH1o`Q*2!r`Yj\G~>endstream
 endobj
 11 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1999
+>>
+stream
+Gat%$bBDVu&Dd46B&Q0#0hq.3mufY*F5j&lU@r+*Oe@Ab,$9r4UVH9U7EM\tV8l(a"CBq&>g*T\-4o/IdD)_6^mbL4h[ptC//fX&OMKishCU?HNKC1K#7*10ZB'!k=Je'14Nh-;KqI3pg99Jop'tun<krX4ekFr95du0b?k>D&Z(GIp2_9D<6'?tkj?^)C8le;(,`Hi%DuL(gq`Y(1,csNg3rD1#_eH,-8V3='5!@7-"*,<KKOI]sP@`c-<,5NOL)Xgj?L1-`MHs:^\Hg4t3IC>nT,+=]\.`=>c>0q&c00R78bBV1>dKR`(-U;(f#([<FkrEt<Qf(==\Y%aC$GQ">V5D`q)>Ne*KtS5=_g&r%mccl@K+-3?KnqqEhdgK=N>nDJi"`a7c<B8N10(_QhqqZeR7Aad\I>J;,GmN$IV%3o*g5&PU)7H.Wcp0,S'?CAf.Dc:0s&6%e?\$ZY+4VpiQ8hp>)XcLY)8jc@&1V0Nduu&Ys+F=eV7dmtBJF'?d%@BN@&l?.N_\OsnR)>)-f072:Y.?,gh6OQA]@5]dp__<FA/8eZ;bf<eW=U%#O+&&4-F=,f;`i%HF&_^ha]fGb<'&S[]QRL_)+'Cs%3jZ!7ZJ?8Ll[,MC`ppc(GXrY'q0=B@*]W61:8Dmdu\riG/&NXJg8;ni'JjV!kIP3Gi8QS1Hc'CMu(7)S@A`K!ob1P(iMK^S?2P.u>+A5F2!F,[%W?Y9\q2L6Y#V+4Z>],=,a%t/q+_4/XknIQc,#=&*$0)+2ee>XCH23-.[FZ>&P`5HD<WY[Wh$/%-H\Sr\[5F8&Xa"A0dSj"-@@BcQ1%;R4\1bO+"-\d<,I9.1]&#gHDoAh84$Y"%"%I\I-i7AfIg#mT+<&JKDK#7*?^f-s),G@LU.V)^Fskf*1PIE+p3(fcj-iWATo6"@p#FcPOdk`aUYOJ?I#W+O(uDisfkQQ\+dLK#\HcD2^V##V0ae*@o%&QfGNa=uoR`-h1R\+$r<65hVi+:h`O+NS.OAiZ_H0ft8tEoZ</Zb]'rsc4<<"YXmHFe:;AB1eq`O:0lOM#Klp:2TVk7r`Sm756Me3kdhG3*ERSNFj:92cN)N1Ye`mJ35cYP\&UM2d7SOk]-SL-cH6rlc55!4bGFF%Q=m[5YlKbCp)Z4e.3GS$ZSP^BKqUA(Xgjg.JjSOQ%ZH%`aS;<U+-;9Le`&j`.JZ\BLSCXWej`^6CoI:W5OTX(.HA[05@&hW<&p*bJ]';YNq'i&G7aVfUa<^]5sCs:q+2<N7l@t&q`QK?iMn"Sj;OL(6(1n@RoJM*_A+#$9Tqpo[[3Im=OorLkPSMHKF^@b]?%cE;ZR5O-);o[hLb./HRQ/<Lf5Va:J%X%#%.>q&N7S=!%jb\H)*iY\fl/u!rn1$4IV?<L!!Dhrt`06!YRotr(;D]8XV<5B)eOH,&K5J:OZ0cP<j=MJ:0+l2[`tQe0i]rie-d%]A7;2qE%W.upG]h$cfurk!<Sc923E(8P#-Su0M(:]XX*.SA\e+7)BI1]*Tb[I,&tSa0'T]u1G&E!)V;o@=KmdJbjKlJWs6S_)e2?,3(min/QqQXdLVnl,27+=5AF1F>4Ref-Q;$0K:%sY<_NLVDfGl=MdhtcdRdIQDfEh;a;.sh;Q(^*a]f*&T7c*O"[aSYD-38Hifj[n7L_d/s.e$Q`PdKVbUF:.gK,X]-G8(Y<aaG0aU?:/S#@&tJBqn@OjD^_fVVu*9'SVa7@IgKM+dqY6e7`T,#]X^?)U2"r*[?=!,gX(Ao?<0LZa8JIM-8?D<!,<`C5Y2+U5<4^reL_K1_&@n4l5@TY8g[YKsq+eg>Yq+<to.A_NGDQhs=S(gfrnlDgnXU2/C]=,l-B186O@l%?ajl#=)2@nl;T*'WP&R'qZp)::c3<Y0;+f=r.fUT\4kfZhn0nIt!#YKBY4%)*_K<8URC=:&nO.7j%PAk)/IQcW%UbJ<]>l_)ieUeLd=DlQdZep;-j[iFoFhFBA(oIpg+3^R/R+ao~>endstream
+endobj
+12 0 obj
 <<
 /Filter [ /ASCII85Decode /FlateDecode ] /Length 2075
 >>
 stream
 GasargJZfd&:N^loU+GdN9.\CQ@t>o'br&L5G58=1Z#Ag8!\_ZYMYWsBaqlk70*H1*OUr4I9M.u#Tm/sXZD,!Dpd)E7Q<`h4i0dPT^=?-]"J@aJfcTR+B3k^:W%+UAr8C/B,TEHkef>SL*PDWhk4c=1%[CN2<>q-8@kLkBOhd[kT=L8&).$Y#"]^_Oq";kiNu($`fVB*=SWaGoN<=3jJ3Ctlf%#(N,MXk8J8to`j?loMP@SR8JhYCCj2K27FdN$Vsu!HadGj)mF]q?KV&jSNt$M@NB]#Odboj7!M!6TQL;`Wg*BO227TN81bD+7U3&Xj("Li`SuZ$eqN[sMnfTMY*1EpFHA_2^FJ(eY7"D?r&S-S<c\!p$(!IfnlNf_s2n@H.f0tdU\BHXQr>i3+l>V57L?L>:q%G4*4\DKBcl!OnH(="7$4:%t1d[P&)4?mPK[2E+1gL<2M6f1_ZNAD?m*"4GS+"s9Ir)lL\m5I5;^_)5[gUjYl(XLoB0b#k8M*FaH8*1#.^qbagJX4@AOWE'H4V4<gWJJ1%fQ]N.Hsl>FbgjD+!C&.M<?"&)e;,;fcsb_E`jBM)&Or<d\>)EEqEfFFOr<&H8-(fAd1`rN6K5iCbJ<%"UR*AbL(>WcHQ!&oO9.&gWRub-7[75EqEff2A+$XEX%jW!]dP0j2>ae7kYX2ApZPD$gcG5kk_,V>p[`X[Sp%kg8TA!Vf]<tA3uPIp3SthMT_8f3hJ.PH9qH)m;.X%Ee3%c-C?b''TV7a;Yr:tRKfbtXATtPLJ-.%>pG:!5V"3pOp.8;df=o^<#$Fo#)F4<L2b,Z8KHt[ihSI4T]U>9=?e^)'^[k+Vh$`(RM0B2#ckA*8TjSqXeB)=Vs)Ul4&k4E3NSHLc&T&!CBK[09]CjXGidAnS?-/[;;2)$FWfk5OW'3e>hr"dT4q4P;bj/@!,+YK,q`Y&?le:4)4]3%Y1ERLj:^+>-DFDu&\`f<JYP<;ZeV[f"[L^Ma%i[8>-XoX>?_I82L'[si$q&I6,B%'-Zr=5oJHW:afK?'OH[95E:V#R>'/#h'qD/Q\;,t8KJuS[N+u,=RLd(t'RLNP!*M#pXb`/QH:bTg#+uG`F>Y:3r@:85SMa)(!ZQ[6"@5fTaBI9GNT]/$hNFU4X6t*UYH@W0NQd"!Ztl-C:,OkBI0I$h?#.dY7X=6!g&g1=e9chJ;)aZm9cL\*[K%V_Ch1ple(<s.WHXM6\)%lCWuJ7&Z7abR#[+X+Hmt4(Za&<qFNu8Ci#7#.ofL/grgZ_mNsf-A3p1ibk*$(Se'/hWSBq>5-8"<\M'LZ=bXAqmf].T"!5ttRX@V)4'`jm&_qP(/b-j=Q[/TFI5FgQuJQ<G>lKim;)S:\N,6F<iR^Oj:\FeFL"i.GNW8Kg"P.kg8+&13"*hTe>l'%?U%C@GM.ck[<Yt>C#fi'bIquu)$E]T'+Hs(/g+rfaHEpdI64B?.sn$1"pp/n-p!*`50E/NWP=7B>;7#rRR9j5?L)r=Go@Q`E&VBo]tprXUNDkXEHdkEI8U/8>Fo$t90#X(([!>,#_J5+VEg\s[=a!iT*3W^=p0*=-mUHPOI?g$a5$BJCp!&3kuDF_^(2hS`=Nj@@9mWKi:O(@\M?##i4f47#3(u_mfI\:dCG=aquB`YLgTl;h<,fhe-=go$&iUqGl"ir<`F2i>?+'@8sDX,1#QPL^e*8CUg^=`mF>Ok>:EQVj-PLY+In"\hP?kO/>,t.oKqaT.8n+AEP*ojU-GR/H`R(;%`(j]H9!n>E[(l+"o\E5bj-SI)8VJ-(HqeMo>>]kmjFA"7m5>\iY\1i-DDJ0u]mKU@%WIi,;8tFQ\S9oY2![)lU.'+GOY=69q`tg6l'j(Lf-.UpPlRpsPopDHWW69)7#asaJlR%U4F1I]"Lr=;@d$s5&VY-77!o*/eY:HOBilL/>(')a_g]-P]9+tcq4^,Y<a,JD*M*m=i>/9\ik&;5P"KcF=&cCYB^7;=q((>VfWLK[0\1R>QUT-&64X9F*e.s)Y/`L@$O0ZHN]@C>QIui/>)#56T:(Qj\Um9PlWb&JBbe_ZhM@N7F2`aNPnK4Kio@X~>endstream
 endobj
-12 0 obj
+13 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2259
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2321
 >>
 stream
-Gat%$=``=U&:XAW^nZ4Ck"X6ADJZ5=H=FqB[*qO$KI"JI^]:0ApXaV/;=["$R>`/Rpp_+U]AGA01&O\gmq.L)*t*16SY.5sM\SkT-qB17FL=)b%773n4<QP4e8<+P`(A*D<0\b5CshUE`8(XR?!a:!Z5)S!Jm0GFOi#k5&Z!>f)tFA?Hp`g!h[rc)7`_,G*L<Ki.j7cNQgj-UW$bA(Jffi=SdGsWX'WImWlXc[91GE=n=$$:I:s\B;4W]8XhC[dOQJj",DMi0d%dESG`1Z>P2qagh5("gr4NqP$djUN1NYubrT(S9DVfNoQLpP"Yi((o%W./)B.LUG0S9+R2gH,Q[C=&q@[%OjS>.t#7,f9)g>X/L#cOaOY$N!pl1f,#I*a6d(ru(m;%Y0uR@r136e7d0mr)0af#m,NC4r`dO[aDY5uCKj79-'qT%$>oU=7bur(\$F:L-;U*ZB<mPZ^tNF(EV`_sQXQ:R>.T(S<<t%ZL;E');Id$#&+bE#n$QKPcheX]GpZou>N/\)YlE_jI6uS>Sj,f,d9KIcQYQMtXpi_:sgANfsS#B*e!8&mHT]dE'HKa\agsi3`W&Yrd8S\<GNc\"d"XG)G)D^rl*/I"UbO*lBK&fZLImF#(eLZnB?]]CpTSC<Ug.l_o1M=#asnC0Bak]F@hDfDFsg.9_X",!"cpERtchBYQi$24.fN&L?.3b1EM*ZrD1#cLjpdg,r0%RB`D5U3Y)i&")><JVtNnm@%htT.3'#CgKSB:ojnPF-?/<:HN"P7@;I[f/ejLN3"a$)o5^RTJj1[dsbc_+tT2mI>#jABlXDh<Km^tnpoDRnlG+om\TM'%8-3lE6gO5Sf6&1UEXKRFDWaF.!AFT&6?sNX?DaYig/;^D$Qen(("30e3SHJ2H\F!U"&=)86tLd/q"fIkg6TcV?m_EKhfP9aqS)C.&)Z#hZcYP92,d$)AC^mP0*l=[b6=f`CEhJ"2Hu=7,/<9\D/23a[LKmL0!J496<qn$\Guc$HO@Uh[20JKJX4-;o%j0,)q*jmWG!WLD]ZfR&AnZ)?J.$;mBN>j.JP#BTS*:gM.d#YC8u\_Ca/X@gR"B&U4AK#-Fl1TIk>6-D@.$+AoZ4BbSe:!]j@9*CbS):VdL`d76QK9:lbp5.[Ht*dq!.BrK<S,.HK+KB4=<L%=s?^(koQQU\b!_d.*'IGDVL'f&l[$Qr^NV2GOEU$.Xpg/#B>oXG_*m0.;`dHR;."I5e)OYD*s(e+]$%C/9`TV1?k4VAM@!6Gc4Gq#t6OXVG>Z#OsJWd"N"j]G-%`!e:*$Uu>4=6?X>Nl]T?Z<BBe:8n.+WYo_5^oLJFl=_de%/'r,gUDc58.k&i7#(SJ?I$HN*Wc*GR=LcC.O9Wd%*C0eE2Z9Wc&EI'>G)D5g_oMk9TVBGQi<El%MF`/K7;g@!XaQt,a8IDB1Ju>#QW<_SYnUOisE6C^dZ/]\l#%?\b%+3'.rEp]f*HIJ5-[jRhS@ZmK"GR3<3iHb;`&l2G;oNRYg"`RSpmZD.`BlaY#G0SalebFMEARcGU4?PoC\hn/*R?PVJs?,[*dE[4j)(2HZ'4E2(J%/?9biLGB-3M:Z@TK0Lc.N<d$AE42$D1g7?Q0^$$l>4G4pKeq6+<O0T..n$UP'OK9F/\K:"S/X.1T;/LWacP``9HFLe.=+!.7f#(6I5)(?\Xs9%lA%m'/@/:,Kd7<fUn*0$%S!=EQm`5`()eL5-<8X@F>Pd:(gk_FcRF1JIpDcr8[%iK;a35*ebD+lqk6TbJrf<S@q0-&q`R%8fKHk?HUh_A4@WI_X2UoKJp#Q&m]S5qrsb58&(Hl%dJkOcQ.?pNQ5ulD)W4T6qmp<&nOtE*lcBcMPm%.gfa%RhNqlCbX";s(EY/YX7kJU3DaP-0\.?#`9PZ4-8\\1`%<.au!.<9p-87Lrn?SRS$bX1uK>RrpI:;EEe`DMF*5P#`@=JGjl;/:W_frWJ9P_p#7s(YM)W9+jJ0>X1o:_Z)Q;13C:>7V@BhS2q4cIhM$&\[R&f'miZ#'4$cuhYZM2mAJ?iBrflCVIC*V*tFNPpk2NrG,`WlKWUnKcY.AkW;sFq4S1mm_&a@]1$dTI5YZ"\CjKafP^IJ@/bfb\eup>r#6Z^ZaA^*,bIuBuEeFOef>ekJGP[bm&CPB3.6s*=d#NP9_Am?_C+h8%,=VoA?$drp&=`-X-p&r(k%rVYb7>N!;bgQ2Z6JL"sPO4l\9@WYL&7Ok7r/L-%pQ?24)j"@I4Z@5-*Ns&TI8^A~>endstream
+Gat%$=]=??&:WeDkV7ElHopJM*FO&*WI\JUHTWddP%[Z;Y@J=!?b`_d$&=e6RXu.&kO,NXXZi8J)#biDGI'a%[fnh):/I+J`<mo:PbZ2,\ltWB"sMSG*Y98UlF,YciZr(]Wlbr+[V5A3ibjD:0!EYKfa@@5_(Cf48E"F+#Z>,n%J^;^^7iNlmg(@O,NMU_%SP6EQ&qrb96g%Ee<?dO_2lN/:BcNg<Nk6q<TJFi,pT<L]I#%R+.C5i<+ht<b83#TdQFIL`:1)MHF+@gDm=[ZOuuXJS)dr#ht+[l&3\)s6T8Q+:VN=]k$8408WP;&"qQB/BOb/8XmBB3#j)fOjAf1/SqiNK-mpE'7r,tu`'(W<`BBe(:fU@t]ctp>s)##gcmO,&a+$mZ,#7DY6*L<DW&\)>hl%BoQ&VEc#[O,JNTMjFU8#efW^P5sWKSMpVm0V)SLfMf\qDb#,^GiC=]CZ-AC'V[mH<e2QWKdqT.Y!kaF+)8&?P#Z'GX&nb.3XVFtMeKDm>7i*1-&mC$W3@M^0ms#.JSLVeM?*(b[[e.6rd(#5938JG8Jbla&'ldM?PKHH"64DdmR$83C(#kh-[BVhX]m*ZY$js-#L%p:pjJgPLH;P69TQ32XTo?qFBDai]e-.%+0+=ohmpNa<aojRq<qkgbT^,541'Z9(*^+XsqAYR3S&EieSsb],;<MfI(GrLV1qF7%U@.c:(;!_0q.(>9F?*L54KIX?6qf&Df_Nd4"IAO\c8D\,bTB%Z/Z#reIH[E1Q`<Sa<d9ICZoSu9lX0IVfl*ou5[1Yb*3Z"'S8P:b`l8^*%9bGYi,o`-[@Ori[u,:m2T)-q<c_cXgt)De`4X@3IO>WXWV-g!"tZJ!SpfF0&c7jtF44@mNqAin.>Ym[%fcD*3EblbaDB,#W+88"!@XJsVcb+,0X6%21'.;uQ$9S/1,C/;8YLe`@DbUBHCI-`bqBr"SjF=F"<(bV-R*=1lU^=Ld:#EM3bibE&Q2BEQ0L=Nb!;UnZDaF[s^qFFG.^s&+GYd!mn.!YepVk&Y@5nXtQj<1r\DqNG%fP-2&.=FL$f1>uTAF3T0`g.1u+Z]f)%L1>eR,M?fHZP!/$]B9KNi!EH/3FZJeN3uh",&G1#Sb&9Jb85/"=Mt;SMuk]$nq`Y^sX?p.LU:%gG9.IGmAo;78KClC_fkAK&JBbFF4F5H6mtrKX^R[60=pmg>L@JeWGUO(aX21p,#l8P#Fo$hdK`OLLY$$bV7hkf%e:T>ZN##=gW^f9ttetJ1D=>;F^P?(RuQ@_S*X5X_sIda8nRQBl_.O*\b0&5naOOTNeCgj<QnJ((UDe&*/!bY\]Fn+[NAQG3#ZJ!/T`=8peJb0*r#4,+hs!XkSlWd.O\J4ShgOrY2XUD`5t5X)QY;*G*UN,655l"fDnU:q)5hf>YCmLHRd%oGKCb2q__4"u-sZ>L[(_NrU+<.k8$T1>$\]HA>mYjLMtrf@9F86#SjK-iPM:1$Cqj=\s9b,WgqbTPfJcg(PT)^l/IM)Eq2]o(:#"*s&t#K"BQLd`hknMP/Ut39"rh!3s]J\gFqGKB-sGjNYW3R!r;LeF1Y`g&,5A9[-;0I"2jcDkMnBYsWWp`_Qnh%&?P=(t&j=>"Q!,0Ie5)=HK,<U<*EhX'AR6Bb6pMYK`F?Io,P?%oc9efiG\ZdBZc-3S.inMH@YH*)Y=jOtEP9+bD#8n=lM5iE`UajT)!%Nj?M,6_a$*GpMaQkiKSsl/2:1`@-u4IP0!JmiI1gbg()BP"\QDFqX@*(n(5/+sGTABU&;'WNnA0O_/nn^8/0/;tOi)\F?8W?L8i4IW!T7nSp>Y6^(g[+5=?HqTQ,:HZnh^HZnfNNm9n8N3^B6MbDG#o;9Ra?X6q9'1tJ1W&#0`s%T:=XZ;tH4&4lo^o<4cH-(L`RT,U(P:=R&$NR96&HKsYk;TNFZH`B8Mi^RpC2nTG)tKrJIBZ^]>&-.OoK.cU!2mp@^d^Iu6>*1t<gJqjJ_,*VE#8VK0AQD>Fa;qlNaSN?YWm_'Ff5]"_frWJ9P_p#7s(YM)W9+jJ8$J=k!M)0/Y/EeS[N6_e!BDlHPiU$'.!I?,V!21@_:U&6e;V^Cihf3rp%g*=+:C%m#Y<GD^9MUG3ofSVeQVOMC2VF7q3Iq[!Me[phlo$+bj1J%!o2b0hCTOQJ=5$!%`a70Y=SQmui6BrE\')i,H$k9+jJAMBo$8E%_'ienf:aI_=4;g>VOE51sHlmQ7kVl,_HJEW1;`cX4ATq-Zj(K`Al4dr\qK$u+or\C07F\<'p>[dSH7B@R>S^rU<F.>Bni-Csr)VZbK0W'b3lPQ(ZZ&Kf@~>endstream
 endobj
 xref
-0 13
+0 14
 0000000000 65535 f 
 0000000061 00000 n 
 0000000102 00000 n 
 0000000209 00000 n 
 0000000321 00000 n 
-0000000553 00000 n 
-0000000785 00000 n 
-0000001017 00000 n 
-0000001085 00000 n 
-0000001346 00000 n 
-0000001417 00000 n 
-0000003448 00000 n 
-0000005615 00000 n 
+0000000522 00000 n 
+0000000818 00000 n 
+0000001051 00000 n 
+0000001347 00000 n 
+0000001416 00000 n 
+0000001677 00000 n 
+0000001749 00000 n 
+0000003840 00000 n 
+0000006007 00000 n 
 trailer
 <<
 /ID 
-[<9c2068c94c554d36263431fca2a3c0c8><9c2068c94c554d36263431fca2a3c0c8>]
+[<3e86630e9e032ba36b4ef943037be105><3e86630e9e032ba36b4ef943037be105>]
 % ReportLab generated PDF document -- digest (opensource)
 
-/Info 8 0 R
-/Root 7 0 R
-/Size 13
+/Info 9 0 R
+/Root 8 0 R
+/Size 14
 >>
 startxref
-7966
+8420
 %%EOF

--- a/graph_pdf/sample_generator.py
+++ b/graph_pdf/sample_generator.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import base64
+from io import BytesIO
 from pathlib import Path
 from typing import Dict, Iterable, List, Sequence, Tuple
 
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
+from reportlab.lib.utils import ImageReader
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfgen import canvas
 
@@ -12,6 +15,9 @@ from sample_fixture import load_demo_fixture
 
 LineItem = Tuple[str, int]
 TableRow = Tuple[str, str, str]
+_SMALL_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR42mP8z/C/HwAHAQL/5ncLrgAAAABJRU5ErkJggg=="
+)
 
 def _fixture_tables() -> Dict[str, Tuple[Tuple[str, str, str], Tuple[TableRow, ...]]]:
     fixture = load_demo_fixture()
@@ -111,6 +117,20 @@ class DemoPdfBuilder:
         self.canvas = canvas.Canvas(str(output_path), pagesize=letter)
         self._start_new_page()
 
+    def _draw_small_page_image(self) -> None:
+        if self.page_no not in (1, 3):
+            return
+        image = ImageReader(BytesIO(_SMALL_PNG))
+        self.canvas.drawImage(
+            image,
+            self.width - self.margin_x - 20,
+            self.body_top - 10,
+            width=12,
+            height=12,
+            preserveAspectRatio=True,
+            mask="auto",
+        )
+
     def _start_new_page(self) -> None:
         if self.page_no > 0:
             self.canvas.showPage()
@@ -151,6 +171,7 @@ class DemoPdfBuilder:
         )
 
         self._draw_watermark(self.width / 2, self.height / 2, size=44)
+        self._draw_small_page_image()
 
         self.cursor_y = self.body_top
 

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -2,11 +2,19 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 from pathlib import Path
 
 import pdfplumber
 
-from extractor import _looks_like_table, _normalize_cell_lines, _parse_pages_spec, extract_pdf_to_outputs
+from extractor import (
+    _extract_embedded_images,
+    _looks_like_table,
+    _normalize_cell_lines,
+    _parse_pages_spec,
+    extract_pdf_to_outputs,
+)
 from verify import _extract_markdown_tables
 from sample_fixture import load_demo_fixture
 from sample_generator import create_demo_pdf
@@ -141,6 +149,31 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertIn("### Page 3 table 1", result["table_markdown"])
         self.assertIn("### Page 3 table 2", result["table_markdown"])
         self.assertEqual(2, result["summary"]["table_count"])
+        self.assertEqual(1, len(result["image_files"]))
+        self.assertTrue(result["image_files"][0].name.startswith("sample_page_03_image_"))
+
+    def test_extract_embedded_images_respects_selected_pages(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        out_dir = Path(tmp.name) / "images"
+        fake_reader = SimpleNamespace(
+            pages=[
+                SimpleNamespace(images=[SimpleNamespace(name="p1.png", data=b"one")]),
+                SimpleNamespace(images=[SimpleNamespace(name="p2.png", data=b"two")]),
+                SimpleNamespace(images=[SimpleNamespace(name="p3.png", data=b"three")]),
+            ]
+        )
+
+        with patch("extractor.PdfReader", return_value=fake_reader):
+            image_files = _extract_embedded_images(
+                pdf_path=Path("ignored.pdf"),
+                out_image_dir=out_dir,
+                stem="sample",
+                pages=[2],
+            )
+
+        self.assertEqual(1, len(image_files))
+        self.assertEqual("sample_page_02_image_01.png", image_files[0].name)
 
     def test_spanning_stage_table_merges_into_one_block(self) -> None:
         markdown = self._extract_table_markdown()
@@ -170,6 +203,7 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertEqual(table_markdown, table_md_file.read_text(encoding="utf-8"))
         self.assertTrue(table_md_file.name.endswith("_table.md"))
         self.assertIn("### Page 1 table 1", table_markdown)
+        self.assertEqual(2, len(result["image_files"]))
 
     def test_stage_table_repeats_header_after_page_break(self) -> None:
         pdf_path = self._build_pdf()


### PR DESCRIPTION
## Summary
- pass the pages selection through embedded image extraction so only requested source pages are scanned
- add small embedded sample images on pages 1 and 3 to validate end-to-end image extraction behavior
- extend extractor tests to cover page-filtered image output and sample image counts

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 run_demo.py
- python3 extractor.py sample.pdf --out-md-dir /tmp/graph_pdf_pages_check_md2 --out-image-dir /tmp/graph_pdf_pages_check_img2 --stem page3_only --pages 3