### PR TITLE
Guard table continuation merges by page boundary

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -686,6 +686,13 @@ def _normalize_two_col_continuation_rows(rows: TableRows) -> TableRows:
     return [["", str(row[0] or "").strip(), str(row[1] or "").strip()] for row in rows if row]
 
 
+def _should_try_table_continuation_merge(
+    pending_page: int | None,
+    current_page: int,
+) -> bool:
+    return pending_page is not None and current_page == pending_page + 1
+
+
 def _vertical_axes_for_bbox(
     page: pdfplumber.page.PageObject,
     bbox: Tuple[float, float, float, float],
@@ -1219,26 +1226,50 @@ def extract_pdf_to_outputs(
                     footer_margin=footer_margin,
                 )
                 for table_rows, bbox in tables:
-                    merged_missing_first = _maybe_merge_missing_first_column_chunk(
-                        pending_table,
-                        table_rows,
-                        full_page_text,
+                    cross_page_continuation = _should_try_table_continuation_merge(
+                        pending_page=pending_page,
+                        current_page=page_idx,
                     )
+
+                    merged_missing_first = None
+                    if cross_page_continuation:
+                        merged_missing_first = _maybe_merge_missing_first_column_chunk(
+                            pending_table,
+                            table_rows,
+                            full_page_text,
+                        )
                     if merged_missing_first is not None:
                         pending_table = merged_missing_first
+                        pending_page = page_idx
+                        pending_bbox = bbox
+                        pending_axes = _vertical_axes_for_bbox(page, bbox)
                         continue
 
-                    continuation_rows = _split_repeated_header(pending_table or [], table_rows)
-                    if pending_table is not None and _is_continuation_chunk(pending_table, continuation_rows):
-                        pending_table.extend(continuation_rows)
-                        continue
+                    continuation_rows = table_rows
+                    if cross_page_continuation:
+                        continuation_rows = _split_repeated_header(pending_table or [], table_rows)
+                        if pending_table is not None and _is_continuation_chunk(pending_table, continuation_rows):
+                            pending_table.extend(continuation_rows)
+                            pending_page = page_idx
+                            current_axes = _vertical_axes_for_bbox(page, bbox)
+                            if pending_bbox is not None:
+                                pending_bbox = (
+                                    min(pending_bbox[0], bbox[0]),
+                                    min(pending_bbox[1], bbox[1]),
+                                    max(pending_bbox[2], bbox[2]),
+                                    max(pending_bbox[3], bbox[3]),
+                                )
+                            else:
+                                pending_bbox = bbox
+                            pending_axes = _merge_numeric_positions([*pending_axes, *current_axes], tolerance=1.0)
+                            continue
 
                     current_axes = _vertical_axes_for_bbox(page, bbox)
                     if (
                         pending_table is not None
                         and pending_bbox is not None
                         and pending_page is not None
-                        and page_idx == pending_page + 1
+                        and cross_page_continuation
                         and _continuation_regions_should_merge(
                             prev_bbox=pending_bbox,
                             curr_bbox=bbox,
@@ -1250,6 +1281,7 @@ def extract_pdf_to_outputs(
                         )
                     ):
                         pending_table.extend(continuation_rows)
+                        pending_page = page_idx
                         pending_bbox = (
                             min(pending_bbox[0], bbox[0]),
                             min(pending_bbox[1], bbox[1]),

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -78,7 +78,7 @@ endobj
 endobj
 9 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260316202919+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316202919+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260317100031+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260317100031+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -127,7 +127,7 @@ xref
 trailer
 <<
 /ID 
-[<62170f418ba85c7a049e7028d8c2864d><62170f418ba85c7a049e7028d8c2864d>]
+[<5d1c7c023a152ff114f7eab70c4aa248><5d1c7c023a152ff114f7eab70c4aa248>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 9 0 R

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -25,6 +25,7 @@ from extractor import (
     _merge_vertical_band_segments,
     _normalize_cell_lines,
     _parse_pages_spec,
+    _should_try_table_continuation_merge,
     _table_regions,
     extract_pdf_to_outputs,
 )
@@ -243,6 +244,10 @@ class TableExtractionFormattingTests(unittest.TestCase):
         )
 
         self.assertFalse(should_merge)
+
+    def test_same_page_tables_do_not_trigger_continuation_merge(self) -> None:
+        self.assertFalse(_should_try_table_continuation_merge(pending_page=2, current_page=2))
+        self.assertTrue(_should_try_table_continuation_merge(pending_page=2, current_page=3))
 
     def test_table_regions_split_when_components_have_different_vertical_edges(self) -> None:
         page = SimpleNamespace(


### PR DESCRIPTION
## Summary
- prevent same-page tables with identical headers from being merged as continuations
- keep cross-page continuation merges working by refreshing pending table page/bbox/axis metadata on each merge path
- refresh the sample PDF artifact to match the current extractor behavior

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 run_demo.py
