### PR TITLE
Lower table region minimum width

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -727,7 +727,7 @@ def _table_regions(
     for edge in edges:
         if edge["top"] < 80 or edge["top"] > page.height - 80:
             continue
-        if edge["x1"] - edge["x0"] < 120:
+        if edge["x1"] - edge["x0"] < 50:
             continue
 
         placed = False


### PR DESCRIPTION
## Summary
- lower the minimum horizontal line width used for table region grouping from 120 to 50
- allow shorter cell-level horizontal segments to participate in table region detection

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 extractor.py sample.pdf --out-md-dir /tmp/graph_pdf_debug_tables_md --out-image-dir /tmp/graph_pdf_debug_tables_img --stem debug_tables --debug
