### PR TITLE
Split body text blocks on style changes

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -555,6 +555,19 @@ def _line_kind(line: dict) -> str:
     return "paragraph"
 
 
+def _style_signature(line: dict) -> tuple:
+    color = line.get("color")
+    normalized_color = None
+    if isinstance(color, tuple):
+        normalized_color = tuple(round(float(value), 3) for value in color[:3])
+    return (
+        str(line.get("fontname") or ""),
+        bool(line.get("is_bold")),
+        bool(line.get("is_italic")),
+        normalized_color,
+    )
+
+
 def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
     if not lines:
         return []
@@ -574,8 +587,9 @@ def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
         size_close = abs(float(line.get("size", 0.0)) - float(previous.get("size", 0.0))) <= 0.8
         line_gap = float(line.get("top", 0.0)) - float(previous.get("bottom", 0.0))
         gap_close = line_gap <= max(6.0, float(previous.get("size", 0.0)) * 0.9)
+        style_close = _style_signature(line) == _style_signature(previous)
 
-        if same_kind and indent_close and size_close and gap_close and kind == "paragraph":
+        if same_kind and indent_close and size_close and gap_close and style_close and kind == "paragraph":
             current_block["lines"].append(line)
             continue
 
@@ -641,6 +655,14 @@ def _extract_body_word_lines(
         text = " ".join(text_parts).strip()
         if not text or _is_layout_artifact(text):
             continue
+        fontnames = [str(word.get("fontname") or "") for word in ordered if str(word.get("fontname") or "")]
+        dominant_font = max(fontnames, key=fontnames.count) if fontnames else ""
+        colors = [word.get("non_stroking_color") or word.get("stroking_color") for word in ordered]
+        normalized_colors = [color for color in colors if isinstance(color, tuple) and len(color) >= 3]
+        dominant_color = None
+        if normalized_colors:
+            color_keys = [tuple(round(float(value), 3) for value in color[:3]) for color in normalized_colors]
+            dominant_color = max(color_keys, key=color_keys.count)
         lines.append(
             {
                 "text": text,
@@ -649,6 +671,10 @@ def _extract_body_word_lines(
                 "top": min(float(word.get("top", 0.0)) for word in ordered),
                 "bottom": max(float(word.get("bottom", 0.0)) for word in ordered),
                 "size": sum(float(word.get("size", 0.0)) for word in ordered) / max(len(ordered), 1),
+                "fontname": dominant_font,
+                "color": dominant_color,
+                "is_bold": bool(re.search(r"bold", dominant_font, flags=re.IGNORECASE)),
+                "is_italic": bool(re.search(r"(italic|oblique)", dominant_font, flags=re.IGNORECASE)),
             }
         )
 

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -78,7 +78,7 @@ endobj
 endobj
 9 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260317135127+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260317135127+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260317140353+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260317140353+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -127,7 +127,7 @@ xref
 trailer
 <<
 /ID 
-[<d8dc9bcb7b71fa4aed5c6660d9d514c1><d8dc9bcb7b71fa4aed5c6660d9d514c1>]
+[<d2d4df6a09c689eca9d312c9464e845d><d2d4df6a09c689eca9d312c9464e845d>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 9 0 R

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -162,10 +162,10 @@ class TableExtractionFormattingTests(unittest.TestCase):
 
     def test_build_body_blocks_splits_heading_paragraph_and_list(self) -> None:
         lines = [
-            {"text": "Chapter 1: Deep Structure Verification", "x0": 36.0, "x1": 260.0, "top": 90.0, "bottom": 102.0, "size": 14.0},
-            {"text": "This paragraph starts on one extracted line", "x0": 36.0, "x1": 320.0, "top": 118.0, "bottom": 130.0, "size": 11.0},
-            {"text": "and continues on the next extracted line", "x0": 36.0, "x1": 310.0, "top": 132.0, "bottom": 144.0, "size": 11.0},
-            {"text": "- bullet item", "x0": 48.0, "x1": 120.0, "top": 160.0, "bottom": 172.0, "size": 11.0},
+            {"text": "Chapter 1: Deep Structure Verification", "x0": 36.0, "x1": 260.0, "top": 90.0, "bottom": 102.0, "size": 14.0, "fontname": "Helvetica-Bold", "color": (0.0, 0.0, 0.0), "is_bold": True, "is_italic": False},
+            {"text": "This paragraph starts on one extracted line", "x0": 36.0, "x1": 320.0, "top": 118.0, "bottom": 130.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False},
+            {"text": "and continues on the next extracted line", "x0": 36.0, "x1": 310.0, "top": 132.0, "bottom": 144.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False},
+            {"text": "- bullet item", "x0": 48.0, "x1": 120.0, "top": 160.0, "bottom": 172.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False},
         ]
 
         blocks = _build_body_blocks(lines)
@@ -178,6 +178,30 @@ class TableExtractionFormattingTests(unittest.TestCase):
             ],
             [{"kind": block["kind"], "lines": [line["text"] for line in block["lines"]]} for block in blocks],
         )
+
+    def test_build_body_blocks_splits_when_color_changes_between_lines(self) -> None:
+        lines = [
+            {"text": "First paragraph line", "x0": 36.0, "x1": 220.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False},
+            {"text": "Second line with different color", "x0": 36.0, "x1": 250.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Helvetica", "color": (0.4, 0.4, 0.4), "is_bold": False, "is_italic": False},
+        ]
+
+        blocks = _build_body_blocks(lines)
+
+        self.assertEqual(2, len(blocks))
+        self.assertEqual(["First paragraph line"], [line["text"] for line in blocks[0]["lines"]])
+        self.assertEqual(["Second line with different color"], [line["text"] for line in blocks[1]["lines"]])
+
+    def test_build_body_blocks_splits_when_bold_changes_between_lines(self) -> None:
+        lines = [
+            {"text": "Regular line", "x0": 36.0, "x1": 140.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False},
+            {"text": "Bold line", "x0": 36.0, "x1": 120.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Helvetica-Bold", "color": (0.0, 0.0, 0.0), "is_bold": True, "is_italic": False},
+        ]
+
+        blocks = _build_body_blocks(lines)
+
+        self.assertEqual(2, len(blocks))
+        self.assertEqual(["Regular line"], [line["text"] for line in blocks[0]["lines"]])
+        self.assertEqual(["Bold line"], [line["text"] for line in blocks[1]["lines"]])
 
     def test_parse_pages_spec_supports_ranges_and_lists(self) -> None:
         self.assertEqual([1, 3, 4, 5, 8], _parse_pages_spec("1,3-5,8"))


### PR DESCRIPTION
## Summary
- carry representative font and color style metadata onto reconstructed body lines
- stop merging paragraph blocks across line-to-line style changes such as color, bold, or italic differences
- add regression coverage for color and bold block boundaries and refresh the sample PDF artifact

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 run_demo.py
