### PR TITLE
Parse body text via layout blocks

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -485,44 +485,24 @@ def _extract_body_text_lines(
     footer_margin: float,
     excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
 ) -> Tuple[List[str], List[str]]:
-    body_top, body_bottom = _detect_body_bounds(page, header_margin=header_margin, footer_margin=footer_margin)
-    body_page = _filter_page_for_extraction(page)
+    line_payloads = _extract_body_word_lines(
+        page=page,
+        header_margin=header_margin,
+        footer_margin=footer_margin,
+        excluded_bboxes=excluded_bboxes,
+    )
+    raw_lines = [str(line["text"]) for line in line_payloads]
+    blocks = _build_body_blocks(line_payloads)
 
-    def _clean_lines(raw: str) -> List[str]:
-        lines = []
-        for line in (raw or "").splitlines():
-            fixed = _repair_watermark_bleed(line.strip())
-            if not fixed:
-                continue
-            if _is_layout_artifact(fixed):
-                continue
-            lines.append(fixed)
-        return lines
+    normalized_lines: List[str] = []
+    for block in blocks:
+        block_lines = [str(line["text"]) for line in block["lines"]]
+        if block["kind"] == "paragraph":
+            normalized_lines.extend(_normalize_body_lines(block_lines))
+        else:
+            normalized_lines.extend(block_lines)
 
-    excluded = []
-    for x0, top, x1, bottom in excluded_bboxes:
-        if bottom <= body_top or top >= body_bottom:
-            continue
-        excluded.append((max(body_top, top), min(body_bottom, bottom)))
-    excluded.sort()
-
-    slices: List[Tuple[float, float]] = []
-    cursor = body_top
-    for top, bottom in excluded:
-        if top > cursor:
-            slices.append((cursor, top))
-        cursor = max(cursor, bottom)
-    if cursor < body_bottom:
-        slices.append((cursor, body_bottom))
-
-    raw_lines: List[str] = []
-    for top, bottom in slices:
-        if bottom - top < 4:
-            continue
-        raw = body_page.crop((0, top, page.width, bottom)).extract_text(x_tolerance=1.5, y_tolerance=2) or ""
-        raw_lines.extend(_clean_lines(raw))
-
-    return raw_lines, _normalize_body_lines(raw_lines)
+    return raw_lines, normalized_lines
 
 
 def _merge_cells(table: Sequence[Sequence[str]]) -> List[List[str]]:
@@ -564,6 +544,115 @@ def _is_body_heading_line(line: str) -> bool:
     if not text:
         return False
     return bool(re.match(r"^(?:chapter|section|appendix)\b", text, flags=re.IGNORECASE))
+
+
+def _line_kind(line: dict) -> str:
+    text = str(line.get("text") or "").strip()
+    if _is_bullet_line(text):
+        return "list"
+    if _is_body_heading_line(text):
+        return "heading"
+    return "paragraph"
+
+
+def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
+    if not lines:
+        return []
+
+    blocks: List[dict] = []
+    current_block: dict | None = None
+
+    for line in lines:
+        kind = _line_kind(line)
+        if current_block is None:
+            current_block = {"kind": kind, "lines": [line]}
+            continue
+
+        previous = current_block["lines"][-1]
+        same_kind = current_block["kind"] == kind
+        indent_close = abs(float(line.get("x0", 0.0)) - float(previous.get("x0", 0.0))) <= 8.0
+        size_close = abs(float(line.get("size", 0.0)) - float(previous.get("size", 0.0))) <= 0.8
+        line_gap = float(line.get("top", 0.0)) - float(previous.get("bottom", 0.0))
+        gap_close = line_gap <= max(6.0, float(previous.get("size", 0.0)) * 0.9)
+
+        if same_kind and indent_close and size_close and gap_close and kind == "paragraph":
+            current_block["lines"].append(line)
+            continue
+
+        blocks.append(current_block)
+        current_block = {"kind": kind, "lines": [line]}
+
+    if current_block is not None:
+        blocks.append(current_block)
+
+    return blocks
+
+
+def _extract_body_word_lines(
+    page: "pdfplumber.page.Page",
+    header_margin: float,
+    footer_margin: float,
+    excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
+) -> List[dict]:
+    filtered_page = _filter_page_for_extraction(page)
+    body_top, body_bottom = _detect_body_bounds(page, header_margin=header_margin, footer_margin=footer_margin)
+    words = filtered_page.extract_words(
+        x_tolerance=1.5,
+        y_tolerance=2.0,
+        keep_blank_chars=False,
+        extra_attrs=["size", "fontname"],
+    ) or []
+
+    def _word_bbox(word: dict) -> Tuple[float, float, float, float]:
+        top = float(word.get("top", 0.0))
+        bottom = float(word.get("bottom", top))
+        return (
+            float(word.get("x0", 0.0)),
+            top,
+            float(word.get("x1", 0.0)),
+            bottom,
+        )
+
+    def _word_in_body(word: dict) -> bool:
+        bbox = _word_bbox(word)
+        if bbox[3] <= body_top or bbox[1] >= body_bottom:
+            return False
+        return not any(_bboxes_intersect(bbox, excluded_bbox) for excluded_bbox in excluded_bboxes)
+
+    filtered_words = [word for word in words if _word_in_body(word)]
+    grouped_lines: List[List[dict]] = []
+    for word in sorted(filtered_words, key=lambda item: (float(item.get("top", 0.0)), float(item.get("x0", 0.0)))):
+        cleaned = _repair_watermark_bleed(str(word.get("text") or "").strip())
+        if not cleaned or _is_layout_artifact(cleaned):
+            continue
+        if not grouped_lines or abs(float(word.get("top", 0.0)) - float(grouped_lines[-1][0].get("top", 0.0))) > 2.5:
+            grouped_lines.append([word])
+            continue
+        grouped_lines[-1].append(word)
+
+    lines: List[dict] = []
+    for words_in_line in grouped_lines:
+        ordered = sorted(words_in_line, key=lambda item: float(item.get("x0", 0.0)))
+        text_parts = []
+        for word in ordered:
+            cleaned = _repair_watermark_bleed(str(word.get("text") or "").strip())
+            if cleaned:
+                text_parts.append(cleaned)
+        text = " ".join(text_parts).strip()
+        if not text or _is_layout_artifact(text):
+            continue
+        lines.append(
+            {
+                "text": text,
+                "x0": float(ordered[0].get("x0", 0.0)),
+                "x1": float(ordered[-1].get("x1", 0.0)),
+                "top": min(float(word.get("top", 0.0)) for word in ordered),
+                "bottom": max(float(word.get("bottom", 0.0)) for word in ordered),
+                "size": sum(float(word.get("size", 0.0)) for word in ordered) / max(len(ordered), 1),
+            }
+        )
+
+    return lines
 
 
 def _normalize_body_lines(lines: Sequence[str]) -> List[str]:

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -78,7 +78,7 @@ endobj
 endobj
 9 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260317133712+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260317133712+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260317135127+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260317135127+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -127,7 +127,7 @@ xref
 trailer
 <<
 /ID 
-[<93cc9b310d96b240019cd7cc487d213a><93cc9b310d96b240019cd7cc487d213a>]
+[<d8dc9bcb7b71fa4aed5c6660d9d514c1><d8dc9bcb7b71fa4aed5c6660d9d514c1>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 9 0 R

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pdfplumber
 
 from extractor import (
+    _build_body_blocks,
     _collapse_structural_triplet_columns,
     _detect_body_bounds,
     _char_rotation_degrees,
@@ -157,6 +158,25 @@ class TableExtractionFormattingTests(unittest.TestCase):
                 "The next paragraph also starts cleanly.",
             ],
             _normalize_body_lines(lines),
+        )
+
+    def test_build_body_blocks_splits_heading_paragraph_and_list(self) -> None:
+        lines = [
+            {"text": "Chapter 1: Deep Structure Verification", "x0": 36.0, "x1": 260.0, "top": 90.0, "bottom": 102.0, "size": 14.0},
+            {"text": "This paragraph starts on one extracted line", "x0": 36.0, "x1": 320.0, "top": 118.0, "bottom": 130.0, "size": 11.0},
+            {"text": "and continues on the next extracted line", "x0": 36.0, "x1": 310.0, "top": 132.0, "bottom": 144.0, "size": 11.0},
+            {"text": "- bullet item", "x0": 48.0, "x1": 120.0, "top": 160.0, "bottom": 172.0, "size": 11.0},
+        ]
+
+        blocks = _build_body_blocks(lines)
+
+        self.assertEqual(
+            [
+                {"kind": "heading", "lines": ["Chapter 1: Deep Structure Verification"]},
+                {"kind": "paragraph", "lines": ["This paragraph starts on one extracted line", "and continues on the next extracted line"]},
+                {"kind": "list", "lines": ["- bullet item"]},
+            ],
+            [{"kind": block["kind"], "lines": [line["text"] for line in block["lines"]]} for block in blocks],
         )
 
     def test_parse_pages_spec_supports_ranges_and_lists(self) -> None:


### PR DESCRIPTION
## Summary
- reconstruct body text from words into lines and layout blocks before paragraph normalization
- separate heading, paragraph, and list blocks so body joining logic no longer flattens everything into one stream
- keep debug output aligned with the new body parsing path and refresh the sample PDF artifact

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 run_demo.py
