### PR TITLE
Render markdown list markers by detected depth

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -653,15 +653,44 @@ def _looks_like_inline_term_continuation(line: dict) -> bool:
 def _normalize_list_block_lines(lines: Sequence[dict]) -> List[str]:
     normalized: List[str] = []
     current_item: str | None = None
+    current_depth = 0
+    marker_positions = sorted(
+        {
+            round(float(line.get("marker_x", line.get("x0", 0.0))), 2)
+            for line in lines
+            if bool(line.get("marker_candidate")) or _is_bullet_line(str(line.get("text") or "").strip())
+        }
+    )
+
+    def _item_prefix(depth: int) -> str:
+        markers = ["-", "*", "+"]
+        return f"{'  ' * depth}{markers[depth % len(markers)]} "
+
+    def _strip_marker_text(line: dict) -> str:
+        text = str(line.get("text") or "").strip()
+        if not text:
+            return text
+        parts = text.split(maxsplit=1)
+        if len(parts) == 1:
+            return ""
+        first = parts[0]
+        if bool(line.get("marker_candidate")) or _is_bullet_marker_text(first) or _is_bullet_line(text):
+            return parts[1].strip()
+        return text
 
     for line in lines:
         text = str(line.get("text") or "").strip()
         if not text:
             continue
-        if _is_bullet_line(text):
+        if bool(line.get("marker_candidate")) or _is_bullet_line(text):
             if current_item:
                 normalized.append(current_item)
-            current_item = text
+            marker_x = round(float(line.get("marker_x", line.get("x0", 0.0))), 2)
+            try:
+                current_depth = marker_positions.index(marker_x)
+            except ValueError:
+                current_depth = 0
+            current_item = f"{_item_prefix(current_depth)}{_strip_marker_text(line)}".rstrip()
             continue
         if current_item and current_item.endswith("-"):
             current_item = f"{current_item}{text}".strip()

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -292,15 +292,31 @@ class TableExtractionFormattingTests(unittest.TestCase):
 
     def test_normalize_list_block_lines_merges_continuation_lines_into_item(self) -> None:
         lines = [
-            {"text": "- bullet item starts here", "x0": 48.0, "x1": 220.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0},
+            {"text": "- bullet item starts here", "x0": 48.0, "x1": 220.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0, "marker_x": 48.0},
             {"text": "and continues aligned with item text", "x0": 64.0, "x1": 260.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0},
-            {"text": "- next bullet", "x0": 48.0, "x1": 130.0, "top": 160.0, "bottom": 172.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0},
+            {"text": "- next bullet", "x0": 48.0, "x1": 130.0, "top": 160.0, "bottom": 172.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0, "marker_x": 48.0},
         ]
 
         self.assertEqual(
             [
                 "- bullet item starts here and continues aligned with item text",
                 "- next bullet",
+            ],
+            _normalize_list_block_lines(lines),
+        )
+
+    def test_normalize_list_block_lines_uses_different_markers_per_depth(self) -> None:
+        lines = [
+            {"text": "? top level", "x0": 48.0, "x1": 120.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Symbol", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "marker_candidate": True, "marker_x": 48.0, "text_start_x": 64.0},
+            {"text": "o child level", "x0": 64.0, "x1": 132.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Symbol", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "marker_candidate": True, "marker_x": 64.0, "text_start_x": 80.0},
+            {"text": "◆ grandchild level", "x0": 80.0, "x1": 168.0, "top": 148.0, "bottom": 160.0, "size": 11.0, "fontname": "Symbol", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "marker_candidate": True, "marker_x": 80.0, "text_start_x": 96.0},
+        ]
+
+        self.assertEqual(
+            [
+                "- top level",
+                "  * child level",
+                "    + grandchild level",
             ],
             _normalize_list_block_lines(lines),
         )


### PR DESCRIPTION
## Summary
- convert inferred list markers into depth-aware markdown markers instead of preserving broken source glyphs
- derive list depth from marker x positions and emit -, *, + with nested indentation in normalized body output
- add regression tests for list item continuation and depth-specific marker rendering

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 run_demo.py