### PR TITLE
Keep hyphen-wrapped lines in the same body block

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -742,6 +742,18 @@ def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
         list_anchor_x = float(
             current_block.get("list_text_start_x", previous.get("text_start_x", previous.get("x0", 0.0)))
         )
+        hyphen_wrap = str(previous.get("text") or "").strip().endswith("-")
+
+        if (
+            current_block["kind"] == "paragraph"
+            and hyphen_wrap
+            and kind == "paragraph"
+            and gap_close
+            and not bool(line.get("marker_candidate"))
+            and not _is_body_heading_line(str(line.get("text") or "").strip())
+        ):
+            current_block["lines"].append(line)
+            continue
 
         if same_kind and indent_close and size_close and gap_close and kind == "paragraph":
             sentence_continues = not _ends_sentence(str(previous.get("text") or "").strip())

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -243,6 +243,17 @@ class TableExtractionFormattingTests(unittest.TestCase):
 
         self.assertEqual(2, len(blocks))
 
+    def test_build_body_blocks_keeps_hyphen_wrap_together_before_style_checks(self) -> None:
+        lines = [
+            {"text": "special-case-", "x0": 36.0, "x1": 160.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "word_count": 1, "has_mixed_styles": False, "first_word_style_signature": ("Helvetica", False, False, None), "body_right": 180.0},
+            {"text": "ProtoLexeme", "x0": 36.0, "x1": 126.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Helvetica-Bold", "color": (0.2, 0.2, 0.7), "is_bold": True, "is_italic": False, "word_count": 1, "has_mixed_styles": False, "first_word_style_signature": ("Helvetica-Bold", True, False, None), "first_word_width": 40.0},
+        ]
+
+        blocks = _build_body_blocks(lines)
+
+        self.assertEqual(1, len(blocks))
+        self.assertEqual("paragraph", blocks[0]["kind"])
+
     def test_extract_body_word_lines_marks_marker_candidate_and_text_start(self) -> None:
         filtered_page = SimpleNamespace(
             extract_words=lambda **kwargs: [


### PR DESCRIPTION
## Summary
- prevent paragraph block splitting when a line ends with a hyphen and the next line continues the same wrapped term
- apply the hyphen-wrap exception before style-based body block splitting
- add regression coverage for hyphen-ended lines followed by styled continuation text

## Validation
- python3 -m unittest -q
- python3 verify.py