### PR TITLE
Remove non-empty cell table rejection

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -568,6 +568,10 @@ def _normalize_cell_lines(cell: str) -> List[str]:
 
 
 def _normalize_extracted_table(table: Sequence[Sequence[str]]) -> List[List[str]]:
+    # TODO: Some source PDFs render one visual column as three structural
+    # columns by inserting narrow left/right spacer columns. Collapse those
+    # structural triples into one display column before markdown output once the
+    # grouping rule is validated on real documents.
     normalized: List[List[str]] = []
     for row in table:
         normalized_row = []
@@ -585,20 +589,10 @@ def _table_rejection_reason(table: Sequence[Sequence[str]]) -> str | None:
     if not table:
         return "empty table"
 
-    max_cols = max(len(r) for r in table)
-
     normalized_rows = [[str(cell or "").strip() for cell in row] for row in table]
 
     if not any(cell for cell in normalized_rows[0]):
         return "empty first row"
-
-    non_empty_cells = sum(1 for row in normalized_rows for cell in row if cell)
-    continuation_like = not _normalize_text(normalized_rows[0][0]) and len(normalized_rows) == 2
-    min_cells = max_cols * 2
-    if continuation_like:
-        min_cells = max_cols + 1
-    if non_empty_cells < min_cells:
-        return f"too few non-empty cells ({non_empty_cells} < {min_cells})"
 
     return None
 

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -164,6 +164,13 @@ class TableExtractionFormattingTests(unittest.TestCase):
         table = [["Value"] for _ in range(81)]
         self.assertIsNone(_table_rejection_reason(table))
 
+    def test_table_rejection_reason_allows_sparse_tables(self) -> None:
+        table = [
+            ["Status", "", ""],
+            ["Ready", "", ""],
+        ]
+        self.assertIsNone(_table_rejection_reason(table))
+
     def test_gray_text_between_53_and_57_degrees_is_treated_as_watermark(self) -> None:
         char = {
             "object_type": "char",


### PR DESCRIPTION
## Summary
- remove the table rejection rule based on non-empty cell counts
- keep only empty-table and empty-first-row rejection cases
- add a TODO for collapsing visual single columns that are structurally split into three columns
- add regression coverage for sparse tables

## Validation
- python3 -m unittest -q
- python3 verify.py
