### PR TITLE
Normalize grouped debug band segments

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -118,24 +118,61 @@ def _round_segment(
     return payload
 
 
+def _normalize_band_segments(
+    segments: Sequence[dict],
+    start_key: str,
+    end_key: str,
+    orth_min_key: str,
+    orth_max_key: str,
+    tolerance: float = 1.0,
+) -> List[dict]:
+    normalized: List[dict] = []
+    ordered = sorted(
+        (dict(edge) for edge in segments),
+        key=lambda item: (float(item[start_key]), float(item[end_key])),
+    )
+    for edge in ordered:
+        if not normalized:
+            normalized.append(edge)
+            continue
+
+        current = normalized[-1]
+        current_start = float(current[start_key])
+        current_end = float(current[end_key])
+        edge_start = float(edge[start_key])
+        edge_end = float(edge[end_key])
+
+        # Fully-contained duplicates should only widen the orthogonal span.
+        if edge_start >= current_start and edge_end <= current_end:
+            current[orth_min_key] = min(float(current[orth_min_key]), float(edge[orth_min_key]))
+            current[orth_max_key] = max(float(current[orth_max_key]), float(edge[orth_max_key]))
+            continue
+
+        if edge_start - current_end <= tolerance:
+            current[end_key] = max(current_end, edge_end)
+            current[orth_min_key] = min(float(current[orth_min_key]), float(edge[orth_min_key]))
+            current[orth_max_key] = max(float(current[orth_max_key]), float(edge[orth_max_key]))
+            continue
+
+        normalized.append(edge)
+
+    return normalized
+
+
 def _merge_horizontal_band_segments(
     segments: Sequence[dict],
     tolerance: float = 1.0,
     body_top: float | None = None,
     body_bottom: float | None = None,
 ) -> List[dict]:
-    merged: List[dict] = []
-    for edge in sorted(segments, key=lambda item: (float(item["x0"]), float(item["x1"]))):
-        if not merged:
-            merged.append(dict(edge))
-            continue
-        previous = merged[-1]
-        if float(edge["x0"]) - float(previous["x1"]) <= tolerance:
-            previous["x1"] = max(float(previous["x1"]), float(edge["x1"]))
-            previous["top"] = min(float(previous["top"]), float(edge["top"]))
-            previous["bottom"] = max(float(previous["bottom"]), float(edge["bottom"]))
-            continue
-        merged.append(dict(edge))
+    merged = _normalize_band_segments(
+        segments,
+        start_key="x0",
+        end_key="x1",
+        orth_min_key="top",
+        orth_max_key="bottom",
+        tolerance=tolerance,
+    )
     return [_round_segment(edge, body_top=body_top, body_bottom=body_bottom) for edge in merged]
 
 
@@ -145,18 +182,14 @@ def _merge_vertical_band_segments(
     body_top: float | None = None,
     body_bottom: float | None = None,
 ) -> List[dict]:
-    merged: List[dict] = []
-    for edge in sorted(segments, key=lambda item: (float(item["top"]), float(item["bottom"]))):
-        if not merged:
-            merged.append(dict(edge))
-            continue
-        previous = merged[-1]
-        if float(edge["top"]) - float(previous["bottom"]) <= tolerance:
-            previous["x0"] = min(float(previous["x0"]), float(edge["x0"]))
-            previous["bottom"] = max(float(previous["bottom"]), float(edge["bottom"]))
-            previous["x1"] = max(float(previous["x1"]), float(edge["x1"]))
-            continue
-        merged.append(dict(edge))
+    merged = _normalize_band_segments(
+        segments,
+        start_key="top",
+        end_key="bottom",
+        orth_min_key="x0",
+        orth_max_key="x1",
+        tolerance=tolerance,
+    )
     return [_round_segment(edge, body_top=body_top, body_bottom=body_bottom) for edge in merged]
 
 

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -202,6 +202,38 @@ class TableExtractionFormattingTests(unittest.TestCase):
             merged,
         )
 
+    def test_merge_horizontal_band_segments_is_order_independent_with_contained_lines(self) -> None:
+        segments = [
+            {"x0": 50.4, "x1": 80.0, "top": 100.0, "bottom": 100.2},
+            {"x0": 20.0, "x1": 40.0, "top": 99.9, "bottom": 100.1},
+            {"x0": 10.0, "x1": 50.0, "top": 100.0, "bottom": 100.0},
+            {"x0": 80.4, "x1": 100.0, "top": 100.0, "bottom": 100.0},
+        ]
+
+        merged = _merge_horizontal_band_segments(segments, tolerance=1.0)
+
+        self.assertEqual(
+            [{"x0": 10.0, "x1": 100.0, "top": 99.9, "bottom": 100.2}],
+            merged,
+        )
+
+    def test_merge_horizontal_band_segments_keeps_gaps_larger_than_tolerance(self) -> None:
+        segments = [
+            {"x0": 10.0, "x1": 50.0, "top": 100.0, "bottom": 100.0},
+            {"x0": 20.0, "x1": 40.0, "top": 100.0, "bottom": 100.0},
+            {"x0": 55.1, "x1": 80.0, "top": 100.0, "bottom": 100.0},
+        ]
+
+        merged = _merge_horizontal_band_segments(segments, tolerance=1.0)
+
+        self.assertEqual(
+            [
+                {"x0": 10.0, "x1": 50.0, "top": 100.0, "bottom": 100.0},
+                {"x0": 55.1, "x1": 80.0, "top": 100.0, "bottom": 100.0},
+            ],
+            merged,
+        )
+
     def test_merge_vertical_band_segments_handles_contained_and_overlapping_lines(self) -> None:
         segments = [
             {"x0": 200.0, "x1": 200.0, "top": 10.0, "bottom": 50.0},
@@ -214,6 +246,38 @@ class TableExtractionFormattingTests(unittest.TestCase):
 
         self.assertEqual(
             [{"x0": 200.0, "x1": 200.0, "top": 10.0, "bottom": 100.0}],
+            merged,
+        )
+
+    def test_merge_vertical_band_segments_is_order_independent_with_contained_lines(self) -> None:
+        segments = [
+            {"x0": 199.8, "x1": 200.0, "top": 50.4, "bottom": 80.0},
+            {"x0": 200.0, "x1": 200.1, "top": 20.0, "bottom": 40.0},
+            {"x0": 200.0, "x1": 200.0, "top": 10.0, "bottom": 50.0},
+            {"x0": 200.0, "x1": 200.0, "top": 80.4, "bottom": 100.0},
+        ]
+
+        merged = _merge_vertical_band_segments(segments, tolerance=1.0)
+
+        self.assertEqual(
+            [{"x0": 199.8, "x1": 200.1, "top": 10.0, "bottom": 100.0}],
+            merged,
+        )
+
+    def test_merge_vertical_band_segments_keeps_gaps_larger_than_tolerance(self) -> None:
+        segments = [
+            {"x0": 200.0, "x1": 200.0, "top": 10.0, "bottom": 50.0},
+            {"x0": 200.0, "x1": 200.0, "top": 20.0, "bottom": 40.0},
+            {"x0": 200.0, "x1": 200.0, "top": 55.2, "bottom": 80.0},
+        ]
+
+        merged = _merge_vertical_band_segments(segments, tolerance=1.0)
+
+        self.assertEqual(
+            [
+                {"x0": 200.0, "x1": 200.0, "top": 10.0, "bottom": 50.0},
+                {"x0": 200.0, "x1": 200.0, "top": 55.2, "bottom": 80.0},
+            ],
             merged,
         )
 


### PR DESCRIPTION
## Summary
- normalize grouped debug band segments using interval-style merging
- drop fully contained fragments, keep gaps larger than tolerance, and preserve orthogonal span on merged segments
- add regression coverage for contained, overlapping, unordered, and gap-separated fragment cases

## Validation
- python3 -m unittest -q
- python3 verify.py
