### PR TITLE
Include drawing segment coordinates in table debug output

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -106,6 +106,12 @@ def _collect_table_drawing_debug(
     for index, (x0, x1, lines) in enumerate(groups, start=1):
         top = min(float(edge["top"]) for edge in lines)
         bottom = max(float(edge["top"]) for edge in lines)
+        horizontal_edges = [
+            edge
+            for edge in lines
+            if float(edge["top"]) >= body_top
+            and float(edge["bottom"]) <= body_bottom
+        ]
         vertical_edges = [
             edge
             for edge in page.vertical_edges
@@ -114,7 +120,7 @@ def _collect_table_drawing_debug(
             and float(edge["bottom"]) >= top
             and float(edge["top"]) <= bottom
         ]
-        horizontal_positions = _merge_numeric_positions([float(edge["top"]) for edge in lines])
+        horizontal_positions = _merge_numeric_positions([float(edge["top"]) for edge in horizontal_edges])
         vertical_positions = _merge_numeric_positions(
             [x0, x1, *(float(edge["x0"]) for edge in vertical_edges)]
         )
@@ -126,6 +132,24 @@ def _collect_table_drawing_debug(
                 "col_count": max(0, len(vertical_positions) - 1),
                 "horizontal_lines": [round(value, 2) for value in horizontal_positions],
                 "vertical_lines": [round(value, 2) for value in vertical_positions],
+                "horizontal_segments": [
+                    {
+                        "x0": round(float(edge["x0"]), 2),
+                        "x1": round(float(edge["x1"]), 2),
+                        "top": round(float(edge["top"]), 2),
+                        "bottom": round(float(edge["bottom"]), 2),
+                    }
+                    for edge in horizontal_edges
+                ],
+                "vertical_segments": [
+                    {
+                        "x0": round(float(edge["x0"]), 2),
+                        "x1": round(float(edge["x1"]), 2),
+                        "top": round(float(edge["top"]), 2),
+                        "bottom": round(float(edge["bottom"]), 2),
+                    }
+                    for edge in vertical_edges
+                ],
                 "horizontal_count": len(horizontal_positions),
                 "vertical_count": len(vertical_positions),
             }

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -330,6 +330,16 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertEqual(3, payload["tables"][0]["col_count"])
         self.assertEqual(3, payload["tables"][1]["row_count"])
         self.assertEqual(3, payload["tables"][1]["col_count"])
+        self.assertTrue(payload["tables"][0]["horizontal_segments"])
+        self.assertTrue(payload["tables"][0]["vertical_segments"])
+        self.assertEqual(
+            {"x0", "x1", "top", "bottom"},
+            set(payload["tables"][0]["horizontal_segments"][0].keys()),
+        )
+        self.assertEqual(
+            {"x0", "x1", "top", "bottom"},
+            set(payload["tables"][0]["vertical_segments"][0].keys()),
+        )
 
     def test_debug_writes_table_drawing_log(self) -> None:
         tmp = tempfile.TemporaryDirectory()


### PR DESCRIPTION
## Summary
- extend table drawing debug output with horizontal and vertical segment coordinates
- keep grouped row/column estimates and crop-related debug data together
- add regression coverage for the new debug payload fields

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 extractor.py sample.pdf --out-md-dir /tmp/graph_pdf_debug_tables_md --out-image-dir /tmp/graph_pdf_debug_tables_img --stem debug_tables --debug
