### PR TITLE
Handle hierarchical numbered markers and list follow-up lines

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -17,7 +17,7 @@ WATERMARK_GRAY_MIN = 0.88
 WATERMARK_GRAY_MAX = 0.96
 WATERMARK_GRAY_NEUTRAL_TOLERANCE = 0.03
 BULLET_PREFIX_RE = re.compile(
-    r"^(?:[-*•●○◦◯▪▫■□◆◇◈◊‣∙◉]|[0-9]+[.)]|o|\?|\uFFFD)\s+"
+    r"^(?:[-*•●○◦◯▪▫■□◆◇◈◊‣∙◉]|[0-9]+(?:[-.][0-9]+)*[.)]|o|\?|\uFFFD)\s+"
 )
 
 
@@ -636,8 +636,7 @@ def _is_list_continuation_line(line: dict, previous: dict, anchor_x: float) -> b
     style_close = _style_signature(line) == _style_signature(previous)
     indent_x = float(line.get("x0", 0.0))
     aligned_with_text = abs(indent_x - anchor_x) <= 8.0
-    further_indented = indent_x > anchor_x
-    return gap_close and size_close and style_close and (aligned_with_text or further_indented)
+    return gap_close and size_close and style_close and aligned_with_text
 
 
 def _looks_like_inline_term_continuation(line: dict) -> bool:
@@ -663,6 +662,7 @@ def _normalize_list_block_lines(lines: Sequence[dict]) -> List[str]:
     normalized: List[str] = []
     current_item: str | None = None
     current_depth = 0
+    current_text_start_x: float | None = None
     marker_positions = sorted(
         {
             round(float(line.get("marker_x", line.get("x0", 0.0))), 2)
@@ -674,6 +674,9 @@ def _normalize_list_block_lines(lines: Sequence[dict]) -> List[str]:
     def _item_prefix(depth: int) -> str:
         markers = ["-", "*", "+"]
         return f"{'  ' * depth}{markers[depth % len(markers)]} "
+
+    def _continuation_prefix(depth: int) -> str:
+        return f"{'  ' * (depth + 1)}"
 
     def _strip_marker_text(line: dict) -> str:
         text = str(line.get("text") or "").strip()
@@ -699,13 +702,20 @@ def _normalize_list_block_lines(lines: Sequence[dict]) -> List[str]:
                 current_depth = marker_positions.index(marker_x)
             except ValueError:
                 current_depth = 0
+            current_text_start_x = float(line.get("text_start_x", line.get("x0", 0.0)))
             current_item = f"{_item_prefix(current_depth)}{_strip_marker_text(line)}".rstrip()
             continue
         if current_item and current_item.endswith("-"):
             current_item = f"{current_item}{text}".strip()
             continue
         if current_item:
-            current_item = f"{current_item} {text}".strip()
+            line_x0 = float(line.get("x0", line.get("text_start_x", 0.0)))
+            if current_text_start_x is not None and abs(line_x0 - current_text_start_x) <= 8.0:
+                current_item = f"{current_item} {text}".strip()
+                continue
+            normalized.append(current_item)
+            current_item = None
+            normalized.append(f"{_continuation_prefix(current_depth)}{text}".rstrip())
             continue
         normalized.append(text)
 

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -144,6 +144,14 @@ class TableExtractionFormattingTests(unittest.TestCase):
         cell = "review-\n- next item"
         self.assertEqual(["review-", "- next item"], _normalize_cell_lines(cell))
 
+    def test_hyphen_ended_line_does_not_absorb_hierarchical_numbering_marker(self) -> None:
+        cell = "review-\n1-1) next item"
+        self.assertEqual(["review-", "1-1) next item"], _normalize_cell_lines(cell))
+        self.assertEqual(
+            ["Wrapped sentence line", "1-1) next item"],
+            _normalize_body_lines(["Wrapped sentence line", "1-1) next item"]),
+        )
+
     def test_hollow_circle_like_o_is_treated_as_bullet(self) -> None:
         cell = "review-\no next item"
         self.assertEqual(["review-", "o next item"], _normalize_cell_lines(cell))
@@ -311,6 +319,16 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertEqual(1, len(blocks))
         self.assertEqual("list", blocks[0]["kind"])
 
+    def test_build_body_blocks_splits_when_further_indented_line_starts_new_nested_item(self) -> None:
+        lines = [
+            {"text": "- parent item", "x0": 48.0, "x1": 180.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0, "marker_candidate": True, "marker_x": 48.0},
+            {"text": "o nested child", "x0": 64.0, "x1": 170.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Symbol", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 80.0, "marker_candidate": True, "marker_x": 64.0},
+        ]
+
+        blocks = _build_body_blocks(lines)
+
+        self.assertEqual(2, len(blocks))
+
     def test_normalize_list_block_lines_merges_continuation_lines_into_item(self) -> None:
         lines = [
             {"text": "- bullet item starts here", "x0": 48.0, "x1": 220.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 64.0, "marker_x": 48.0},
@@ -338,6 +356,20 @@ class TableExtractionFormattingTests(unittest.TestCase):
                 "- top level",
                 "  * child level",
                 "    + grandchild level",
+            ],
+            _normalize_list_block_lines(lines),
+        )
+
+    def test_normalize_list_block_lines_keeps_non_aligned_followup_on_separate_line(self) -> None:
+        lines = [
+            {"text": "- top level", "x0": 48.0, "x1": 120.0, "top": 120.0, "bottom": 132.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "marker_candidate": True, "marker_x": 48.0, "text_start_x": 64.0},
+            {"text": "follow-up detail at different indent", "x0": 80.0, "x1": 220.0, "top": 134.0, "bottom": 146.0, "size": 11.0, "fontname": "Helvetica", "color": (0.0, 0.0, 0.0), "is_bold": False, "is_italic": False, "text_start_x": 80.0},
+        ]
+
+        self.assertEqual(
+            [
+                "- top level",
+                "  follow-up detail at different indent",
             ],
             _normalize_list_block_lines(lines),
         )


### PR DESCRIPTION
## Summary
- recognize hierarchical numbering markers such as 1-1) and 1.1) as list starts
- stop treating deeper-indented non-marker lines as automatic list continuations
- keep non-aligned follow-up lines on separate indented lines instead of appending them to the previous bullet item

## Validation
- python3 -m unittest -q
- python3 verify.py