### PR TITLE
Include body line boxes in debug output

### DIFF
--- a/graph_pdf/extractor.py
+++ b/graph_pdf/extractor.py
@@ -308,6 +308,11 @@ def _collect_table_drawing_debug(
             }
         )
 
+    line_payloads = _extract_body_word_lines(
+        page=page,
+        header_margin=header_margin,
+        footer_margin=footer_margin,
+    )
     raw_text_lines, normalized_text_lines = _extract_body_text_lines(
         page,
         header_margin=header_margin,
@@ -321,6 +326,18 @@ def _collect_table_drawing_debug(
         "tables": tables,
         "text_debug": {
             "raw_lines": raw_text_lines,
+            "raw_line_boxes": [
+                {
+                    "text": str(line.get("text") or ""),
+                    "x0": round(float(line.get("x0", 0.0)), 2),
+                    "x1": round(float(line.get("x1", 0.0)), 2),
+                    "top": round(float(line.get("top", 0.0)), 2),
+                    "bottom": round(float(line.get("bottom", 0.0)), 2),
+                    "text_start_x": round(float(line.get("text_start_x", line.get("x0", 0.0))), 2),
+                    "marker_candidate": bool(line.get("marker_candidate")),
+                }
+                for line in line_payloads
+            ],
             "normalized_lines": normalized_text_lines,
         },
     }

--- a/graph_pdf/tests/test_extractor.py
+++ b/graph_pdf/tests/test_extractor.py
@@ -1054,11 +1054,22 @@ class TableExtractionFormattingTests(unittest.TestCase):
         self.assertEqual(6, payload["pages"][0]["tables"][0]["row_count"])
         self.assertIn("text_debug", payload["pages"][0])
         self.assertIn("raw_lines", payload["pages"][0]["text_debug"])
+        self.assertIn("raw_line_boxes", payload["pages"][0]["text_debug"])
         self.assertIn("normalized_lines", payload["pages"][0]["text_debug"])
         self.assertGreaterEqual(
             len(payload["pages"][0]["text_debug"]["raw_lines"]),
             len(payload["pages"][0]["text_debug"]["normalized_lines"]),
         )
+        self.assertEqual(
+            len(payload["pages"][0]["text_debug"]["raw_lines"]),
+            len(payload["pages"][0]["text_debug"]["raw_line_boxes"]),
+        )
+        first_line_box = payload["pages"][0]["text_debug"]["raw_line_boxes"][0]
+        self.assertIn("text", first_line_box)
+        self.assertIn("x0", first_line_box)
+        self.assertIn("x1", first_line_box)
+        self.assertIn("top", first_line_box)
+        self.assertIn("bottom", first_line_box)
         edge_debug_file = result["debug_edges_file"]
         self.assertIsNotNone(edge_debug_file)
         edge_payload = json.loads(edge_debug_file.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- add  to text debug output so each reconstructed body line includes its box coordinates
- keep existing raw and normalized text debug entries
- extend debug log tests to verify line box payloads are emitted

## Validation
- python3 -m unittest -q
- python3 verify.py
