### PR TITLE
Collapse structural triplet columns after table extraction

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -559,6 +559,9 @@ def _normalize_cell_lines(cell: str) -> List[str]:
         if logical_lines and _is_bullet_line(logical_lines[-1]) and not buffer:
             logical_lines[-1] = f"{logical_lines[-1]} {line}".strip()
             continue
+        if buffer and str(buffer[-1]).endswith("-"):
+            buffer[-1] = f"{buffer[-1]}{line}".strip()
+            continue
         if buffer and _ends_sentence(buffer[-1]):
             _flush_buffer()
         buffer.append(line)
@@ -567,18 +570,39 @@ def _normalize_cell_lines(cell: str) -> List[str]:
     return logical_lines
 
 
+def _collapse_structural_triplet_columns(table: Sequence[Sequence[str]]) -> List[List[str]]:
+    rows = [list(row) for row in table]
+    if not rows:
+        return []
+
+    col_count = max((len(row) for row in rows), default=0)
+    if col_count == 0 or col_count % 3 != 0:
+        return [list(row) for row in rows]
+
+    padded_rows = [list(row) + [""] * (col_count - len(row)) for row in rows]
+    collapsed_indices: List[int] = []
+
+    for start in range(0, col_count, 3):
+        left_values = [_normalize_text(row[start]) for row in padded_rows]
+        right_values = [_normalize_text(row[start + 2]) for row in padded_rows]
+        if any(left_values) or any(right_values):
+            collapsed_indices.extend([start, start + 1, start + 2])
+            continue
+        collapsed_indices.append(start + 1)
+
+    return [[row[idx] for idx in collapsed_indices] for row in padded_rows]
+
+
 def _normalize_extracted_table(table: Sequence[Sequence[str]]) -> List[List[str]]:
-    # TODO: Some source PDFs render one visual column as three structural
-    # columns by inserting narrow left/right spacer columns. Collapse those
-    # structural triples into one display column before markdown output once the
-    # grouping rule is validated on real documents.
+    # TODO: Extend structural-column collapse beyond strict 3-column spacer
+    # triples when real documents expose asymmetric spacer patterns.
     normalized: List[List[str]] = []
     for row in table:
         normalized_row = []
         for cell in row:
             normalized_row.append("\n".join(_normalize_cell_lines(str(cell or ""))))
         normalized.append(normalized_row)
-    return normalized
+    return _collapse_structural_triplet_columns(normalized)
 
 
 def _looks_like_table(table: Sequence[Sequence[str]]) -> bool:
@@ -1168,15 +1192,17 @@ def extract_pdf_to_outputs(
 
     pending_table: Optional[TableRows] = None
     pending_page: Optional[int] = None
+    pending_last_page: Optional[int] = None
     pending_bbox: Optional[Tuple[float, float, float, float]] = None
     pending_axes: List[float] = []
 
     def _flush_pending() -> None:
-        nonlocal pending_table, pending_page, pending_bbox, pending_axes
+        nonlocal pending_table, pending_page, pending_last_page, pending_bbox, pending_axes
         if pending_table is not None and pending_page is not None:
             _append_output_table(output_tables, pending_page, len(output_tables) + 1, pending_table)
         pending_table = None
         pending_page = None
+        pending_last_page = None
         pending_bbox = None
         pending_axes = []
 
@@ -1227,7 +1253,7 @@ def extract_pdf_to_outputs(
                 )
                 for table_rows, bbox in tables:
                     cross_page_continuation = _should_try_table_continuation_merge(
-                        pending_page=pending_page,
+                        pending_page=pending_last_page,
                         current_page=page_idx,
                     )
 
@@ -1240,7 +1266,7 @@ def extract_pdf_to_outputs(
                         )
                     if merged_missing_first is not None:
                         pending_table = merged_missing_first
-                        pending_page = page_idx
+                        pending_last_page = page_idx
                         pending_bbox = bbox
                         pending_axes = _vertical_axes_for_bbox(page, bbox)
                         continue
@@ -1250,7 +1276,7 @@ def extract_pdf_to_outputs(
                         continuation_rows = _split_repeated_header(pending_table or [], table_rows)
                         if pending_table is not None and _is_continuation_chunk(pending_table, continuation_rows):
                             pending_table.extend(continuation_rows)
-                            pending_page = page_idx
+                            pending_last_page = page_idx
                             current_axes = _vertical_axes_for_bbox(page, bbox)
                             if pending_bbox is not None:
                                 pending_bbox = (
@@ -1268,7 +1294,7 @@ def extract_pdf_to_outputs(
                     if (
                         pending_table is not None
                         and pending_bbox is not None
-                        and pending_page is not None
+                        and pending_last_page is not None
                         and cross_page_continuation
                         and _continuation_regions_should_merge(
                             prev_bbox=pending_bbox,
@@ -1281,7 +1307,7 @@ def extract_pdf_to_outputs(
                         )
                     ):
                         pending_table.extend(continuation_rows)
-                        pending_page = page_idx
+                        pending_last_page = page_idx
                         pending_bbox = (
                             min(pending_bbox[0], bbox[0]),
                             min(pending_bbox[1], bbox[1]),
@@ -1294,6 +1320,7 @@ def extract_pdf_to_outputs(
                     _flush_pending()
                     pending_table = table_rows
                     pending_page = page_idx
+                    pending_last_page = page_idx
                     pending_bbox = bbox
                     pending_axes = current_axes
 

--- a/graph_pdf/fixtures/demo_document.json
+++ b/graph_pdf/fixtures/demo_document.json
@@ -85,6 +85,14 @@
     {
       "id": "area",
       "columns": ["Area", "Status", "Action"],
+      "render_columns": ["", "Area", "", "", "Status", "", "", "Action", ""],
+      "render_column_weights": [0.03, 0.27, 0.03, 0.03, 0.27, 0.03, 0.03, 0.27, 0.03],
+      "render_rows": [
+        ["", "Docs", "", "", "READY", "", "", "Finalize\n- sample\n- archive", ""],
+        ["", "QA", "", "", "TODO", "", "", "Confirm\n- edge case\n- fallback", ""],
+        ["", "Ops", "", "", "OK", "", "", "Archive path\n- cleanup\n- index refresh", ""],
+        ["", "Support", "", "", "REVIEW", "", "", "Escalation owner confirmed.\nRegional fallback documented.\nLaunch blackout window approved.", ""]
+      ],
       "rows": [
         ["Docs", "READY", "Finalize\n- sample\n- archive"],
         ["QA", "TODO", "Confirm\n- edge case\n- fallback"],

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -78,7 +78,7 @@ endobj
 endobj
 9 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260317100031+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260317100031+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260317102452+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260317102452+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -103,10 +103,10 @@ GasargN)%,&:O:Slsh\YRGaW]94C!-N$hJ=:"ra*KHsS4_18=up$93i!L->Q^lqUs$O6op`F@/29H_,8
 endobj
 13 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2341
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2805
 >>
 stream
-Gat=,=]=??&:WeDkV7ElD#$WG)nWoPe5C?AWBD:;>=gY"P#npqZbLrnQP0S)b\U-Q6Mf2u>-5!!TbMr2qmY6%oZIkQgh%tPBXpT8OVDJSLMiDjWC<c1=TG65JGh7IAmSAATm9Y3jUTPl.+2t[L[//d9m76K7S-8'-.6>UEJh+C<'u.#bKjktj"!I=e-c#EBL`bRd98$LP83H^$2*qi8+<QMdk`H2J)0GB7?p<(jOn4q#I:$OIiV^gBi=,hAnNc3[^:>,Q\^hYEp1nC%\b97$W?VZdJ]m>jl3Zbge-7PbR8M_fDXdeU9Ju-\>;>s*%Z?-ZpS&5e]$7E24P:6iCu%&au\26AT9%FatD(r$E?W-@;SS3-3VQU8NQmoR*NWg8(</Oal>?mBR_Aq_;Q*q:cW_EN^!:'ERmk`F-b;mKjVp&Mp;3k:=2PC*5bhI)O39bpaf(\H#=lQMlb2rN6]m+$7gB/^NB^ZI-ep7:5^C@.cenJmCVK)rO]*lFFWo&gRCEgI/!tJ5u-0?(mQBa$V#ZNMd*0(J&t^='VoKq9j>)<>@tCH)UbKoNH(0DKWK39/ROW</ZSgo`SJ*%2eN[%+57-MF&=b='1O(Eg0VgA%+Xl&@aL1<kF[&[^"3cVX7PBP>Z.ksaNcV(_S(Sl350U^aSBN1]^cAj/`s:>"C'Z=)',mpotmo"dBf+D#V.SIe#CDT5+,8ig<"?.o.n?D>aOK>)i$:XkS>MLF],o3.qG7)>*UEI0*?poqQN(D7iV7pPoufp^2fl0laM]8L2^U[R"FnG`5WS(QK`9@f<^[22.*6+bZ[i/aWbIe!6e"*+QT-CG!gIQ9N=b>[]#?=.Q.:B3CS:VB:Nr7,/W#&(`h0H:,dj$XlM(^:eobr)aB0m&Q-f=4i1[0RX0VWGu@$>$@pg$M,s')mbpTdUXB2Dh"+:gVhTB_W9AtM;\&14aupG;7'mFf)p]4O\7P)=gOYeS9B-e!FjqJA%+[7-C43gZb.LJ5Qi7jNkV08"VF^e#Ku['S[=':@TW,A#I3'*O/[MWme<mU,O]2?8F73UD=F)0V!W]kh5pZE%W6Yp!P[$m=HtZ7B[++0$\KI^6P_9HcriHLi.nK9!3@4T_-IN0eOkqc"H\bN0b6<o=dg5FaT$-g''aNOq_OI\W]X5ocmIed2::R-tDQJA6E!eDZC"/Ss*jrs=cP1>K4X>oH4_s&f=]Tf1*CbS$:FRhL1Ijf$bFT8E5.5&4)1C!TD4&FBWcm;r6e!>DL[t0K^6M,LQU\cL^g1dDIGD\NPq#s+9AkV<do?LDctpZ\lR+T84at;^]7@$BAf]BOW"PVk#\*jn@FW(P+WCi.Mb;:aM6I*_8:I4=<g'Bsfb+o4S)u*$8cXBD6'QC[bfPb5BI&JSh!TLG;&-]L:.mj%OLdZ3C*oB$ZiW9pFUW\X#($K'm5la6U^4V;<5mb6U0>J[4T`hFEX=\X<_*]\(mS=VnPG8HQQ'_;G!HpM\[1'7RNP&X0)[B.*$cG>%t,rL,npRTO>%`@SY)hj,61EH*=1s[(f.u-"tgfSobnS?`2+OVL1nE8f,LKS#C%\l@^GVna9)F\Xp/9.E#Am,?=q<;p,KC+ged:f)WZ9ce;Rj`e!V'2M=.kBLi^*sD!cRT"[!"3-0#s_!f>K#mMq07W!s5IR^-J0S':&ee3b)VW$328PJTOXpkK)\:#Ki'_e>!Fh%:gS1[Dtpkm-'A:KQe@0VK()MDNmug2P[p9PY\(W*#_*%*=U!qb/(\IkH%)E)-9HnU8sqj[JA@bikO#TfdNni0C#MD6N8Y!Y/D2I[DMhXqr!&ISHi4R<UP%+13c3%Xj3P*N%$,3gnB()Mc&KN5k*u&Xk%&MGCdta2Q8^%r8?:EGKG3ekYp(7>gZ[<JtYG7-eI#h;;ICruEUS!GEqtBE(_k.\f"p/3@2"1r-.a%s?!BQ't[,lcBe#PXPRIfa%RhT(u)rRldqUnL>=&J6K\%INOJ]_#<P)NG5NF,jG%1VZC+&!.^--b62FT,@4E7I6l5(U2_"NTJ'(=NOkkVS0OK$,OG/<9Kh[`F81dfgM+q.A;fku:'8/?!3i8N&i"LWg@/Y9m^5ak]Jb.Nm@ffB:JgE0MX$"QR:F.,L9?^i8ot.,`RhScApEC]i>[Vh[6=J^mF3'W#,RM_gRBo,nCdsE.)'W!6].R<2M:6F@MWMI,UIXM6ibMa&MUh<S9Mq<\bQNu5&g;RpULmn8O]r-&Y,oKX#4,0NF.Q;YBJ^6>u$QAb^VIYD`VoWqUkh]GgF.YRtkOld)(:q?AoDuKf'bcM9tD^JWOUOEsK]pR8ka<!A1LO;k.rk9W%<K:C3?Jki6'FZi:#i_`Bd~>endstream
+Gat=.>Bf*U&q801i6cn.,1+;P^L]@GCnJu:mRd<"lonkbgR?2MKB/hTIf1$)OQ)X*c^pZf+Ort^nPKu7$7.G);"M.U'(V(m\Tsj$1:#RFRRSaZ4HfTd<GW4]J)p[8!O+iuDs<oDaiQ<aalZ,05:PG1aHsLDE[Qm1r(HNWW"5]aa0lbZP:'@d^Q?]YAFnC\9![(tq4^:#PpjaL.amo?o_]Zm`ODGSYMquXaTe?K^:UHr9@G;_hPW#S01^+$R`9?S::t0(0.@C*Gj[bWRX^[%So!Mf.Co:MP^'1GCXE)tFbt_U.=9Ee6QX4L&,&^rdrteYU?>Mc*]shXP(W;iAnP[D/U.pG9tH:h[I[nT<EG/&oE3d)7O[*qXX3F]5f%IY`QL&M>0YreX(OSZ;][B5]kYd0Z'ZM&[^<0*HlZPj\+\qP=4*HKpC!++Z[[;f@^>H=N%nge7ktj^L+%tcAYM%M/%VSq,M0293Csk$mlH5#SdshM`G%_S:@,WBr3X"aqK2U*T'h+(GlR)?$pTAG&C[Km,?Y5rJeOgDk!?$-J)iL;;P'5eU0O$fR8K:3"Y\nPbud7FcF4+jP8CUeX8N"E@b9Da:KKfs^hjQkZRkC-VK(O/D3e\uWL?R,"8g<$r+chLGBpLY3f->a7dsn13b(4eI=diRXukt1dQ>"`LB+!J-$7>G(G!n8W?bcQ#)R62O^tGT5g+p]8mORD(AcbMZ.'4D]o9'L0=,LC)\Ut!'>':qpUiiRl)o</R<VLA>H^QeigT5qMbjk$$8H'$nlk\k,.`BXga"TXl(r.g-IJ)Yf:MX*Ch6leha;Hs4NOgAL&0^-$XPqSo!K7p?5uBIb*[h81llZVXTQAsPitE**ea3Qn@I=4g4gJ>/bZh(#?dChK61:gC->>KP_?*s:q_AjbGKnZaYHIcLE'^l=uE.(`J;K7&OWrd!"<c_Pk\:8ekVL_=.N*AAe*oQ,ZDRlcAbtf9EE+DAS8G6$(Y]4mL`a"r`Cn";^g=Af3>6HmPMl1mjA,o1tUG=f`7eO3B#^=lk00FM9^A=gIYCN=d`P/FXCG@"I0'?m/DekMe>Au!FU#<7,FQ#(h,j+Ju`XDqGcb4.><d2]g-hs.L?\ta1()O]nJ/\gr\J-)FtpRi4V<WQq9\9R&q2H9cc!In657'(C"P#&GG`k^eS)rMn]'MJJg(oc5TtIH.2oP^dq=@Q3li7'e^8k!F?pG)VJ0q*h-<(i8NSp3^.+b%VC$%6rR.D#\:Ya<u'MOZ"ld*knk0##idADH4ebjrdJ6k=c17_#:qj9`R:j.""[KPcn(X%),YUh/V&_]g/`@H#<E9:L(7"&!LERuej9j3NA*C\UB>`Z4#h4H2!B!"WgU.1=r[N!5E"u7a]1o+$:34^aimY&!)VEhV<eoJHn/rrM0--^]frnl@EZhtETf']l`VJ$28oSgJI^!eqY5r2m/c/B;)T/B#jbb^iVR)QYAg@%5gNjj@3qBO=[NUlHF#J([0P@:fN%2B7g>INbh3"+O>OA'rh2)[&<uP_qQY=.O;RUZ;Uq`6A0sB_!4ZnrOK',T]RXE)YgE1#DNqGp7IL9RTEY4!YFR;;@AcB@dVOYY#6;0d':bM!0qMA95"a[sa4-X"oo])KJXieg`@*Mm]kU<H7J@&>`,#0@WngM;.QGI6\ub1ckQ<*`.=&;)8jR@!+C14#_.k`.%Yo@$K)eo!De`0pW1%/TJR&r7Ccd'>dCQrU2iZ[+Xnkd&NPX$$\13NOC-!QKW[m;3bAc\"kgCGj-s_r\F2:-7H580.I]IdAWb^"sj7c7sPbbH7d&eBBKp!^q4QG*E9(F6'*Fa#h7%c5GE>D9B(D%"[`"Hk.>Cs/^56[3FZC8+b`e^a]T%U\DNdb,[d?^VuH+KCo_k8iqPd.Ws\od7CR(766\'B]O<J7sFb;d(Rje-LbYJ$qZ+Pc"5TWj_0#lck.(j5AE>Eedf)q_J`pGd/-q*qiCS06Cc]5EVs;u/tmJ"2HKH_]=[3lGigR`6VHJYQV=45)5pE@6[k*XmDn'RD4`&PF[sLOfr$T'gOcrYpag3E'XNQqHV2.D=KdeK9A0:*3[&XH=b<DJg\S@E_7`JmkUGOh`Y_,VG$1e0/:IDFW5-k,rlf50P@LK])"[#t-J=5RbP,1S-i7isA+-RQsP?cclH@6]F%B+DR.FA`.0.jNf"c5Msa;iLhYf@8Q.o*:.K*hgM)!_*MXe`Lr<a=o,$Zl-Af82F^di]ZM)e$Y)Zk&.CqNN:_fY,B%"L@1EmuF#+AWqQ:@olY\T^0s_u3hV_'e%,^W7*/60V2)F2FLm`3!`)mMe@X;nr35dJ8-57Y)#tk@:`?TpL!B'E&7NBoh8.5hgL!J&[kLOTCQ!lBqUh=jgLO61ipP1a=_\U)gi'mC]@2Lf+LL:s6An3TS)9E7r%"3r!SsqH9$%b+6G)ef2-k%bRV`upR`f(<M(l"Is)%:"E#/_:q+<m]GAq7^t.E+4o>B`\]ZZ1ehL+7c"Z"O`-YG\go.WFo6neokgfF/*MQ\2Peh_QpK)H(2r%1;?fXo%Y#Q2UV8>Y0c-;"p%#L)g7`Jet4-[:.9M."Ym+R?>uQB&k_+0l/%CH>[?bj?DA/m=pk239g>++5diS"=i9djfiA4_0B!8$q&9a<Y::''u=Qa0ekgMZZrjd`S2::ec3?l57J*0NTQ'\2teUPqIjcM%r^9jOQ+&[s*km^9??bSaG8[g*Zb5+`S?gmHXl3QY.V@u46rBG"N[&&ch:pdXJ:d(*>)#D^Wn]7*T>h!T4mXE9*pDDp?&Zdjt3A4>sRZcFlj%9RhAK!rWahtGRF~>endstream
 endobj
 xref
 0 14
@@ -127,7 +127,7 @@ xref
 trailer
 <<
 /ID 
-[<5d1c7c023a152ff114f7eab70c4aa248><5d1c7c023a152ff114f7eab70c4aa248>]
+[<700bd90a4f5e38449552c17867cb7a5a><700bd90a4f5e38449552c17867cb7a5a>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 9 0 R
@@ -135,5 +135,5 @@ trailer
 /Size 14
 >>
 startxref
-8613
+9077
 %%EOF

--- a/graph_pdf/sample_generator.py
+++ b/graph_pdf/sample_generator.py
@@ -14,24 +14,38 @@ from reportlab.pdfgen import canvas
 from sample_fixture import load_demo_fixture
 
 LineItem = Tuple[str, int]
-TableRow = Tuple[str, str, str]
+TableRow = Tuple[str, ...]
 _SMALL_PNG = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR42mP8z/C/HwAHAQL/5ncLrgAAAABJRU5ErkJggg=="
 )
 
-def _fixture_tables() -> Dict[str, Tuple[Tuple[str, str, str], Tuple[TableRow, ...]]]:
+def _fixture_tables() -> Dict[str, Tuple[Tuple[str, ...], Tuple[TableRow, ...]]]:
     fixture = load_demo_fixture()
     return {
         table["id"]: (
-            tuple(table["columns"]),
+            tuple(str(cell) for cell in table["columns"]),
             tuple(tuple(str(cell) for cell in row) for row in table["rows"]),
         )
         for table in fixture["tables"]
     }
 
 
-def get_demo_tables() -> Dict[str, Tuple[Tuple[str, str, str], Tuple[TableRow, ...]]]:
+def get_demo_tables() -> Dict[str, Tuple[Tuple[str, ...], Tuple[TableRow, ...]]]:
     return _fixture_tables()
+
+
+def _fixture_table_render_meta(table_id: str) -> tuple[Tuple[str, ...], Tuple[TableRow, ...], Tuple[float, ...] | None]:
+    for table in load_demo_fixture()["tables"]:
+        if table["id"] != table_id:
+            continue
+        columns = tuple(str(cell) for cell in table.get("render_columns", table["columns"]))
+        rows = tuple(
+            tuple(str(cell) for cell in row)
+            for row in table.get("render_rows", table["rows"])
+        )
+        weights = table.get("render_column_weights")
+        return columns, rows, tuple(float(value) for value in weights) if weights else None
+    raise KeyError(table_id)
 
 
 def get_demo_text_lines() -> Tuple[str, ...]:
@@ -232,6 +246,7 @@ class DemoPdfBuilder:
         self,
         header: Sequence[str],
         rows: Sequence[TableRow],
+        column_weights: Sequence[float] | None = None,
         header_font_size: float = 9.0,
         row_font_size: float = 8.0,
         include_header: bool = True,
@@ -247,9 +262,19 @@ class DemoPdfBuilder:
         if not body_width:
             return
 
-        column_weights = [0.28, 0.2, 0.52]
+        if column_weights is None:
+            if len(header) == 3:
+                column_weights = [0.28, 0.2, 0.52]
+            else:
+                column_weights = [1.0 / max(len(header), 1)] * max(len(header), 1)
+        total_weight = sum(column_weights) or 1.0
+        column_weights = [float(weight) / total_weight for weight in column_weights]
         col_widths = [w * body_width for w in column_weights]
-        col_x = [self.margin_x + col_widths[0], self.margin_x + col_widths[0] + col_widths[1]]
+        col_x: List[float] = []
+        running_x = self.margin_x
+        for width in col_widths[:-1]:
+            running_x += width
+            col_x.append(running_x)
         header_height = 20.0
         line_h = row_font_size + 1.2
 
@@ -426,9 +451,9 @@ class DemoPdfBuilder:
 
         if include_header and header:
             self.canvas.setFont("Helvetica-Bold", header_font_size)
-            self.canvas.drawString(x + 6, y_top - 14, header[0])
-            self.canvas.drawString(col_x[0] + 6, y_top - 14, header[1] if len(header) > 1 else "")
-            self.canvas.drawString(col_x[1] + 6, y_top - 14, header[2] if len(header) > 2 else "")
+            text_x_positions = [x + 6, *[boundary + 6 for boundary in col_x]]
+            for idx, title in enumerate(header):
+                self.canvas.drawString(text_x_positions[idx], y_top - 14, title)
             y -= header_h
             self.canvas.line(x, y, x + body_width, y)
 
@@ -460,8 +485,8 @@ class DemoPdfBuilder:
         if include_outer_vertical:
             self.canvas.line(x, y_top, x, y)
             self.canvas.line(x + body_width, y_top, x + body_width, y)
-        self.canvas.line(col_x[0], y_top, col_x[0], y)
-        self.canvas.line(col_x[1], y_top, col_x[1], y)
+        for boundary_x in col_x:
+            self.canvas.line(boundary_x, y_top, boundary_x, y)
 
         # Body text.
         self.canvas.setFont("Helvetica", row_font_size)
@@ -483,22 +508,27 @@ class DemoPdfBuilder:
             ]
             max_line_count = max(len(t) for t in wrap_texts)
             row_baseline_top = row_cursor - 11
+            text_x_positions = [x + 4, *[boundary + 4 for boundary in col_x]]
 
             draw_first_col_per_row = row_idx not in rows_in_spans
             for i in range(max_line_count):
                 if draw_first_col_per_row:
                     self.canvas.drawString(
-                        x + 4,
+                        text_x_positions[0],
                         row_baseline_top - (i * line_h),
                         wrap_texts[0][i] if i < len(wrap_texts[0]) else "",
                     )
-                self.canvas.drawString(col_x[0] + 4, row_baseline_top - (i * line_h), wrap_texts[1][i] if i < len(wrap_texts[1]) else "")
-                self.canvas.drawString(col_x[1] + 4, row_baseline_top - (i * line_h), wrap_texts[2][i] if i < len(wrap_texts[2]) else "")
+                for col_idx in range(1, len(wrap_texts)):
+                    self.canvas.drawString(
+                        text_x_positions[col_idx],
+                        row_baseline_top - (i * line_h),
+                        wrap_texts[col_idx][i] if i < len(wrap_texts[col_idx]) else "",
+                    )
 
             if row_idx in span_starts and str(row[0]).strip():
                 first_col_lines = wrap_texts[0]
                 for i, line in enumerate(first_col_lines):
-                    self.canvas.drawString(x + 4, row_baseline_top - (i * line_h), line)
+                    self.canvas.drawString(text_x_positions[0], row_baseline_top - (i * line_h), line)
 
             row_cursor -= row_h
 
@@ -557,8 +587,9 @@ def create_demo_pdf(path: Path) -> None:
     )
 
     builder._draw_table_block(
-        header=tables["area"][0],
-        rows=tables["area"][1],
+        header=_fixture_table_render_meta("area")[0],
+        rows=_fixture_table_render_meta("area")[1],
+        column_weights=_fixture_table_render_meta("area")[2],
         include_header=True,
         split_pages=False,
         include_outer_vertical=False,

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pdfplumber
 
 from extractor import (
+    _collapse_structural_triplet_columns,
     _detect_body_bounds,
     _char_rotation_degrees,
     _collect_rotated_text_debug,
@@ -130,6 +131,14 @@ class TableExtractionFormattingTests(unittest.TestCase):
             _normalize_cell_lines(cell),
         )
 
+    def test_hyphen_ended_line_joins_next_line_without_space(self) -> None:
+        cell = "cross-\nborder policy"
+        self.assertEqual(["cross-border policy"], _normalize_cell_lines(cell))
+
+    def test_hyphen_ended_line_does_not_absorb_next_bullet(self) -> None:
+        cell = "review-\n- next item"
+        self.assertEqual(["review-", "- next item"], _normalize_cell_lines(cell))
+
     def test_parse_pages_spec_supports_ranges_and_lists(self) -> None:
         self.assertEqual([1, 3, 4, 5, 8], _parse_pages_spec("1,3-5,8"))
 
@@ -171,6 +180,36 @@ class TableExtractionFormattingTests(unittest.TestCase):
             ["Ready", "", ""],
         ]
         self.assertIsNone(_table_rejection_reason(table))
+
+    def test_collapse_structural_triplet_columns_removes_empty_side_columns(self) -> None:
+        table = [
+            ["", "Area", "", "", "Status", "", "", "Action", ""],
+            ["", "Docs", "", "", "READY", "", "", "Finalize", ""],
+            ["", "QA", "", "", "TODO", "", "", "Confirm", ""],
+        ]
+
+        self.assertEqual(
+            [
+                ["Area", "Status", "Action"],
+                ["Docs", "READY", "Finalize"],
+                ["QA", "TODO", "Confirm"],
+            ],
+            _collapse_structural_triplet_columns(table),
+        )
+
+    def test_collapse_structural_triplet_columns_keeps_non_empty_side_columns(self) -> None:
+        table = [
+            ["", "Area", "", "", "Status", "", "", "Action", ""],
+            ["note", "Docs", "", "", "READY", "", "", "Finalize", ""],
+        ]
+
+        self.assertEqual(
+            [
+                ["", "Area", "", "Status", "Action"],
+                ["note", "Docs", "", "READY", "Finalize"],
+            ],
+            _collapse_structural_triplet_columns(table),
+        )
 
     def test_gray_text_between_53_and_57_degrees_is_treated_as_watermark(self) -> None:
         char = {
@@ -495,6 +534,7 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertEqual(3, len(blocks))
         stage_block = next((block for block in blocks if "Phase A" in block), "")
         self.assertTrue(stage_block)
+        self.assertIn("### Page 1 table 2", markdown)
         self.assertIn("Release Notes", stage_block)
         self.assertIn("Phase C", stage_block)
         self.assertIn("Finance", stage_block)
@@ -610,6 +650,13 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertIn("selected_horizontal_edges", edge_payload["pages"][0])
         self.assertIn("all_vertical_edges", edge_payload["pages"][0])
         self.assertIn("selected_vertical_edges", edge_payload["pages"][0])
+
+    def test_third_table_uses_structural_triplet_columns_in_sample_pdf(self) -> None:
+        pdf_path = self._build_pdf()
+        with pdfplumber.open(str(pdf_path)) as pdf:
+            payload = _collect_table_drawing_debug(pdf.pages[2], page_no=3)
+
+        self.assertTrue(any(table["col_count"] == 9 for table in payload["tables"]))
 
     def test_stage_table_repeats_header_after_page_break(self) -> None:
         pdf_path = self._build_pdf()


### PR DESCRIPTION
## Summary
- render the third sample table as structural triplet columns while keeping the logical fixture rows unchanged
- collapse extracted 3-column spacer triples after table normalization so markdown output returns to the visual column shape
- add regression tests for the triplet-collapse helper and the sample PDF debug shape

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 run_demo.py
