### PR TITLE
Document extractor modules and pipeline flow

### DIFF
--- a/graph_pdf/README.md
+++ b/graph_pdf/README.md
@@ -3,13 +3,6 @@
 pdfplumber 기반으로 헤더/푸터/워터마크를 제거한 본문 텍스트와
 페이지별 표 추출, 페이지 이미지를 분리 저장하는 데모입니다.
 
-## 구조
-- `sample_generator.py`: 테스트용 샘플 PDF 생성기
-- `extractor.py`: 본문 텍스트 정제, 표 추출(페이지 경계 병합 포함), 페이지 이미지 추출 로직
-- `run_demo.py`: 샘플 PDF 생성 + 추출 파이프라인 실행
-- `verify.py`: 표준 검증 스크립트
-- `requirements.txt`: 실행에 필요한 라이브러리 목록
-
 ## 실행 방법
 ```bash
 # 가상환경
@@ -25,6 +18,28 @@ pip install -r graph_pdf/requirements.txt
 # 검증 실행
 .venv/bin/python graph_pdf/verify.py
 ```
+
+## 파일별 역할
+- `run_demo.py`: 샘플 PDF를 생성하고 추출 파이프라인을 실행하는 진입 스크립트
+- `verify.py`: 데모 산출물이 기대한 shape인지 확인하는 검증 스크립트
+- `sample_generator.py`: 본문, 표, 워터마크, 이미지가 포함된 테스트용 샘플 PDF 생성기
+- `sample_fixture.py`: 샘플 PDF 검증용 fixture 로더
+- `fixtures/demo_document.json`: 샘플 문서의 기대 본문/표 데이터 fixture
+- `extractor/__init__.py`: 외부에서 사용하는 공개 진입점 export
+- `extractor/__main__.py`: CLI 실행용 entrypoint
+- `extractor/pipeline.py`: 전체 PDF 추출 orchestration, 페이지 순회, cross-page table merge, 결과 파일 기록
+- `extractor/text.py`: 워터마크/레이아웃 artifact 제거, body bounds 계산, 본문 line 추출과 정규화
+- `extractor/tables.py`: 표 영역 탐지, 표 추출, 셀 정규화, 페이지 간 표 continuation merge 판단, markdown table 렌더링
+- `extractor/debug.py`: 표 선분/그리드 디버그와 회전 문자 디버그 payload 생성
+- `extractor/images.py`: body 영역과 겹치는 embedded image만 저장
+- `extractor/shared.py`: 공통 타입, 상수, geometry/segment helper
+- `tests/test_text.py`: 본문/워터마크/바운드 계산 관련 테스트
+- `tests/test_tables.py`: 표 탐지/병합/세그먼트 처리 관련 테스트
+- `tests/test_pipeline.py`: end-to-end 추출 결과와 debug/image 산출물 테스트
+- `tests/test_public_api.py`: 제거된 레거시 helper가 공개 API로 다시 노출되지 않는지 확인
+- `tests/test_refactor_boundaries.py`: 공개 진입점과 모듈 경계 smoke test
+- `docs/extractor-refactor-removals.md`: 이번 리팩토링에서 제거한 레거시 동작 기록
+- `docs/extractor-sequence.md`: extractor 패키지의 실행 시퀀스 정리 문서
 
 ## 현재 데모 동작 요약
 - 헤더/푸터 제거: 페이지 상단/하단 마진 기반 제거
@@ -43,6 +58,20 @@ pip install -r graph_pdf/requirements.txt
 - 표 셀 내 3라인 텍스트 및 bullet 포함
 - 여러 크기의 테이블(작은/큰/컴팩트)
 - 페이지 경계에서 분할되는 표를 하나의 표로 병합 처리
+
+## pipeline 흐름
+1. `extract_pdf_to_outputs(...)`가 PDF를 열고 출력 디렉터리를 준비합니다.
+2. 선택된 페이지 범위가 있으면 그 페이지들만 순회합니다.
+3. `debug=True`면 표 구조/edge 디버그 payload를 수집합니다.
+4. `debug_watermark=True`면 회전된 문자 디버그 payload를 수집합니다.
+5. `extractor.tables._extract_tables(...)`가 현재 페이지의 표 후보를 찾고 행 데이터를 정규화합니다.
+6. `extractor.text._extract_body_text(...)`가 전체 body text를 구합니다.
+7. 표 bbox를 제외한 body text를 다시 계산해 최종 본문 markdown에 사용합니다.
+8. 표가 있으면 이전 페이지의 pending table과 이어붙일 수 있는지 검사합니다.
+9. 이어붙일 수 있으면 pending table을 확장하고, 아니면 이전 pending table을 flush한 뒤 현재 표를 새 pending 상태로 둡니다.
+10. 모든 페이지를 처리한 뒤 남은 pending table을 flush합니다.
+11. 본문 markdown, table markdown, summary json, optional debug json을 기록합니다.
+12. 마지막으로 body 영역과 겹치는 embedded image만 별도 파일로 저장합니다.
 
 ## 산출물 예시 위치
 - 텍스트/마크다운: `graph_pdf/artifacts/run_demo/md/demo.txt`, `demo.md`

--- a/graph_pdf/extractor/__init__.py
+++ b/graph_pdf/extractor/__init__.py
@@ -37,6 +37,8 @@ from .text import (
     _should_merge_paragraph_lines,
 )
 
+# Re-export the main entrypoint and selected helpers so tests and scripts can
+# keep importing from `extractor` after the package split.
 __all__ = [
     "extract_pdf_to_outputs",
     "_append_output_table",

--- a/graph_pdf/extractor/__main__.py
+++ b/graph_pdf/extractor/__main__.py
@@ -8,6 +8,7 @@ from .shared import _parse_pages_spec
 
 
 def main() -> None:
+    # Keep the CLI intentionally thin so the real behavior lives in pipeline.py.
     parser = argparse.ArgumentParser()
     parser.add_argument("pdf_path")
     parser.add_argument("--out-md-dir", default="graph_pdf/artifacts/md")

--- a/graph_pdf/extractor/debug.py
+++ b/graph_pdf/extractor/debug.py
@@ -15,6 +15,7 @@ from .text import _detect_body_bounds, _extract_body_text_lines, _extract_body_w
 
 
 def _collect_rotated_text_debug(page: "pdfplumber.page.Page", page_no: int) -> List[dict]:
+    # Debug output keeps only rotated chars because non-rotated body text is already visible elsewhere.
     entries: List[dict] = []
     for char in getattr(page, "chars", []):
         rotation = _char_rotation_degrees(char)
@@ -45,6 +46,7 @@ def _collect_table_drawing_debug(
     header_margin: float = 90.0,
     footer_margin: float = 40.0,
 ) -> dict:
+    # This payload explains how the extractor turned raw edges into table regions.
     body_top, body_bottom = _detect_body_bounds(page, header_margin=header_margin, footer_margin=footer_margin)
     groups = _table_regions(page)
     tables: List[dict] = []
@@ -132,6 +134,7 @@ def _collect_page_edge_debug(
     header_margin: float = 90.0,
     footer_margin: float = 40.0,
 ) -> dict:
+    # Edge debug is lower-level than table debug and shows both all edges and the subset used for tables.
     body_top, body_bottom = _detect_body_bounds(page, header_margin=header_margin, footer_margin=footer_margin)
     groups = _table_regions(page)
     selected_horizontal_edges = []

--- a/graph_pdf/extractor/images.py
+++ b/graph_pdf/extractor/images.py
@@ -14,6 +14,7 @@ def _image_intersects_body(
     body_top: float,
     body_bottom: float,
 ) -> bool:
+    # Header/footer artwork is ignored; only images overlapping the body band are exported.
     top = float(image_meta.get("top", 0.0))
     bottom = float(image_meta.get("bottom", top))
     return bottom > body_top and top < body_bottom
@@ -25,6 +26,7 @@ def _extract_embedded_images(
     stem: str,
     pages: Optional[Sequence[int]] = None,
 ) -> List[Path]:
+    # Image extraction is intentionally independent from table/text extraction so it can be reused or debugged separately.
     out_image_dir.mkdir(parents=True, exist_ok=True)
 
     image_files: List[Path] = []
@@ -48,6 +50,7 @@ def _extract_embedded_images(
 
             kept_idx = 0
             for image_file in page.images:
+                # pypdf and pdfplumber expose image identifiers slightly differently, so compare both forms.
                 image_name = Path(image_file.name or "").name
                 image_stem = Path(image_name).stem
                 if image_stem not in allowed_names and image_name not in allowed_names:

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -69,6 +69,7 @@ def extract_pdf_to_outputs(
     pending_gap_text_boxes: List[Tuple[float, float, float, float]] = []
 
     def _flush_pending() -> None:
+        # Tables are emitted only after we know the next page will not extend them.
         nonlocal pending_table, pending_page, pending_last_page, pending_bbox, pending_axes, pending_gap_text_boxes
         if pending_table is not None and pending_page is not None:
             _append_output_table(output_tables, pending_page, len(output_tables) + 1, pending_table)
@@ -97,6 +98,7 @@ def extract_pdf_to_outputs(
 
             tables = _extract_tables(page, force_table=force_table)
             full_page_text = _extract_body_text(page, header_margin=header_margin, footer_margin=footer_margin)
+            # Body text for the final page output excludes table areas so prose does not duplicate table content.
             page_text = _extract_body_text(
                 page,
                 header_margin=header_margin,
@@ -117,6 +119,7 @@ def extract_pdf_to_outputs(
                     current_page=page_idx,
                 )
 
+                # Some continuation fragments lose the first column and need a specialized merge path.
                 merged_missing_first = None
                 if cross_page_continuation:
                     merged_missing_first = _maybe_merge_missing_first_column_chunk(
@@ -134,6 +137,7 @@ def extract_pdf_to_outputs(
 
                 continuation_rows = table_rows
                 if cross_page_continuation:
+                    # Repeated headers should not be duplicated when the next page is clearly part of the same table.
                     continuation_rows = _split_repeated_header(pending_table or [], table_rows)
                     if pending_table is not None and _is_continuation_chunk(pending_table, continuation_rows):
                         pending_table.extend(continuation_rows)
@@ -180,6 +184,7 @@ def extract_pdf_to_outputs(
                     pending_gap_text_boxes = _gap_text_boxes_after_bbox(page, bbox, table_bboxes, header_margin=header_margin, footer_margin=footer_margin)
                     continue
 
+                # Once continuation checks fail, the previous pending table is finalized and a new table starts.
                 _flush_pending()
                 pending_table = table_rows
                 pending_page = page_idx
@@ -200,6 +205,7 @@ def extract_pdf_to_outputs(
     md_file.write_text(markdown, encoding="utf-8")
     table_md_file.write_text(table_markdown, encoding="utf-8")
 
+    # Image extraction happens after text/table rendering so image export stays independent from markdown generation.
     image_files = _extract_embedded_images(pdf_path=pdf_path, out_image_dir=out_image_dir, stem=stem, pages=pages)
 
     summary = {

--- a/graph_pdf/extractor/shared.py
+++ b/graph_pdf/extractor/shared.py
@@ -19,6 +19,7 @@ BULLET_PREFIX_RE = re.compile(
 
 
 def _parse_pages_spec(spec: str) -> List[int]:
+    # Accept `1,3-5,8` style CLI input and normalize it into a sorted unique page list.
     values = set()
     for part in str(spec or "").split(","):
         token = part.strip()
@@ -46,10 +47,12 @@ def _parse_pages_spec(spec: str) -> List[int]:
 
 
 def _normalize_text(text: str) -> str:
+    # Most table/body comparisons only care about semantic text, not spacing differences.
     return re.sub(r"\s+", " ", text or "").strip()
 
 
 def _char_rotation_degrees(char: dict) -> float:
+    # pdfplumber exposes the text matrix directly, so rotation comes from the matrix rather than a dedicated field.
     matrix = char.get("matrix")
     if not isinstance(matrix, tuple) or len(matrix) < 2:
         return 0.0
@@ -57,6 +60,7 @@ def _char_rotation_degrees(char: dict) -> float:
 
 
 def _merge_numeric_positions(values: Sequence[float], tolerance: float = 1.0) -> List[float]:
+    # Nearby edge coordinates often differ by sub-pixel noise; collapse them before higher-level reasoning.
     merged: List[float] = []
     for value in sorted(float(v) for v in values):
         if not merged or abs(value - merged[-1]) > tolerance:
@@ -67,6 +71,7 @@ def _merge_numeric_positions(values: Sequence[float], tolerance: float = 1.0) ->
 
 
 def _cluster_axis_values(values: Sequence[float], tolerance: float = 1.0) -> List[List[float]]:
+    # Segment grouping starts by clustering nearly-identical coordinates on one axis.
     clusters: List[List[float]] = []
     for value in sorted(float(v) for v in values):
         if not clusters or abs(value - clusters[-1][-1]) > tolerance:
@@ -81,6 +86,7 @@ def _round_segment(
     body_top: float | None = None,
     body_bottom: float | None = None,
 ) -> dict:
+    # Debug payloads use rounded values so JSON stays readable and stable across runs.
     payload = {
         "x0": round(float(edge["x0"]), 2),
         "x1": round(float(edge["x1"]), 2),
@@ -102,6 +108,7 @@ def _normalize_band_segments(
     orth_max_key: str,
     tolerance: float = 1.0,
 ) -> List[dict]:
+    # Horizontal and vertical segment merging share the same overlap/containment rules.
     normalized: List[dict] = []
     ordered = sorted(
         (dict(edge) for edge in segments),
@@ -140,6 +147,7 @@ def _merge_horizontal_band_segments(
     body_top: float | None = None,
     body_bottom: float | None = None,
 ) -> List[dict]:
+    # Horizontal lines are merged on x-range while preserving the full vertical span seen in source edges.
     merged = _normalize_band_segments(
         segments,
         start_key="x0",
@@ -157,6 +165,7 @@ def _merge_vertical_band_segments(
     body_top: float | None = None,
     body_bottom: float | None = None,
 ) -> List[dict]:
+    # Vertical lines are merged on y-range while preserving the full horizontal span seen in source edges.
     merged = _normalize_band_segments(
         segments,
         start_key="top",
@@ -176,6 +185,7 @@ def _build_segment_groups(
     body_top: float | None = None,
     body_bottom: float | None = None,
 ) -> List[dict]:
+    # Group raw edges by shared axis position first, then expose both original and merged segment views for debug.
     clusters = _cluster_axis_values([float(edge[axis_key]) for edge in segments], tolerance=tolerance)
     groups: List[dict] = []
     for cluster in clusters:
@@ -207,6 +217,7 @@ def _bboxes_intersect(
     a: Tuple[float, float, float, float],
     b: Tuple[float, float, float, float],
 ) -> bool:
+    # Text/table/image exclusion logic only needs simple rectangle overlap checks.
     ax0, ay0, ax1, ay1 = a
     bx0, by0, bx1, by1 = b
     return ax0 < bx1 and ax1 > bx0 and ay0 < by1 and ay1 > by0

--- a/graph_pdf/extractor/tables.py
+++ b/graph_pdf/extractor/tables.py
@@ -24,10 +24,12 @@ from .text import (
 
 
 def _merge_cells(table: Sequence[Sequence[str]]) -> List[List[str]]:
+    # pdfplumber can yield `None` cells, so normalize early to simple stripped strings.
     return [[str(cell or "").strip() for cell in row] for row in table]
 
 
 def _collapse_structural_triplet_columns(table: Sequence[Sequence[str]]) -> List[List[str]]:
+    # Some sample tables use [blank, value, blank] triples to simulate merged columns; collapse only those empty side columns.
     rows = [list(row) for row in table]
     if not rows:
         return []
@@ -50,6 +52,7 @@ def _collapse_structural_triplet_columns(table: Sequence[Sequence[str]]) -> List
 
 
 def _normalize_extracted_table(table: Sequence[Sequence[str]]) -> List[List[str]]:
+    # Table normalization is deliberately cell-local so geometric table structure stays untouched.
     normalized: List[List[str]] = []
     for row in table:
         normalized_row = []
@@ -60,6 +63,7 @@ def _normalize_extracted_table(table: Sequence[Sequence[str]]) -> List[List[str]
 
 
 def _table_rejection_reason(table: Sequence[Sequence[str]]) -> str | None:
+    # Rejection stays intentionally minimal to avoid throwing away sparse but valid tables.
     if not table:
         return "empty table"
     normalized_rows = [[str(cell or "").strip() for cell in row] for row in table]
@@ -73,6 +77,7 @@ def _log_rejected_table(
     crop_bbox: Tuple[float, float, float, float],
     reason: str,
 ) -> None:
+    # Rejection logging is only for manual debugging; tests assert on accepted output instead.
     row_count = len(table)
     col_count = max((len(row) for row in table), default=0)
     bbox_text = ", ".join(f"{value:.2f}" for value in crop_bbox)
@@ -80,6 +85,7 @@ def _log_rejected_table(
 
 
 def _looks_like_header_row(row: Sequence[str]) -> bool:
+    # Header detection is heuristic and only used for cross-page continuation handling.
     if not row:
         return False
     normalized = [_normalize_text(c) for c in row]
@@ -92,18 +98,21 @@ def _looks_like_header_row(row: Sequence[str]) -> bool:
 
 
 def _rows_match(a: Sequence[str], b: Sequence[str]) -> bool:
+    # Header rows are compared after whitespace normalization to avoid duplicate header output.
     if len(a) != len(b):
         return False
     return all(_normalize_text(x) == _normalize_text(y) for x, y in zip(a, b))
 
 
 def _split_repeated_header(prev_rows: TableRows, curr_rows: TableRows) -> TableRows:
+    # When a page repeats the same header row, only keep the first occurrence in the merged output.
     if prev_rows and curr_rows and _rows_match(prev_rows[0], curr_rows[0]):
         return curr_rows[1:]
     return curr_rows
 
 
 def _is_continuation_chunk(prev_rows: TableRows, curr_rows: TableRows) -> bool:
+    # Continuation chunks usually keep the schema but leave the first column blank while the row carries on.
     if not prev_rows or not curr_rows:
         return False
     if len(prev_rows[0]) != len(curr_rows[0]):
@@ -119,6 +128,7 @@ def _extract_continuation_lines(
     repeated_header: str,
     next_row_label: str,
 ) -> List[str]:
+    # Missing-first-column continuation rows borrow prose lines from the surrounding page text.
     lines = [line.strip() for line in str(page_text or "").splitlines() if line.strip()]
     if not lines:
         return []
@@ -141,6 +151,7 @@ def _extract_continuation_lines(
 
 
 def _normalize_two_col_continuation_rows(rows: TableRows) -> TableRows:
+    # Reconstruct a 3-column shape when a continuation fragment drops the first column entirely.
     return [["", str(row[0] or "").strip(), str(row[1] or "").strip()] for row in rows if row]
 
 
@@ -148,6 +159,7 @@ def _should_try_table_continuation_merge(
     pending_page: int | None,
     current_page: int,
 ) -> bool:
+    # Cross-page merging is limited to immediately adjacent pages.
     return pending_page is not None and current_page == pending_page + 1
 
 
@@ -157,6 +169,7 @@ def _body_text_boxes(
     footer_margin: float,
     excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
 ) -> List[Tuple[float, float, float, float]]:
+    # These boxes are used only to detect prose sitting between two candidate table fragments.
     filtered_page = _filter_page_for_extraction(page)
     body_top, body_bottom = _detect_body_bounds(page, header_margin=header_margin, footer_margin=footer_margin)
     text_boxes: List[Tuple[float, float, float, float]] = []
@@ -185,6 +198,7 @@ def _gap_text_boxes_after_bbox(
     header_margin: float,
     footer_margin: float,
 ) -> List[Tuple[float, float, float, float]]:
+    # Text after a table candidate can block continuation into the next page.
     return [
         text_bbox
         for text_bbox in _body_text_boxes(
@@ -204,6 +218,7 @@ def _gap_text_boxes_before_bbox(
     header_margin: float,
     footer_margin: float,
 ) -> List[Tuple[float, float, float, float]]:
+    # Text before a table candidate can mean the new page starts with prose rather than a continuation table.
     return [
         text_bbox
         for text_bbox in _body_text_boxes(
@@ -220,6 +235,7 @@ def _vertical_axes_for_bbox(
     page: pdfplumber.page.PageObject,
     bbox: Tuple[float, float, float, float],
 ) -> List[float]:
+    # Shared vertical axes are one of the strongest geometric signals that two fragments belong to the same table.
     x0, y0, x1, y1 = bbox
     axes = [
         float(edge["x0"])
@@ -243,6 +259,7 @@ def _continuation_regions_should_merge(
     edge_tolerance: float = 24.0,
     axis_tolerance: float = 1.0,
 ) -> bool:
+    # Merge only when geometry matches and no body text sits between the two fragments.
     _prev_x0, _prev_top, _prev_x1, prev_bottom = prev_bbox
     _curr_x0, curr_top, _curr_x1, _curr_bottom = curr_bbox
 
@@ -250,6 +267,7 @@ def _continuation_regions_should_merge(
     if not shared_axes or gap_text_boxes:
         return False
 
+    # Near-footer / near-header placement is the common continuation pattern, but shared axes already make this permissive.
     prev_near_footer = abs(body_bottom - prev_bottom) <= edge_tolerance
     curr_near_header = abs(curr_top - body_top) <= edge_tolerance
     if prev_near_footer or curr_near_header:
@@ -262,6 +280,7 @@ def _maybe_merge_missing_first_column_chunk(
     current_rows: TableRows,
     page_text: str,
 ) -> TableRows | None:
+    # Some PDFs drop the leading column when a long row spills to the next page.
     if not pending_table or not current_rows:
         return None
     if len(pending_table[0]) != 3:
@@ -288,6 +307,7 @@ def _maybe_merge_missing_first_column_chunk(
 
 
 def _format_markdown_cell(value: str) -> str:
+    # Markdown cells preserve logical line breaks with `<br>` while escaping literal pipe characters.
     lines = _normalize_cell_lines(value)
     if not lines:
         return ""
@@ -299,6 +319,7 @@ def _table_regions(
     y_tolerance: float = 65.0,
     min_lines: int = 3,
 ) -> List[tuple]:
+    # Table discovery is driven by connected edge geometry rather than text layout alone.
     del y_tolerance
 
     body_top, body_bottom = _detect_body_bounds(page, header_margin=90.0, footer_margin=40.0)
@@ -333,6 +354,7 @@ def _table_regions(
 
     for h_idx, h_edge in enumerate(merged_h):
         for v_idx, v_edge in enumerate(merged_v):
+            # A horizontal line joins a component only when a vertical edge crosses it within tolerance.
             intersects = (
                 float(v_edge["x0"]) >= float(h_edge["x0"]) - tolerance
                 and float(v_edge["x0"]) <= float(h_edge["x1"]) + tolerance
@@ -368,6 +390,7 @@ def _table_regions(
             stack.extend(graph[idx] - visited)
 
         component_lines = [merged_h[idx] for idx in component]
+        # Ignore weak components that do not look like a stable table grid.
         if len(component_lines) < min_lines or not shared_verticals:
             continue
 
@@ -384,6 +407,7 @@ def _extract_tables_from_crop(
     page: pdfplumber.page.PageObject,
     crop_bbox: Tuple[float, float, float, float],
 ) -> List[TableChunk]:
+    # Crop-level extraction gives table_settings a tighter region and improves recovery of border-light tables.
     x0, y0, x1, y1 = crop_bbox
     crop = page.crop(crop_bbox)
 
@@ -420,6 +444,7 @@ def _extract_tables_from_crop(
     ]
 
     for settings in candidates:
+        # Try line-driven extraction first, then a text-assisted fallback inside the same crop.
         tables = crop.extract_tables(table_settings=settings) or []
         cleaned = []
         for table in tables:
@@ -437,6 +462,7 @@ def _extract_tables(
     page: pdfplumber.page.PageObject,
     force_table: bool = False,
 ) -> List[TableChunk]:
+    # Region-based extraction is preferred because full-page fallback tends to over-merge adjacent content.
     page = _filter_page_for_extraction(page)
     seen_keys = set()
     merged: List[TableChunk] = []
@@ -457,6 +483,7 @@ def _extract_tables(
     if merged or not force_table:
         return merged
 
+    # The caller can opt into a more aggressive page-wide fallback when geometric table regions are absent.
     full_bbox = (0.0, 0.0, float(page.width), float(page.height))
     fallback_settings = [
         {
@@ -511,6 +538,7 @@ def _extract_tables(
 
 
 def _table_text_from_rows(rows: Sequence[Sequence[str]]) -> str:
+    # Convert normalized row data into markdown table text used by the final artifacts.
     if not rows:
         return ""
 
@@ -530,6 +558,7 @@ def _table_text_from_rows(rows: Sequence[Sequence[str]]) -> str:
 
 
 def _merge_split_rows(rows: TableRows) -> TableRows:
+    # Post-process rows that were extracted as separate fragments even though they belong to the same logical row.
     if not rows:
         return rows
 
@@ -554,6 +583,7 @@ def _merge_split_rows(rows: TableRows) -> TableRows:
 
 
 def _append_output_table(output_tables: List[str], page_no: int, table_no: int, table_rows: TableRows) -> None:
+    # Table numbering is derived at append time so merged cross-page tables keep one output block.
     table_text = _table_text_from_rows(_merge_split_rows(table_rows))
     if table_text:
         output_tables.append(f"### Page {page_no} table {table_no}\n{table_text}")

--- a/graph_pdf/extractor/text.py
+++ b/graph_pdf/extractor/text.py
@@ -17,11 +17,13 @@ from .shared import (
 
 
 def _repair_watermark_bleed(text: str) -> str:
+    # Rotated watermark glyphs can leak as a trailing single character in extracted words.
     text = re.sub(r"\s+[A-Za-z]$", "", text)
     return text.strip()
 
 
 def _is_layout_artifact(text: str) -> bool:
+    # The sample/demo PDFs contain known header/footer strings that should never enter body extraction.
     normalized = _normalize_text(text).lower()
     if not normalized:
         return True
@@ -54,6 +56,7 @@ def _is_layout_artifact(text: str) -> bool:
 
 
 def _is_gray_color(color: object) -> bool:
+    # Watermark detection uses a narrow neutral-gray band instead of any light-colored text.
     if not isinstance(color, tuple) or len(color) < 3:
         return False
     rgb = [float(c) for c in color[:3]]
@@ -62,6 +65,7 @@ def _is_gray_color(color: object) -> bool:
 
 
 def _is_non_watermark_obj(obj: dict) -> bool:
+    # Only rotated gray chars are treated as watermark; everything else remains extractable.
     if obj.get("object_type") != "char":
         return True
     angle = _char_rotation_degrees(obj)
@@ -71,10 +75,12 @@ def _is_non_watermark_obj(obj: dict) -> bool:
 
 
 def _filter_page_for_extraction(page: "pdfplumber.page.Page") -> "pdfplumber.page.Page":
+    # Apply watermark filtering once so downstream code can work on a cleaned page view.
     return page.filter(_is_non_watermark_obj)
 
 
 def _detect_chapter_body_top(page: "pdfplumber.page.Page") -> float | None:
+    # If the page lacks a clear top divider, use a large chapter-like heading as the body start.
     extract_words = getattr(page, "extract_words", None)
     if not callable(extract_words):
         return None
@@ -118,6 +124,7 @@ def _detect_body_bounds(
     header_margin: float,
     footer_margin: float,
 ) -> Tuple[float, float]:
+    # Prefer explicit horizontal divider lines, then fall back to a chapter heading or the configured margins.
     default_top = float(footer_margin)
     default_bottom = float(page.height - header_margin)
     min_width = float(page.width) * 0.7
@@ -154,6 +161,7 @@ def _extract_body_text(
     footer_margin: float,
     excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
 ) -> str:
+    # Most callers want page text as joined logical lines rather than raw line payloads.
     _raw_lines, normalized_lines = _extract_body_text_lines(
         page=page,
         header_margin=header_margin,
@@ -169,6 +177,7 @@ def _extract_body_text_lines(
     footer_margin: float,
     excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
 ) -> Tuple[List[str], List[str]]:
+    # Return both the raw visual lines and the normalized logical lines for debug and downstream reuse.
     line_payloads = _extract_body_word_lines(
         page=page,
         header_margin=header_margin,
@@ -192,6 +201,7 @@ def _extract_body_text_lines(
 
 
 def _clean_cell_line(line: str) -> str:
+    # Table cell cleanup is conservative: collapse whitespace and drop a common trailing watermark fragment.
     cleaned = str(line or "").strip()
     cleaned = re.sub(r"\s+", " ", cleaned).strip()
     tokens = cleaned.split()
@@ -201,23 +211,28 @@ def _clean_cell_line(line: str) -> str:
 
 
 def _remove_watermark_fragment_lines(lines: Sequence[str]) -> List[str]:
+    # Preserve multi-line structure but drop empty fragments after cleanup.
     cleaned = [_clean_cell_line(line) for line in lines]
     return [line for line in cleaned if line]
 
 
 def _is_bullet_line(line: str) -> bool:
+    # Bullet detection is shared by body and table-cell normalization.
     return bool(BULLET_PREFIX_RE.match(str(line or "").strip()))
 
 
 def _is_bullet_marker_text(text: str) -> bool:
+    # Marker detection is looser because line-building needs to recognize standalone marker glyphs.
     return bool(BULLET_PREFIX_RE.match(f"{str(text or '').strip()} x"))
 
 
 def _ends_sentence(line: str) -> bool:
+    # Sentence-ending punctuation is used as a lightweight signal for table-cell line splitting.
     return bool(re.search(r"[.!?;:。！？]$", str(line or "").strip()))
 
 
 def _is_body_heading_line(line: str) -> bool:
+    # Body normalization only gives special treatment to coarse chapter/section-like headings.
     text = str(line or "").strip()
     if not text:
         return False
@@ -225,17 +240,20 @@ def _is_body_heading_line(line: str) -> bool:
 
 
 def _line_kind(line: dict) -> str:
+    # The current body flow distinguishes only headings and paragraphs.
     if _is_body_heading_line(str(line.get("text") or "").strip()):
         return "heading"
     return "paragraph"
 
 
 def _should_merge_paragraph_lines(previous: dict, line: dict) -> bool:
+    # Paragraph grouping intentionally uses a simple fixed gap rule after legacy heuristics were removed.
     line_gap = float(line.get("top", 0.0)) - float(previous.get("bottom", 0.0))
     return line_gap <= 5.0
 
 
 def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
+    # Collapse adjacent body lines into coarse logical blocks before converting them to page text.
     if not lines:
         return []
 
@@ -250,6 +268,7 @@ def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
         previous = current_block["lines"][-1]
         same_kind = current_block["kind"] == kind
         if same_kind and kind == "paragraph" and _should_merge_paragraph_lines(previous, line):
+            # Paragraphs are the only block type that can absorb the next visual line.
             current_block["lines"].append(line)
             continue
 
@@ -267,6 +286,7 @@ def _extract_body_word_lines(
     footer_margin: float,
     excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
 ) -> List[dict]:
+    # Convert word-level extraction into line payloads enriched with the signals later heuristics need.
     filtered_page = _filter_page_for_extraction(page)
     body_top, body_bottom = _detect_body_bounds(page, header_margin=header_margin, footer_margin=footer_margin)
     words = filtered_page.extract_words(
@@ -284,6 +304,7 @@ def _extract_body_word_lines(
     filtered_words = []
     for word in words:
         bbox = _word_bbox(word)
+        # Excluded bboxes are used to suppress table text when generating the final body output.
         if bbox[3] <= body_top or bbox[1] >= body_bottom:
             continue
         if any(_bboxes_intersect(bbox, excluded_bbox) for excluded_bbox in excluded_bboxes):
@@ -324,6 +345,7 @@ def _extract_body_word_lines(
         first_cleaned = _repair_watermark_bleed(str(ordered[0].get("text") or "").strip())
         second_word = ordered[1] if len(ordered) > 1 else ordered[0]
         marker_gap = float(second_word.get("x0", ordered[0].get("x1", 0.0))) - float(ordered[0].get("x1", 0.0))
+        # Standalone punctuation and symbol glyphs often represent bullets in PDF word extraction.
         marker_candidate = len(ordered) > 1 and (
             _is_bullet_marker_text(first_cleaned)
             or (len(first_cleaned) == 1 and not first_cleaned.isalnum() and marker_gap >= 4.0)
@@ -379,11 +401,13 @@ def _extract_body_word_lines(
 
 
 def _join_non_heading_block_lines(lines: Sequence[str]) -> str:
+    # Paragraph blocks are intentionally flattened into one logical line for downstream indexing.
     joined = [str(raw_line or "").strip() for raw_line in lines if str(raw_line or "").strip()]
     return " ".join(joined).strip()
 
 
 def _normalize_cell_lines(cell: str) -> List[str]:
+    # Table cells keep bullet and sentence boundaries, unlike body text which is flattened more aggressively.
     raw_lines = [part.strip() for part in str(cell or "").splitlines()]
     lines = _remove_watermark_fragment_lines(raw_lines)
     if not lines:
@@ -400,6 +424,7 @@ def _normalize_cell_lines(cell: str) -> List[str]:
 
     for line in lines:
         if _is_bullet_line(line):
+            # Bullets always start a new logical line in markdown table output.
             _flush_buffer()
             logical_lines.append(line)
             continue


### PR DESCRIPTION
## Summary
- expand README with file-by-file responsibilities and the end-to-end extractor pipeline flow
- add concise inline comments across extractor package modules so helper intent and key branches are easier to follow
- keep behavior unchanged and verify the package still passes the existing regression suite

## Validation
- python3 -m unittest discover -s tests
