### PR TITLE
Handle diamond bullet markers and inline term wraps

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -17,7 +17,7 @@ WATERMARK_GRAY_MIN = 0.88
 WATERMARK_GRAY_MAX = 0.96
 WATERMARK_GRAY_NEUTRAL_TOLERANCE = 0.03
 BULLET_PREFIX_RE = re.compile(
-    r"^(?:[-*•●○◦◯▪▫■□‣∙◉]|[0-9]+[.)]|o|\?|\uFFFD)\s+"
+    r"^(?:[-*•●○◦◯▪▫■□◆◇◈◊‣∙◉]|[0-9]+[.)]|o|\?|\uFFFD)\s+"
 )
 
 
@@ -638,6 +638,14 @@ def _is_list_continuation_line(line: dict, previous: dict, anchor_x: float) -> b
     return gap_close and size_close and style_close and (aligned_with_text or further_indented)
 
 
+def _looks_like_inline_term_continuation(line: dict) -> bool:
+    text = str(line.get("text") or "").strip()
+    if not text:
+        return False
+    tokens = text.split()
+    return len(tokens) == 1 and not _ends_sentence(text)
+
+
 def _normalize_list_block_lines(lines: Sequence[dict]) -> List[str]:
     normalized: List[str] = []
     current_item: str | None = None
@@ -693,9 +701,11 @@ def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
             current_block.get("list_text_start_x", previous.get("text_start_x", previous.get("x0", 0.0)))
         )
 
-        if same_kind and indent_close and size_close and gap_close and style_close and kind == "paragraph":
-            current_block["lines"].append(line)
-            continue
+        if same_kind and indent_close and size_close and gap_close and kind == "paragraph":
+            sentence_continues = not _ends_sentence(str(previous.get("text") or "").strip())
+            if style_close or (sentence_continues and _looks_like_inline_term_continuation(line)):
+                current_block["lines"].append(line)
+                continue
         if current_block["kind"] == "list":
             if kind == "list" and size_close and gap_close and style_close:
                 current_block["lines"].append(line)

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -159,6 +159,14 @@ class TableExtractionFormattingTests(unittest.TestCase):
             _normalize_body_lines(["Wrapped sentence line", "? next item"]),
         )
 
+    def test_diamond_bullet_starts_new_item_instead_of_continuation(self) -> None:
+        cell = "review-\n◆ next item"
+        self.assertEqual(["review-", "◆ next item"], _normalize_cell_lines(cell))
+        self.assertEqual(
+            ["Wrapped sentence line", "◆ next item"],
+            _normalize_body_lines(["Wrapped sentence line", "◆ next item"]),
+        )
+
     def test_normalize_body_lines_joins_wrapped_sentence_lines(self) -> None:
         lines = [
             "This paragraph starts on one visual line and",
@@ -208,6 +216,21 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertEqual(2, len(blocks))
         self.assertEqual(["First paragraph line"], [line["text"] for line in blocks[0]["lines"]])
         self.assertEqual(["Second line with different color"], [line["text"] for line in blocks[1]["lines"]])
+
+    def test_build_body_blocks_keeps_paragraph_together_despite_style_change_when_sentence_continues(self) -> None:
+        lines = [
+            {"text": "This line introduces the uncommon term", "x0": 36.0, "x1": 260.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False},
+            {"text": "ProtoLexeme", "x0": 36.0, "x1": 130.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Helvetica-Bold", "color": (0.2, 0.2, 0.7), "is_bold": True, "is_italic": False},
+        ]
+
+        blocks = _build_body_blocks(lines)
+
+        self.assertEqual(1, len(blocks))
+        self.assertEqual("paragraph", blocks[0]["kind"])
+        self.assertEqual(
+            ["This line introduces the uncommon term", "ProtoLexeme"],
+            [line["text"] for line in blocks[0]["lines"]],
+        )
 
     def test_build_body_blocks_splits_when_bold_changes_between_lines(self) -> None:
         lines = [


### PR DESCRIPTION
## Summary
- recognize diamond-style bullet markers as new list items so they do not get merged into the previous bullet continuation
- keep a paragraph together when the next wrapped line is a single inline term with a style change and the sentence has not ended
- add regression tests for diamond bullets, inline term continuation, and existing style-split behavior

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 run_demo.py