### PR TITLE
Detect chapter titles as body-start fallback

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -434,6 +434,46 @@ def _filter_page_for_extraction(page: "pdfplumber.page.Page") -> "pdfplumber.pag
     return page.filter(_is_non_watermark_obj)
 
 
+def _detect_chapter_body_top(page: "pdfplumber.page.Page") -> float | None:
+    extract_words = getattr(page, "extract_words", None)
+    if not callable(extract_words):
+        return None
+
+    words = extract_words(
+        x_tolerance=1.5,
+        y_tolerance=2.0,
+        keep_blank_chars=False,
+        extra_attrs=["size", "fontname"],
+    ) or []
+    if not words:
+        return None
+
+    grouped_lines: List[List[dict]] = []
+    for word in sorted(words, key=lambda item: (float(item.get("top", 0.0)), float(item.get("x0", 0.0)))):
+        if not grouped_lines or abs(float(word.get("top", 0.0)) - float(grouped_lines[-1][0].get("top", 0.0))) > 2.5:
+            grouped_lines.append([word])
+            continue
+        grouped_lines[-1].append(word)
+
+    page_top_limit = float(page.height) * 0.25
+    for words_in_line in grouped_lines:
+        ordered = sorted(words_in_line, key=lambda item: float(item.get("x0", 0.0)))
+        text = " ".join(str(word.get("text") or "").strip() for word in ordered).strip()
+        if not text:
+            continue
+        top = min(float(word.get("top", 0.0)) for word in ordered)
+        if top > page_top_limit:
+            continue
+        avg_size = sum(float(word.get("size", 0.0)) for word in ordered) / max(len(ordered), 1)
+        if avg_size < 20.0:
+            continue
+        if not re.search(r"\b(chapter|section|appendix)\b", text, flags=re.IGNORECASE):
+            continue
+        return top
+
+    return None
+
+
 def _detect_body_bounds(
     page: "pdfplumber.page.Page",
     header_margin: float,
@@ -458,6 +498,11 @@ def _detect_body_bounds(
 
     body_top = min((float(edge["top"]) for edge in top_candidates), default=default_top)
     body_bottom = max((float(edge["top"]) for edge in bottom_candidates), default=default_bottom)
+
+    if not top_candidates:
+        chapter_top = _detect_chapter_body_top(page)
+        if chapter_top is not None:
+            body_top = chapter_top
 
     if body_bottom <= body_top:
         return default_top, default_bottom

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -78,7 +78,7 @@ endobj
 endobj
 9 0 obj
 <<
-/Author (anonymous) /CreationDate (D:20260317140353+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260317140353+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (anonymous) /CreationDate (D:20260317142616+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260317142616+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
@@ -127,7 +127,7 @@ xref
 trailer
 <<
 /ID 
-[<d2d4df6a09c689eca9d312c9464e845d><d2d4df6a09c689eca9d312c9464e845d>]
+[<96009fa78c4e1acebb3f40d0c147ed56><96009fa78c4e1acebb3f40d0c147ed56>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 9 0 R

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -312,6 +312,58 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertEqual(40.0, body_top)
         self.assertEqual(710.0, body_bottom)
 
+    def test_detect_body_bounds_uses_large_chapter_line_when_no_top_divider_exists(self) -> None:
+        page = SimpleNamespace(
+            width=600.0,
+            height=800.0,
+            horizontal_edges=[
+                {"x0": 35.0, "x1": 565.0, "top": 742.0},
+            ],
+            extract_words=lambda **kwargs: [
+                {
+                    "text": "Chapter",
+                    "x0": 36.0,
+                    "x1": 110.0,
+                    "top": 96.0,
+                    "bottom": 114.0,
+                    "size": 20.0,
+                    "fontname": "Helvetica-Bold",
+                },
+                {
+                    "text": "3:",
+                    "x0": 118.0,
+                    "x1": 140.0,
+                    "top": 96.0,
+                    "bottom": 114.0,
+                    "size": 20.0,
+                    "fontname": "Helvetica-Bold",
+                },
+                {
+                    "text": "New",
+                    "x0": 148.0,
+                    "x1": 190.0,
+                    "top": 96.0,
+                    "bottom": 114.0,
+                    "size": 20.0,
+                    "fontname": "Helvetica-Bold",
+                },
+                {
+                    "text": "Section",
+                    "x0": 198.0,
+                    "x1": 260.0,
+                    "top": 96.0,
+                    "bottom": 114.0,
+                    "size": 20.0,
+                    "fontname": "Helvetica-Bold",
+                },
+            ],
+        )
+
+        body_top, body_bottom = _detect_body_bounds(page, header_margin=90.0, footer_margin=40.0)
+
+        self.assertEqual(96.0, body_top)
+        self.assertEqual(742.0, body_bottom)
+
     def test_continuation_regions_merge_when_near_footer_header_with_shared_axes(self) -> None:
         prev_bbox = (100.0, 620.0, 400.0, 705.0)
         curr_bbox = (102.0, 88.0, 402.0, 190.0)


### PR DESCRIPTION
## Summary
- add a body-start fallback that treats large top-of-page chapter/section/appendix lines as the body start when no top divider exists
- keep divider-based body bound detection as the primary path and only use the chapter fallback when needed
- add regression coverage for the chapter fallback case and refresh the sample PDF artifact

## Validation
- python3 -m unittest -q
- python3 verify.py
