### PR TITLE
Support multi-row table headers

### DIFF
--- a/graph_pdf/README.md
+++ b/graph_pdf/README.md
@@ -19,6 +19,52 @@ pip install -r graph_pdf/requirements.txt
 .venv/bin/python graph_pdf/verify.py
 ```
 
+## 직접 실행 방법
+샘플 생성 없이 임의의 PDF를 바로 추출하려면 `extractor` 모듈을 직접 실행하면 됩니다.
+
+```bash
+python3 -m extractor sample.pdf \
+  --out-md-dir artifacts/manual/md \
+  --out-image-dir artifacts/manual/images \
+  --stem sample
+```
+
+또는 엔트리 파일을 직접 실행할 수도 있습니다.
+
+```bash
+python3 extractor/__main__.py sample.pdf \
+  --out-md-dir artifacts/manual/md \
+  --out-image-dir artifacts/manual/images \
+  --stem sample
+```
+
+### 주요 옵션
+- `--pages 1,3,5-8`: 추출할 페이지 범위 지정
+- `--force-table`: 표 영역 탐지 실패 시 더 공격적인 페이지 전체 표 추출 허용
+- `--debug`: 표 구조/edge 디버그 JSON 생성
+- `--debug-watermark`: 회전 문자 디버그 JSON 생성
+
+### 직접 실행 예시
+```bash
+python3 -m extractor sample.pdf \
+  --out-md-dir artifacts/manual/md \
+  --out-image-dir artifacts/manual/images \
+  --stem sample \
+  --pages 1-2 \
+  --debug \
+  --debug-watermark
+```
+
+### 직접 실행 산출물
+- `artifacts/manual/md/sample.txt`: 본문 텍스트
+- `artifacts/manual/md/sample.md`: 본문 markdown
+- `artifacts/manual/md/sample_table.md`: 표 markdown
+- `artifacts/manual/md/sample_summary.json`: 추출 요약
+- `artifacts/manual/md/sample_debug.json`: 표 구조 디버그 (`--debug`)
+- `artifacts/manual/md/sample_edges_debug.json`: edge 디버그 (`--debug`)
+- `artifacts/manual/md/sample_watermark_debug.json`: 회전 문자 디버그 (`--debug-watermark`)
+- `artifacts/manual/images/*`: body 영역 이미지 추출 결과
+
 ## 파일별 역할
 - `run_demo.py`: 샘플 PDF를 생성하고 추출 파이프라인을 실행하는 진입 스크립트
 - `verify.py`: 데모 산출물이 기대한 shape인지 확인하는 검증 스크립트

--- a/graph_pdf/extractor/tables.py
+++ b/graph_pdf/extractor/tables.py
@@ -104,10 +104,43 @@ def _rows_match(a: Sequence[str], b: Sequence[str]) -> bool:
     return all(_normalize_text(x) == _normalize_text(y) for x, y in zip(a, b))
 
 
+def _header_row_count(rows: Sequence[Sequence[str]], max_header_rows: int = 2) -> int:
+    # Treat consecutive short alpha-like top rows as a multi-row header block.
+    count = 0
+    for row in rows[:max_header_rows]:
+        if not _looks_like_header_row(row):
+            break
+        count += 1
+    return count
+
+
+def _collapse_header_rows(header_rows: Sequence[Sequence[str]]) -> List[str]:
+    # Markdown can only express one header row directly, so fold multi-row headers into one logical row.
+    if not header_rows:
+        return []
+    col_count = max((len(row) for row in header_rows), default=0)
+    collapsed: List[str] = []
+    for col_idx in range(col_count):
+        parts = [
+            str(row[col_idx]).strip()
+            for row in header_rows
+            if col_idx < len(row) and str(row[col_idx]).strip()
+        ]
+        collapsed.append("\n".join(parts))
+    return collapsed
+
+
 def _split_repeated_header(prev_rows: TableRows, curr_rows: TableRows) -> TableRows:
     # When a page repeats the same header row, only keep the first occurrence in the merged output.
-    if prev_rows and curr_rows and _rows_match(prev_rows[0], curr_rows[0]):
-        return curr_rows[1:]
+    prev_header_count = _header_row_count(prev_rows)
+    curr_header_count = _header_row_count(curr_rows)
+    if not prev_header_count or prev_header_count != curr_header_count:
+        return curr_rows
+    if all(
+        _rows_match(prev_rows[idx], curr_rows[idx])
+        for idx in range(curr_header_count)
+    ):
+        return curr_rows[curr_header_count:]
     return curr_rows
 
 
@@ -312,6 +345,13 @@ def _format_markdown_cell(value: str) -> str:
     if not lines:
         return ""
     return "<br>".join(line.replace("|", "\\|") for line in lines)
+
+
+def _format_header_markdown_cell(value: str) -> str:
+    # Header rows are already semantically separated, so preserve their row boundaries directly.
+    parts = [str(part or "").strip().replace("|", "\\|") for part in str(value or "").splitlines()]
+    parts = [part for part in parts if part]
+    return "<br>".join(parts)
 
 
 def _table_regions(
@@ -542,13 +582,15 @@ def _table_text_from_rows(rows: Sequence[Sequence[str]]) -> str:
     if not rows:
         return ""
 
-    header = [str(col or "").strip() for col in rows[0]]
-    body = rows[1:]
+    header_row_count = _header_row_count(rows)
+    header_rows = rows[:header_row_count] if header_row_count else rows[:1]
+    header = _collapse_header_rows(header_rows)
+    body = rows[header_row_count:] if header_row_count else rows[1:]
     if not body:
         body = rows
         header = [f"Column {idx}" for idx in range(1, len(rows[0]) + 1)]
 
-    header_line = "| " + " | ".join(cell or f"Column {idx + 1}" for idx, cell in enumerate(header)) + " |"
+    header_line = "| " + " | ".join(_format_header_markdown_cell(cell or f"Column {idx + 1}") for idx, cell in enumerate(header)) + " |"
     divider_line = "| " + " | ".join("---" for _ in header) + " |"
     body_lines = []
     for row in body:

--- a/graph_pdf/fixtures/demo_document.json
+++ b/graph_pdf/fixtures/demo_document.json
@@ -59,6 +59,10 @@
     },
     {
       "id": "stage",
+      "header_rows": [
+        ["Stage", "Team", "Notes"],
+        ["Group", "Function", "Deliverable"]
+      ],
       "columns": ["Stage", "Team", "Notes"],
       "rows": [
         ["Phase A", "Discovery", "Kickoff scope lock\n- gather baseline\n- define risks\n- align dependencies"],

--- a/graph_pdf/sample_generator.py
+++ b/graph_pdf/sample_generator.py
@@ -15,6 +15,7 @@ from sample_fixture import load_demo_fixture
 
 LineItem = Tuple[str, int]
 TableRow = Tuple[str, ...]
+_HEADER_ROW_HEIGHT = 16.0
 _SMALL_PNG = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR42mP8z/C/HwAHAQL/5ncLrgAAAABJRU5ErkJggg=="
 )
@@ -34,17 +35,26 @@ def get_demo_tables() -> Dict[str, Tuple[Tuple[str, ...], Tuple[TableRow, ...]]]
     return _fixture_tables()
 
 
-def _fixture_table_render_meta(table_id: str) -> tuple[Tuple[str, ...], Tuple[TableRow, ...], Tuple[float, ...] | None]:
+def _fixture_table_render_meta(
+    table_id: str,
+) -> tuple[Tuple[TableRow, ...], Tuple[TableRow, ...], Tuple[float, ...] | None]:
     for table in load_demo_fixture()["tables"]:
         if table["id"] != table_id:
             continue
-        columns = tuple(str(cell) for cell in table.get("render_columns", table["columns"]))
+        header_rows = table.get("render_header_rows") or table.get("header_rows")
+        if header_rows:
+            headers = tuple(
+                tuple(str(cell) for cell in header_row)
+                for header_row in header_rows
+            )
+        else:
+            headers = (tuple(str(cell) for cell in table.get("render_columns", table["columns"])),)
         rows = tuple(
             tuple(str(cell) for cell in row)
             for row in table.get("render_rows", table["rows"])
         )
         weights = table.get("render_column_weights")
-        return columns, rows, tuple(float(value) for value in weights) if weights else None
+        return headers, rows, tuple(float(value) for value in weights) if weights else None
     raise KeyError(table_id)
 
 
@@ -250,7 +260,7 @@ class DemoPdfBuilder:
 
     def _draw_table_block(
         self,
-        header: Sequence[str],
+        header_rows: Sequence[TableRow],
         rows: Sequence[TableRow],
         column_weights: Sequence[float] | None = None,
         header_font_size: float = 9.0,
@@ -268,6 +278,7 @@ class DemoPdfBuilder:
         if not body_width:
             return
 
+        header = tuple(header_rows[0]) if header_rows else ()
         if column_weights is None:
             if len(header) == 3:
                 column_weights = [0.28, 0.2, 0.52]
@@ -281,7 +292,7 @@ class DemoPdfBuilder:
         for width in col_widths[:-1]:
             running_x += width
             col_x.append(running_x)
-        header_height = 20.0
+        header_height = (_HEADER_ROW_HEIGHT * len(header_rows)) if include_header else 0.0
         line_h = row_font_size + 1.2
 
         prepared_rows = []
@@ -411,7 +422,7 @@ class DemoPdfBuilder:
                 col_x=col_x,
                 col_widths=col_widths,
                 body_width=body_width,
-                header=header if include_header else (),
+                header_rows=header_rows if include_header else (),
                 rows=chunk_rows,
                 row_heights=chunk_heights,
                 include_outer_vertical=include_outer_vertical,
@@ -433,7 +444,7 @@ class DemoPdfBuilder:
         col_x: Sequence[float],
         col_widths: Sequence[float],
         body_width: float,
-        header: Sequence[str],
+        header_rows: Sequence[TableRow],
         rows: Sequence[TableRow],
         row_heights: Sequence[float],
         include_outer_vertical: bool,
@@ -446,7 +457,7 @@ class DemoPdfBuilder:
         self.canvas.setStrokeColor(colors.black)
         self.canvas.setLineWidth(0.8)
 
-        header_h = 20.0 if include_header else 0.0
+        header_h = (_HEADER_ROW_HEIGHT * len(header_rows)) if include_header else 0.0
         table_h = header_h + sum(row_heights)
         row_tops = [0.0]
         for row_h in row_heights:
@@ -455,13 +466,16 @@ class DemoPdfBuilder:
         y = y_top
         self.canvas.line(x, y_top, x + body_width, y_top)
 
-        if include_header and header:
+        if include_header and header_rows:
             self.canvas.setFont("Helvetica-Bold", header_font_size)
             text_x_positions = [x + 6, *[boundary + 6 for boundary in col_x]]
-            for idx, title in enumerate(header):
-                self.canvas.drawString(text_x_positions[idx], y_top - 14, title)
+            header_cursor = y_top
+            for header_row in header_rows:
+                for idx, title in enumerate(header_row):
+                    self.canvas.drawString(text_x_positions[idx], header_cursor - 11, title)
+                header_cursor -= _HEADER_ROW_HEIGHT
+                self.canvas.line(x, header_cursor, x + body_width, header_cursor)
             y -= header_h
-            self.canvas.line(x, y, x + body_width, y)
 
         # Horizontal lines (including header/body split and bottom line).
         table_start = y
@@ -562,7 +576,7 @@ def create_demo_pdf(path: Path) -> None:
     )
 
     builder._draw_table_block(
-        header=tables["item"][0],
+        header_rows=(tables["item"][0],),
         rows=tables["item"][1],
         include_header=True,
         split_pages=False,
@@ -572,10 +586,10 @@ def create_demo_pdf(path: Path) -> None:
     builder.add_gap(24.0)
 
     builder.add_body_text(after_item_table)
-    builder.add_gap(100.0)
+    builder.add_gap(76.0)
 
     builder._draw_table_block(
-        header=tables["stage"][0],
+        header_rows=_fixture_table_render_meta("stage")[0],
         rows=tables["stage"][1],
         include_header=True,
         split_pages=True,
@@ -593,7 +607,7 @@ def create_demo_pdf(path: Path) -> None:
     )
 
     builder._draw_table_block(
-        header=_fixture_table_render_meta("area")[0],
+        header_rows=_fixture_table_render_meta("area")[0],
         rows=_fixture_table_render_meta("area")[1],
         column_weights=_fixture_table_render_meta("area")[2],
         include_header=True,

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -85,6 +85,13 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertIn("| Laptop<br>- line 1 | 12 | $120 |", markdown)
         self.assertIn("| Docs | READY | Finalize<br>- sample<br>- archive |", markdown)
 
+    def test_stage_table_uses_collapsed_multirow_header_in_markdown_output(self) -> None:
+        markdown = self._extract_table_markdown()
+        self.assertIn(
+            "| Stage<br>Group | Team<br>Function | Notes<br>Deliverable |",
+            markdown,
+        )
+
     def test_extract_can_limit_to_selected_pages(self) -> None:
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)

--- a/graph_pdf/tests/test_tables.py
+++ b/graph_pdf/tests/test_tables.py
@@ -8,9 +8,11 @@ from extractor.tables import (
     _collapse_structural_triplet_columns,
     _continuation_regions_should_merge,
     _extract_tables,
+    _split_repeated_header,
     _should_try_table_continuation_merge,
     _table_regions,
     _table_rejection_reason,
+    _table_text_from_rows,
 )
 
 
@@ -152,3 +154,32 @@ class TableModuleTests(unittest.TestCase):
             filter=lambda fn: page,
         )
         self.assertEqual([], _extract_tables(page))
+
+    def test_table_text_from_rows_collapses_two_header_rows_into_single_markdown_header(self) -> None:
+        rows = [
+            ["Stage", "Team", "Notes"],
+            ["Group", "Function", "Deliverable"],
+            ["Phase A", "Discovery", "Kickoff scope lock"],
+        ]
+
+        markdown = _table_text_from_rows(rows)
+
+        self.assertIn("| Stage<br>Group | Team<br>Function | Notes<br>Deliverable |", markdown)
+        self.assertIn("| Phase A | Discovery | Kickoff scope lock |", markdown)
+
+    def test_split_repeated_header_removes_repeated_two_row_header_block(self) -> None:
+        prev_rows = [
+            ["Stage", "Team", "Notes"],
+            ["Group", "Function", "Deliverable"],
+            ["Phase A", "Discovery", "Kickoff scope lock"],
+        ]
+        curr_rows = [
+            ["Stage", "Team", "Notes"],
+            ["Group", "Function", "Deliverable"],
+            ["", "Design", "UX skeleton review"],
+        ]
+
+        self.assertEqual(
+            [["", "Design", "UX skeleton review"]],
+            _split_repeated_header(prev_rows, curr_rows),
+        )


### PR DESCRIPTION
## Summary
- add multi-row header metadata to the sample stage table and render it in the generated sample PDF
- collapse repeated top header rows into one logical markdown header row while preserving cross-page repeated-header removal
- add regression tests for helper-level and pipeline-level multi-row header behavior

## Validation
- python3 -m unittest discover -s tests
