### PR TITLE
Preserve span when merging debug drawing segments

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -132,6 +132,7 @@ def _merge_horizontal_band_segments(
         previous = merged[-1]
         if float(edge["x0"]) - float(previous["x1"]) <= tolerance:
             previous["x1"] = max(float(previous["x1"]), float(edge["x1"]))
+            previous["top"] = min(float(previous["top"]), float(edge["top"]))
             previous["bottom"] = max(float(previous["bottom"]), float(edge["bottom"]))
             continue
         merged.append(dict(edge))
@@ -151,6 +152,7 @@ def _merge_vertical_band_segments(
             continue
         previous = merged[-1]
         if float(edge["top"]) - float(previous["bottom"]) <= tolerance:
+            previous["x0"] = min(float(previous["x0"]), float(edge["x0"]))
             previous["bottom"] = max(float(previous["bottom"]), float(edge["bottom"]))
             previous["x1"] = max(float(previous["x1"]), float(edge["x1"]))
             continue

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -19,6 +19,8 @@ from extractor import (
     _is_gray_color,
     _is_non_watermark_obj,
     _looks_like_table,
+    _merge_horizontal_band_segments,
+    _merge_vertical_band_segments,
     _normalize_cell_lines,
     _parse_pages_spec,
     extract_pdf_to_outputs,
@@ -184,6 +186,62 @@ class TableExtractionFormattingTests(unittest.TestCase):
 
         self.assertEqual(40.0, body_top)
         self.assertEqual(710.0, body_bottom)
+
+    def test_merge_horizontal_band_segments_handles_contained_and_overlapping_lines(self) -> None:
+        segments = [
+            {"x0": 10.0, "x1": 50.0, "top": 100.0, "bottom": 100.0},
+            {"x0": 20.0, "x1": 40.0, "top": 100.0, "bottom": 100.0},
+            {"x0": 49.5, "x1": 80.0, "top": 100.0, "bottom": 100.0},
+            {"x0": 80.5, "x1": 100.0, "top": 100.0, "bottom": 100.0},
+        ]
+
+        merged = _merge_horizontal_band_segments(segments, tolerance=1.0)
+
+        self.assertEqual(
+            [{"x0": 10.0, "x1": 100.0, "top": 100.0, "bottom": 100.0}],
+            merged,
+        )
+
+    def test_merge_vertical_band_segments_handles_contained_and_overlapping_lines(self) -> None:
+        segments = [
+            {"x0": 200.0, "x1": 200.0, "top": 10.0, "bottom": 50.0},
+            {"x0": 200.0, "x1": 200.0, "top": 20.0, "bottom": 40.0},
+            {"x0": 200.0, "x1": 200.0, "top": 49.5, "bottom": 80.0},
+            {"x0": 200.0, "x1": 200.0, "top": 80.5, "bottom": 100.0},
+        ]
+
+        merged = _merge_vertical_band_segments(segments, tolerance=1.0)
+
+        self.assertEqual(
+            [{"x0": 200.0, "x1": 200.0, "top": 10.0, "bottom": 100.0}],
+            merged,
+        )
+
+    def test_merge_horizontal_band_segments_preserves_full_vertical_span(self) -> None:
+        segments = [
+            {"x0": 10.0, "x1": 50.0, "top": 100.0, "bottom": 100.6},
+            {"x0": 50.4, "x1": 80.0, "top": 99.6, "bottom": 100.0},
+        ]
+
+        merged = _merge_horizontal_band_segments(segments, tolerance=1.0)
+
+        self.assertEqual(
+            [{"x0": 10.0, "x1": 80.0, "top": 99.6, "bottom": 100.6}],
+            merged,
+        )
+
+    def test_merge_vertical_band_segments_preserves_full_horizontal_span(self) -> None:
+        segments = [
+            {"x0": 199.6, "x1": 200.0, "top": 10.0, "bottom": 50.0},
+            {"x0": 200.0, "x1": 200.6, "top": 49.5, "bottom": 80.0},
+        ]
+
+        merged = _merge_vertical_band_segments(segments, tolerance=1.0)
+
+        self.assertEqual(
+            [{"x0": 199.6, "x1": 200.6, "top": 10.0, "bottom": 80.0}],
+            merged,
+        )
 
     def test_extract_can_limit_to_selected_pages(self) -> None:
         tmp = tempfile.TemporaryDirectory()


### PR DESCRIPTION
## Summary
- make debug segment merging robust to contained and overlapping line fragments
- preserve full vertical span for merged horizontal segments and full horizontal span for merged vertical segments
- add regression tests for overlapping and contained fragment cases

## Validation
- python3 -m unittest -q
- python3 verify.py
