### PR TITLE
Detect hollow and broken bullet glyphs in text normalization

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -16,6 +16,9 @@ WATERMARK_ROTATION_MAX_DEGREES = 57.0
 WATERMARK_GRAY_MIN = 0.88
 WATERMARK_GRAY_MAX = 0.96
 WATERMARK_GRAY_NEUTRAL_TOLERANCE = 0.03
+BULLET_PREFIX_RE = re.compile(
+    r"^(?:[-*•●○◦◯▪▫■□‣∙◉]|[0-9]+[.)]|o|\?|\uFFFD)\s+"
+)
 
 
 def _parse_pages_spec(spec: str) -> List[int]:
@@ -577,7 +580,7 @@ def _remove_watermark_fragment_lines(lines: Sequence[str]) -> List[str]:
 
 
 def _is_bullet_line(line: str) -> bool:
-    return bool(re.match(r"^(?:[-*•]|[0-9]+[.)])\s+", line))
+    return bool(BULLET_PREFIX_RE.match(str(line or "").strip()))
 
 
 def _ends_sentence(line: str) -> bool:

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -142,6 +142,22 @@ class TableExtractionFormattingTests(unittest.TestCase):
         cell = "review-\n- next item"
         self.assertEqual(["review-", "- next item"], _normalize_cell_lines(cell))
 
+    def test_hollow_circle_like_o_is_treated_as_bullet(self) -> None:
+        cell = "review-\no next item"
+        self.assertEqual(["review-", "o next item"], _normalize_cell_lines(cell))
+        self.assertEqual(
+            ["Wrapped sentence line", "o next item"],
+            _normalize_body_lines(["Wrapped sentence line", "o next item"]),
+        )
+
+    def test_unknown_glyph_like_question_mark_is_treated_as_bullet(self) -> None:
+        cell = "review-\n? next item"
+        self.assertEqual(["review-", "? next item"], _normalize_cell_lines(cell))
+        self.assertEqual(
+            ["Wrapped sentence line", "? next item"],
+            _normalize_body_lines(["Wrapped sentence line", "? next item"]),
+        )
+
     def test_normalize_body_lines_joins_wrapped_sentence_lines(self) -> None:
         lines = [
             "This paragraph starts on one visual line and",


### PR DESCRIPTION
## Summary
- expand bullet prefix detection so hollow-circle bullets and broken glyph bullets are treated as list items
- prevent those lines from being merged into the previous wrapped sentence in both body and table-cell normalization
- add regression tests for hollow bullets rendered like o and broken glyph bullets rendered like ?

## Validation
- python3 -m unittest -q
- python3 verify.py