### PR TITLE
Preserve list item continuations by indent and text alignment

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -544,10 +544,13 @@ def _extract_body_text_lines(
 
     normalized_lines: List[str] = []
     for block in blocks:
-        block_lines = [str(line["text"]) for line in block["lines"]]
         if block["kind"] == "paragraph":
+            block_lines = [str(line["text"]) for line in block["lines"]]
             normalized_lines.extend(_normalize_body_lines(block_lines))
+        elif block["kind"] == "list":
+            normalized_lines.extend(_normalize_list_block_lines(block["lines"]))
         else:
+            block_lines = [str(line["text"]) for line in block["lines"]]
             normalized_lines.extend(block_lines)
 
     return raw_lines, normalized_lines
@@ -583,6 +586,10 @@ def _is_bullet_line(line: str) -> bool:
     return bool(BULLET_PREFIX_RE.match(str(line or "").strip()))
 
 
+def _is_bullet_marker_text(text: str) -> bool:
+    return bool(BULLET_PREFIX_RE.match(f"{str(text or '').strip()} x"))
+
+
 def _ends_sentence(line: str) -> bool:
     return bool(re.search(r"[.!?;:。！？]$" , str(line or "").strip()))
 
@@ -616,6 +623,48 @@ def _style_signature(line: dict) -> tuple:
     )
 
 
+def _is_list_continuation_line(line: dict, previous: dict, anchor_x: float) -> bool:
+    text = str(line.get("text") or "").strip()
+    if not text or _is_bullet_line(text) or _is_body_heading_line(text):
+        return False
+
+    line_gap = float(line.get("top", 0.0)) - float(previous.get("bottom", 0.0))
+    gap_close = line_gap <= max(6.0, float(previous.get("size", 0.0)) * 0.9)
+    size_close = abs(float(line.get("size", 0.0)) - float(previous.get("size", 0.0))) <= 0.8
+    style_close = _style_signature(line) == _style_signature(previous)
+    indent_x = float(line.get("x0", 0.0))
+    aligned_with_text = abs(indent_x - anchor_x) <= 8.0
+    further_indented = indent_x > anchor_x
+    return gap_close and size_close and style_close and (aligned_with_text or further_indented)
+
+
+def _normalize_list_block_lines(lines: Sequence[dict]) -> List[str]:
+    normalized: List[str] = []
+    current_item: str | None = None
+
+    for line in lines:
+        text = str(line.get("text") or "").strip()
+        if not text:
+            continue
+        if _is_bullet_line(text):
+            if current_item:
+                normalized.append(current_item)
+            current_item = text
+            continue
+        if current_item and current_item.endswith("-"):
+            current_item = f"{current_item}{text}".strip()
+            continue
+        if current_item:
+            current_item = f"{current_item} {text}".strip()
+            continue
+        normalized.append(text)
+
+    if current_item:
+        normalized.append(current_item)
+
+    return normalized
+
+
 def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
     if not lines:
         return []
@@ -626,7 +675,11 @@ def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
     for line in lines:
         kind = _line_kind(line)
         if current_block is None:
-            current_block = {"kind": kind, "lines": [line]}
+            current_block = {
+                "kind": kind,
+                "lines": [line],
+                "list_text_start_x": float(line.get("text_start_x", line.get("x0", 0.0))),
+            }
             continue
 
         previous = current_block["lines"][-1]
@@ -636,13 +689,28 @@ def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
         line_gap = float(line.get("top", 0.0)) - float(previous.get("bottom", 0.0))
         gap_close = line_gap <= max(6.0, float(previous.get("size", 0.0)) * 0.9)
         style_close = _style_signature(line) == _style_signature(previous)
+        list_anchor_x = float(
+            current_block.get("list_text_start_x", previous.get("text_start_x", previous.get("x0", 0.0)))
+        )
 
         if same_kind and indent_close and size_close and gap_close and style_close and kind == "paragraph":
             current_block["lines"].append(line)
             continue
+        if current_block["kind"] == "list":
+            if kind == "list" and size_close and gap_close and style_close:
+                current_block["lines"].append(line)
+                current_block["list_text_start_x"] = float(line.get("text_start_x", list_anchor_x))
+                continue
+            if _is_list_continuation_line(line, previous, list_anchor_x):
+                current_block["lines"].append(line)
+                continue
 
         blocks.append(current_block)
-        current_block = {"kind": kind, "lines": [line]}
+        current_block = {
+            "kind": kind,
+            "lines": [line],
+            "list_text_start_x": float(line.get("text_start_x", line.get("x0", 0.0))),
+        }
 
     if current_block is not None:
         blocks.append(current_block)
@@ -711,6 +779,14 @@ def _extract_body_word_lines(
         if normalized_colors:
             color_keys = [tuple(round(float(value), 3) for value in color[:3]) for color in normalized_colors]
             dominant_color = max(color_keys, key=color_keys.count)
+        first_non_bullet_word = next(
+            (
+                word
+                for word in ordered
+                if not _is_bullet_marker_text(_repair_watermark_bleed(str(word.get("text") or "").strip()))
+            ),
+            ordered[0],
+        )
         lines.append(
             {
                 "text": text,
@@ -723,6 +799,7 @@ def _extract_body_word_lines(
                 "color": dominant_color,
                 "is_bold": bool(re.search(r"bold", dominant_font, flags=re.IGNORECASE)),
                 "is_italic": bool(re.search(r"(italic|oblique)", dominant_font, flags=re.IGNORECASE)),
+                "text_start_x": float(first_non_bullet_word.get("x0", ordered[0].get("x0", 0.0))),
             }
         )
 

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -23,6 +23,7 @@ from extractor import (
     _is_gray_color,
     _is_non_watermark_obj,
     _looks_like_table,
+    _normalize_list_block_lines,
     _normalize_body_lines,
     _table_rejection_reason,
     _merge_horizontal_band_segments,
@@ -219,6 +220,47 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertEqual(2, len(blocks))
         self.assertEqual(["Regular line"], [line["text"] for line in blocks[0]["lines"]])
         self.assertEqual(["Bold line"], [line["text"] for line in blocks[1]["lines"]])
+
+    def test_build_body_blocks_keeps_bullet_continuation_aligned_with_text_start(self) -> None:
+        lines = [
+            {"text": "- bullet item starts here", "x0": 48.0, "x1": 220.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0},
+            {"text": "and continues aligned with item text", "x0": 64.0, "x1": 260.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0},
+        ]
+
+        blocks = _build_body_blocks(lines)
+
+        self.assertEqual(1, len(blocks))
+        self.assertEqual("list", blocks[0]["kind"])
+        self.assertEqual(
+            ["- bullet item starts here", "and continues aligned with item text"],
+            [line["text"] for line in blocks[0]["lines"]],
+        )
+
+    def test_build_body_blocks_keeps_bullet_continuation_when_further_indented(self) -> None:
+        lines = [
+            {"text": "- bullet item starts here", "x0": 48.0, "x1": 220.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0},
+            {"text": "continuation under the bullet body", "x0": 72.0, "x1": 260.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 72.0},
+        ]
+
+        blocks = _build_body_blocks(lines)
+
+        self.assertEqual(1, len(blocks))
+        self.assertEqual("list", blocks[0]["kind"])
+
+    def test_normalize_list_block_lines_merges_continuation_lines_into_item(self) -> None:
+        lines = [
+            {"text": "- bullet item starts here", "x0": 48.0, "x1": 220.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0},
+            {"text": "and continues aligned with item text", "x0": 64.0, "x1": 260.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0},
+            {"text": "- next bullet", "x0": 48.0, "x1": 130.0, "top": 160.0, "bottom": 172.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0},
+        ]
+
+        self.assertEqual(
+            [
+                "- bullet item starts here and continues aligned with item text",
+                "- next bullet",
+            ],
+            _normalize_list_block_lines(lines),
+        )
 
     def test_parse_pages_spec_supports_ranges_and_lists(self) -> None:
         self.assertEqual([1, 3, 4, 5, 8], _parse_pages_spec("1,3-5,8"))


### PR DESCRIPTION
## Summary
- treat non-bullet lines aligned with a bullet item's text start as list-item continuations
- also keep more-indented continuation lines within the same list item block
- normalize list blocks into single markdown bullet lines with regression tests

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 run_demo.py