### PR TITLE
Normalize wrapped body text lines and expose text debug

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -305,11 +305,21 @@ def _collect_table_drawing_debug(
             }
         )
 
+    raw_text_lines, normalized_text_lines = _extract_body_text_lines(
+        page,
+        header_margin=header_margin,
+        footer_margin=footer_margin,
+    )
+
     return {
         "page": page_no,
         "body_bounds": [round(body_top, 2), round(body_bottom, 2)],
         "table_count": len(tables),
         "tables": tables,
+        "text_debug": {
+            "raw_lines": raw_text_lines,
+            "normalized_lines": normalized_text_lines,
+        },
     }
 
 
@@ -460,6 +470,21 @@ def _extract_body_text(
     footer_margin: float,
     excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
 ) -> str:
+    _raw_lines, normalized_lines = _extract_body_text_lines(
+        page=page,
+        header_margin=header_margin,
+        footer_margin=footer_margin,
+        excluded_bboxes=excluded_bboxes,
+    )
+    return "\n".join(normalized_lines)
+
+
+def _extract_body_text_lines(
+    page: "pdfplumber.page.Page",
+    header_margin: float,
+    footer_margin: float,
+    excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
+) -> Tuple[List[str], List[str]]:
     body_top, body_bottom = _detect_body_bounds(page, header_margin=header_margin, footer_margin=footer_margin)
     body_page = _filter_page_for_extraction(page)
 
@@ -470,8 +495,6 @@ def _extract_body_text(
             if not fixed:
                 continue
             if _is_layout_artifact(fixed):
-                continue
-            if re.fullmatch(r"^[A-Za-z]$", fixed):
                 continue
             lines.append(fixed)
         return lines
@@ -492,14 +515,14 @@ def _extract_body_text(
     if cursor < body_bottom:
         slices.append((cursor, body_bottom))
 
-    lines: List[str] = []
+    raw_lines: List[str] = []
     for top, bottom in slices:
         if bottom - top < 4:
             continue
         raw = body_page.crop((0, top, page.width, bottom)).extract_text(x_tolerance=1.5, y_tolerance=2) or ""
-        lines.extend(_clean_lines(raw))
+        raw_lines.extend(_clean_lines(raw))
 
-    return "\n".join(lines)
+    return raw_lines, _normalize_body_lines(raw_lines)
 
 
 def _merge_cells(table: Sequence[Sequence[str]]) -> List[List[str]]:
@@ -534,6 +557,42 @@ def _is_bullet_line(line: str) -> bool:
 
 def _ends_sentence(line: str) -> bool:
     return bool(re.search(r"[.!?;:。！？]$" , str(line or "").strip()))
+
+
+def _is_body_heading_line(line: str) -> bool:
+    text = str(line or "").strip()
+    if not text:
+        return False
+    return bool(re.match(r"^(?:chapter|section|appendix)\b", text, flags=re.IGNORECASE))
+
+
+def _normalize_body_lines(lines: Sequence[str]) -> List[str]:
+    normalized: List[str] = []
+    buffer: List[str] = []
+
+    def _flush_buffer() -> None:
+        nonlocal buffer
+        if buffer:
+            normalized.append(" ".join(buffer))
+            buffer = []
+
+    for raw_line in lines:
+        line = str(raw_line or "").strip()
+        if not line:
+            continue
+        if _is_bullet_line(line) or _is_body_heading_line(line):
+            _flush_buffer()
+            normalized.append(line)
+            continue
+        if buffer and str(buffer[-1]).endswith("-"):
+            buffer[-1] = f"{buffer[-1]}{line}".strip()
+            continue
+        if buffer and _ends_sentence(buffer[-1]):
+            _flush_buffer()
+        buffer.append(line)
+
+    _flush_buffer()
+    return normalized
 
 
 def _normalize_cell_lines(cell: str) -> List[str]:

--- a/graph_pdf/fixtures/demo_document.json
+++ b/graph_pdf/fixtures/demo_document.json
@@ -17,12 +17,12 @@
     "Footer page marker: {page_no}"
   ],
   "body": {
-    "intro": [
-      "Chapter 1: Deep Structure Verification",
-      "This section starts a body flow with multiple lines and clear indentation to test ordered extraction.",
-      "- 1st level bullet: layout and spacing checks",
-      "- nested detail: line 2 confirms indentation",
-      "- deeper detail: line 3 confirms paragraph wrap and line breaks",
+      "intro": [
+        "Chapter 1: Deep Structure Verification",
+        "This intentionally verbose sentence exists to force a visual wrap in the sample PDF while still representing single logical sentence for downstream language-model parsing and retrieval quality checks across extracted body text.",
+        "- 1st level bullet: layout and spacing checks",
+        "- nested detail: line 2 confirms indentation",
+        "- deeper detail: line 3 confirms paragraph wrap and line breaks",
       "The extraction should remove header/footer and watermark while preserving indented body content.",
       "- level 1: body copy, one of many lines",
       "- level 2: second nested line",

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -78,7 +78,7 @@ endobj
 endobj
 9 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260317125340+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260317125340+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260317133712+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260317133712+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -89,10 +89,10 @@ endobj
 endobj
 11 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2027
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2130
 >>
 stream
-Gat=,bBDVu&Dd46B&Q0#0hq-`dQ=A8e"!p.Nh`K-66mtQ-4(H`m-*n"GYrK2:hbuOF<GOIB5fSH0ee.is+pY,>Ca1U\@a%O,$<D]Os#>;4kq[96>[mtB?hXL#*F=mZc"',)(`'%Q7`%(:==Rn%l\]O_cd)U10QDX"TrW=L;>"@Z=H2:nh4,EF9Eiu29:D\4dE+#>"BLp$K(b!7eUs-r(("O>]faf(l.-JBp&TRR::K8CBik0BbH.d&Pnum]MNKJq(u>B6[*!$_FeXVMTQr1p<;3J2uYWu`ke2W,@Xur4f_*A]1JaS[Diq#.;pnl-cUJbkbp+Lo;laFm6%F@(-u-63%S+J4'_b"XBERh*Kep1Nmn08=9RUBRp^Q]?VBLEg;u]'$+udNHK1_2>"BHAeA,]Y4jBG;^X%KU!r'OT\m.JV%jA"ZP@K_u>XKD5\]qE&?,R'na@S\G#VJG&E_k[+5=L=+I(58r-qj\/1,/V%ro<SCn`0:*4PkO4J,@:&)EqS/R+(o6#gsE>`?5`YnkR:":U(8LKP"4i<^i9S.>cKSUfEct;,i^GdT$]7iWr/BBE&(q?St>qc,INhWlka5iP02BYBC7sq*l[Sk>?-?E@VoS@?T6TUoIt<\X2E?L08Eh!!>%M22kLp"&R5@C'Sl+?JpNu)ec_*aAjsq]Y`i;V))!NmjcnJe.eh-oa*roiaTpplSe6&OdWSi!.o,Im$T`8g,9BZVa=A.L7X^D>MC(hUi?lIC2t0L!\dB?p:@3*9L2'CMQZ*I*=`09%[Vm2-)$#kJ/+50<N-.\pOFYuFKJ!i"i#30g12KIonBIQLbcROlqlo#NS$-(C/6@Off**-TO4q#V(,8cfl5`5?F#.(B>p!9)(o4`+iZJ#c^>drOkg&U5,ONlZ/<4qJL_9h$:2-WHgfS&,(G:[?)an<(ouI!p%jW)-El9dY@-.)BfU:'<O%#.pb<Or]ABRWouXJT49S>rXe,6"6&H4GEP1"V<pdrnGF5]jn<Q!kV8#@CH_qU,aIK6Za*2/E<E99'fc.V',:.S8eI#U#i?W/nR>PaA(tRT*X?F9?;CDQbG+ZdFBAF^k0RJoZePU*KN2I6ICbO9d88]>9dr_n:mBdf!VbnT(1lh:Y`6#\2:"/XL\Q#?WBp(-$aO4bAqe&cg:=%/:4gS%S/!>f542Pun-VCC1\OW2)]oQ`!T=#rlEN?#d%]mrI'`&^Uj>%1A6I:MWXCGo1p$"D3c9e72I:0[PTX(#/ASq%l-!I)8fY[hQ9b?ai=#a@[>g=07B6b2%LX&#%=_H%6lca:?S7N)ql8R,\;92m9ehiq-di"]HR6P,CFQ$H=Fla#O"kU(ErG]n^P5EgKSN-f8m-Ul15Fca0a-P$<i)+she/FM'giQT[*\6>,MGJ3U$ugKd+0e=NAmP9'PW-66c'.B#d+a)KF>r2N`65&]Q[VbQ)&J"H]+O.g3pR%*HBk5lEO=^7+6RPn-8L>ic\:A;c4a!>X+9cX&rI^`PI`QK1D\;CL8V!8^4rO!g,gI&_jF\6i7V?ngWJ-%k]fEe3VEf>fX6TYg@nK-qmP44&^F%i*r,m7aBlqh(X`98_oJ`l^6(*%Z*c;FhKFgpRcBsJ)nBM(%Tbd^MOBc(?V*udNV()F+kP?d.1FZC9"(>Y[c?!OH!Mq9mIH6f2LW8^Y<#/0D41+H@5fM6HViC';d5.aY66?F=Mki\Vn/WOEa=;9I<TlL&_"jM*\jGPg*:7?ACT'tRJt:\I70NYDu1cl27apJjAf8J1=t?\dF?17/#Jjag&/4n0f3!+o")Ffcck$)45&GWS4*pH)XsG">NBK1:&[36%k'];XoVnonNJ=JEb&J:?3R^?q-HqM'Q[-gM@Rkfls&8!=6;(%@]u=;X4:&mq;AkU=jS]/P$(UoJ=s:.lV?7aPYuWMT+Mf.h89Fuju\$/#`0:02B_qaITXeNs+K>;b@s?^5:tY95,":+!A:XPc[7ls`H@7iP]&<B89N;;SIe5tV6dI&,'%-GS:N^@mId&g.t79N1-#.9#DEdW~>endstream
+Gat=,968iG&AJ$Cm(nIk9G;f1oI[&+1_Vh.3bk-76p_N$P$gRJNrFHN!K`ICJSmLdB4,\`Nt8iEG0M/JJ'@gt2?9qIE;c('MdX("Q37LFn)2I]+uBpYF"n#T7Nc`DEL/[[E<_=PK4P/B^!jXK_Yrk+\.t!T?NdQc^4Dk7>qM^N4'da4@JL]jIlO2K%?6Nt/NU%'"`'rCi%$qc,7NST!;N=73Cq][n,:V*=-Y+(&@9KVHbL*-cAO#X(_lLNg%l*<<g8[D%Fk<KFp"hqY-#2tJ/3J\T"P'#q)Jl?.Q*mECUb&D_0\(3bZQ;uM1Nhg4a7[8K<=\/H>UE^[G\/7RUd#+`TW*+<Qc/q^O_AXL#rKS>4I/j'J("c\G447NpphoI\`Gq`KA!c7;FM.$DE#m@95=6Enf'Gh>I-o-mBLX0XIo@%sNF-S)3:0A.5XbNIoqs=cb7FdLbK@?tfaFiOBf@`$,*o)5ct=+BMF-"H6o"n+HY"jdV$dYO:?-bocE3r-8pmDs.quZoJjeR\I.P"=h$4X*!r9Xb&=e=g]l_U.VJN7;5fn.SPaK.Tt!k.Y_/M7SB%[s$OuEC6"^NMhCV$QPDErJ)9aVD@1=XQ4i?/TQfM%dfTL[>-;GYWFWZPQfX?,ZeW\EA35U5`-GW1?n_.EoiSbV[S)/d.'`2J:fNt[4,:N9GJ&YXb^)A[_cD`X:*oD:PuRO2XD9AZ:(,JqgPt*Yb[tdS6?oe:)g&hY3^B33WMd0H[,;CZBY2r+JmL=7&iJgOVLu\=$I'#`MEN$[)]b0\_::F4;QIMRa[B*W?W()6.odSu!<mr"`+I^<Y^V++m*V6OY-,_td0TQtGJ#4$X='S`bTVm"Vl`CVUQRKfE+=edJl9!lW>iFN$A"VUhCO>=78@!>aYC&Y;\gI?+aABEaNIg8q.iB!LpYK2U:hapkp&q0]&0Mn9t/KJ^%dK&8G*X:OX=7O3F["rmg1!R'o$RU8,jt`rRe#niW?Ks@i;e/h;K_X(kGj8J[G^rc:f@=n<ojR+"i,qX76th\GpZ>4Za\A?nFq:0Z8R:(CRM:L94fQ@^#(iQuIj#<\]o:@=@kq,"/Ae0O>d8]J^;(h>r)hAKtun%=VZWPFXB.T-@nck2G,";QOBs1s-h7du&t8Z#O3n-_/9Q1e3\iQppuP+I_m&Z%@dIPl#;WGiB4dM:fM-cWUJ;@Q:n8k/R]R_2GeWZoW*&j246bj#0(+DAu[+G)Yd#[qU!?:.CGSRb_TOJc[V[g@au?<2@u%],n^IMU)Ui,08&;*(!OS$n->@n#GuQ9^n%)/35F!'uc$Z-&Y)s6\JPoJp^7'dlbhm*i6P.r;pMG&K=Xj`*oLPp2I8mj^du9&=q0Zlp65^B(<>u3(eNlq?=rBRKV<C0oo\efI6,Ejqf.MEFDQ>W`hD24_r/rVR'qsU!"jR8XQIG`U?K[![@iOAo7Cp).T?nrm=jC*:MMN`k:TX=I;-/GJ/e-SP^cUk&]!C?$`<n@Z29]Mrc47iMg^fk%N'$N'=P5BCfM+!be^V=1TFA-'IBMX@^0)1:^d^hlS@Ml)jDkpO\HKe)>$f9rBm.BfXM0Sp8g$-Zkc$ZCDoWQie%LZU^I,k`*Qj=5YT$SQGjd!r#G.]P^CiY4-9\lWrW<6HC5gIk9[5/(Ek2&Epdm[+bD[g:8pZoXZbk^;:qs;u5/IrJe-R*$nP8L[?=p2Khu:G.:dMSCOmjf)fRjg%M]a[O!`)FDq"?KGRYjYngq`E1N[<)pAM9Y89"LUV0ipZn_B?<Gbn[CS!RVg$XNudpb85!IIXK@oL!?Ffh5`nO+r7g6]Aq<fC;dXo<Bc`8"&ZBu#[rCQCs$,u-7;rR!%f&Rjt>mZ6"0EcR:*lUk8AFuQdsg6d9S@e+nae*/OtfQI2+Z*Bqf3rb7hNQkLi=Y@@PI7]dcBb#"BNkum"HIR6MGbh+fcppLL7-`ktV`$\Yl%W[`C0:"4ptL1o2t7NNe!h=[ZP%&"KXC)o,Eu+F07m_8kpV'SELbjl1eSBM[ABCeP7bD'/OnlLGb#5)ULqoKqUtabP.uL$rXfNP5QZG'Z5J"?-RSp5I/.)dAd2J;144ZE-37(;:CL!N8>coh-$1]^frGt)e"c+2HG6H@l!O2CiZJ#(9`Y~>endstream
 endobj
 12 0 obj
 <<
@@ -122,12 +122,12 @@ xref
 0000001479 00000 n 
 0000001740 00000 n 
 0000001812 00000 n 
-0000003931 00000 n 
-0000006180 00000 n 
+0000004034 00000 n 
+0000006283 00000 n 
 trailer
 <<
 /ID 
-[<f4804b30ec3baa1c95bd7ef56b7581d9><f4804b30ec3baa1c95bd7ef56b7581d9>]
+[<93cc9b310d96b240019cd7cc487d213a><93cc9b310d96b240019cd7cc487d213a>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 9 0 R
@@ -135,5 +135,5 @@ trailer
 /Size 14
 >>
 startxref
-9077
+9180
 %%EOF

--- a/graph_pdf/sample_generator.py
+++ b/graph_pdf/sample_generator.py
@@ -226,14 +226,20 @@ class DemoPdfBuilder:
         self.canvas.setFillColor(colors.black)
         self.canvas.setFont("Helvetica", 11)
 
-        estimated_height = len(lines) * line_height
-        self._ensure_space(estimated_height)
-
+        wrapped_items: List[Tuple[str, int]] = []
         for item in lines:
             indent = 0
             text = item
             if isinstance(item, tuple):
                 text, indent = item
+            available_width = self.width - (self.margin_x * 2) - indent
+            wrapped_lines = _wrap_visual_line(str(text), max(available_width, 48.0), "Helvetica", 11)
+            wrapped_items.extend((wrapped_line, indent) for wrapped_line in wrapped_lines)
+
+        estimated_height = len(wrapped_items) * line_height
+        self._ensure_space(estimated_height)
+
+        for text, indent in wrapped_items:
             self.canvas.drawString(self.margin_x + indent, self.cursor_y, text)
             self.cursor_y -= line_height
 

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -21,6 +21,7 @@ from extractor import (
     _is_gray_color,
     _is_non_watermark_obj,
     _looks_like_table,
+    _normalize_body_lines,
     _table_rejection_reason,
     _merge_horizontal_band_segments,
     _merge_vertical_band_segments,
@@ -138,6 +139,25 @@ class TableExtractionFormattingTests(unittest.TestCase):
     def test_hyphen_ended_line_does_not_absorb_next_bullet(self) -> None:
         cell = "review-\n- next item"
         self.assertEqual(["review-", "- next item"], _normalize_cell_lines(cell))
+
+    def test_normalize_body_lines_joins_wrapped_sentence_lines(self) -> None:
+        lines = [
+            "This paragraph starts on one visual line and",
+            "continues on the next extracted line without punctuation",
+            "- bullet item should stay separate",
+            "Chapter 2: Heading stays separate",
+            "The next paragraph also starts cleanly.",
+        ]
+
+        self.assertEqual(
+            [
+                "This paragraph starts on one visual line and continues on the next extracted line without punctuation",
+                "- bullet item should stay separate",
+                "Chapter 2: Heading stays separate",
+                "The next paragraph also starts cleanly.",
+            ],
+            _normalize_body_lines(lines),
+        )
 
     def test_parse_pages_spec_supports_ranges_and_lists(self) -> None:
         self.assertEqual([1, 3, 4, 5, 8], _parse_pages_spec("1,3-5,8"))
@@ -562,6 +582,10 @@ class TableExtractionFormattingTests(unittest.TestCase):
         result = self._extract_result()
         markdown = result["markdown"]
         self.assertIn("Chapter 1: Deep Structure Verification", markdown)
+        self.assertIn(
+            "This intentionally verbose sentence exists to force a visual wrap in the sample PDF while still representing single logical sentence for downstream language-model parsing and retrieval quality checks across extracted body text.",
+            markdown,
+        )
         self.assertNotIn("### Page 1 table 1", markdown)
         self.assertNotIn("| Item | Qty | Price |", markdown)
         self.assertNotIn("Phase A", markdown)
@@ -657,13 +681,22 @@ class TableExtractionFormattingTests(unittest.TestCase):
         debug_file = result["debug_file"]
         self.assertIsNotNone(debug_file)
         payload = json.loads(debug_file.read_text(encoding="utf-8"))
-        self.assertEqual(3, len(payload["pages"]))
+        with pdfplumber.open(str(pdf_path)) as pdf:
+            expected_page_count = len(pdf.pages)
+        self.assertEqual(expected_page_count, len(payload["pages"]))
         self.assertEqual(2, payload["pages"][0]["table_count"])
         self.assertEqual(6, payload["pages"][0]["tables"][0]["row_count"])
+        self.assertIn("text_debug", payload["pages"][0])
+        self.assertIn("raw_lines", payload["pages"][0]["text_debug"])
+        self.assertIn("normalized_lines", payload["pages"][0]["text_debug"])
+        self.assertGreaterEqual(
+            len(payload["pages"][0]["text_debug"]["raw_lines"]),
+            len(payload["pages"][0]["text_debug"]["normalized_lines"]),
+        )
         edge_debug_file = result["debug_edges_file"]
         self.assertIsNotNone(edge_debug_file)
         edge_payload = json.loads(edge_debug_file.read_text(encoding="utf-8"))
-        self.assertEqual(3, len(edge_payload["pages"]))
+        self.assertEqual(expected_page_count, len(edge_payload["pages"]))
         self.assertIn("all_horizontal_edges", edge_payload["pages"][0])
         self.assertIn("selected_horizontal_edges", edge_payload["pages"][0])
         self.assertIn("all_vertical_edges", edge_payload["pages"][0])


### PR DESCRIPTION
## Summary
- normalize wrapped body text lines so non-terminal sentence breaks are merged before markdown output
- add raw-vs-normalized body text debug payloads to debug output for inspection
- update the sample PDF body content to include a long wrapped sentence and keep the sample layout stable

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 run_demo.py
