### PR TITLE
Use remaining line width before joining wrapped text

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -650,6 +650,15 @@ def _looks_like_inline_term_continuation(line: dict) -> bool:
     return bool(line.get("has_mixed_styles")) and int(line.get("word_count", 0)) >= 2
 
 
+def _has_room_for_next_line_start(previous: dict, line: dict) -> bool:
+    body_right = float(previous.get("body_right", previous.get("x1", 0.0)))
+    remaining_width = body_right - float(previous.get("x1", 0.0))
+    first_word_width = float(line.get("first_word_width", 0.0))
+    if first_word_width <= 0.0:
+        return False
+    return remaining_width >= first_word_width * 1.25
+
+
 def _normalize_list_block_lines(lines: Sequence[dict]) -> List[str]:
     normalized: List[str] = []
     current_item: str | None = None
@@ -736,7 +745,11 @@ def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
 
         if same_kind and indent_close and size_close and gap_close and kind == "paragraph":
             sentence_continues = not _ends_sentence(str(previous.get("text") or "").strip())
-            if style_close or (sentence_continues and _looks_like_inline_term_continuation(line)):
+            if style_close or (
+                sentence_continues
+                and _looks_like_inline_term_continuation(line)
+                and not _has_room_for_next_line_start(previous, line)
+            ):
                 current_block["lines"].append(line)
                 continue
         if current_block["kind"] == "list":
@@ -876,6 +889,8 @@ def _extract_body_word_lines(
                 "is_italic": bool(re.search(r"(italic|oblique)", dominant_font, flags=re.IGNORECASE)),
                 "marker_candidate": marker_candidate,
                 "text_start_x": float(first_non_bullet_word.get("x0", ordered[0].get("x0", 0.0))),
+                "first_word_width": float(first_non_bullet_word.get("x1", 0.0)) - float(first_non_bullet_word.get("x0", 0.0)),
+                "body_right": float(getattr(page, "width", 0.0)),
                 "word_count": len(ordered),
                 "has_mixed_styles": len(set(word_style_signatures)) > 1,
                 "first_word_style_signature": word_style_signatures[0] if word_style_signatures else None,

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -220,8 +220,8 @@ class TableExtractionFormattingTests(unittest.TestCase):
 
     def test_build_body_blocks_keeps_paragraph_together_despite_style_change_when_sentence_continues(self) -> None:
         lines = [
-            {"text": "This line introduces the uncommon term", "x0": 36.0, "x1": 260.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "word_count": 6, "has_mixed_styles": False, "first_word_style_signature": ("Helvetica", False, False, None)},
-            {"text": "ProtoLexeme expands into explanation", "x0": 36.0, "x1": 220.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Helvetica", "color": (0.2, 0.2, 0.7), "is_bold": False, "is_italic": False, "word_count": 4, "has_mixed_styles": True, "first_word_style_signature": ("Helvetica-Bold", True, False, None)},
+            {"text": "This line introduces the uncommon term", "x0": 36.0, "x1": 300.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "word_count": 6, "has_mixed_styles": False, "first_word_style_signature": ("Helvetica", False, False, None), "body_right": 320.0},
+            {"text": "ProtoLexeme expands into explanation", "x0": 36.0, "x1": 220.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Helvetica", "color": (0.2, 0.2, 0.7), "is_bold": False, "is_italic": False, "word_count": 4, "has_mixed_styles": True, "first_word_style_signature": ("Helvetica-Bold", True, False, None), "first_word_width": 36.0},
         ]
 
         blocks = _build_body_blocks(lines)
@@ -232,6 +232,16 @@ class TableExtractionFormattingTests(unittest.TestCase):
             ["This line introduces the uncommon term", "ProtoLexeme expands into explanation"],
             [line["text"] for line in blocks[0]["lines"]],
         )
+
+    def test_build_body_blocks_splits_when_previous_line_has_room_for_next_first_word(self) -> None:
+        lines = [
+            {"text": "Short lead-in text", "x0": 36.0, "x1": 140.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "word_count": 3, "has_mixed_styles": False, "first_word_style_signature": ("Helvetica", False, False, None), "body_right": 320.0},
+            {"text": "ProtoLexeme expands into explanation", "x0": 36.0, "x1": 220.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Helvetica", "color": (0.2, 0.2, 0.7), "is_bold": False, "is_italic": False, "word_count": 4, "has_mixed_styles": True, "first_word_style_signature": ("Helvetica-Bold", True, False, None), "first_word_width": 36.0},
+        ]
+
+        blocks = _build_body_blocks(lines)
+
+        self.assertEqual(2, len(blocks))
 
     def test_extract_body_word_lines_marks_marker_candidate_and_text_start(self) -> None:
         filtered_page = SimpleNamespace(


### PR DESCRIPTION
## Summary
- add remaining-width vs next-first-word-width checks before treating a mixed-style next line as wrapped continuation
- carry first-word width and body right-edge metadata on body line payloads
- add regression coverage for keeping true wraps together while splitting short lead-in lines that still had room for the next word

## Validation
- python3 -m unittest -q
- python3 verify.py
- python3 run_demo.py