### PR TITLE
Expose edge style fields in debug payloads

### DIFF
--- a/graph_pdf/extractor/shared.py
+++ b/graph_pdf/extractor/shared.py
@@ -87,11 +87,20 @@ def _round_segment(
     body_bottom: float | None = None,
 ) -> dict:
     # Debug payloads use rounded values so JSON stays readable and stable across runs.
+    stroking_color = edge.get("stroking_color")
+    non_stroking_color = edge.get("non_stroking_color")
     payload = {
         "x0": round(float(edge["x0"]), 2),
         "x1": round(float(edge["x1"]), 2),
         "top": round(float(edge["top"]), 2),
         "bottom": round(float(edge["bottom"]), 2),
+        "linewidth": round(float(edge.get("linewidth", 0.0)), 2),
+        "stroke": bool(edge.get("stroke", False)),
+        "dash": edge.get("dash"),
+        "object_type": edge.get("object_type"),
+        "orientation": edge.get("orientation"),
+        "stroking_color": list(stroking_color) if isinstance(stroking_color, tuple) else stroking_color,
+        "non_stroking_color": list(non_stroking_color) if isinstance(non_stroking_color, tuple) else non_stroking_color,
     }
     if body_top is not None and body_bottom is not None:
         payload["in_body_bounds"] = (

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -217,6 +217,9 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertEqual(3, payload["tables"][0]["col_count"])
         self.assertTrue(payload["tables"][0]["horizontal_groups"])
         self.assertTrue(payload["tables"][0]["vertical_groups"])
+        self.assertIn("stroking_color", payload["tables"][0]["horizontal_segments"][0])
+        self.assertIn("linewidth", payload["tables"][0]["horizontal_segments"][0])
+        self.assertIn("stroke", payload["tables"][0]["horizontal_segments"][0])
 
     def test_debug_writes_table_drawing_log(self) -> None:
         tmp = tempfile.TemporaryDirectory()
@@ -238,6 +241,8 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertEqual(3, len(payload["pages"]))
         self.assertEqual(3, len(edge_payload["pages"]))
         self.assertIn("text_debug", payload["pages"][0])
+        self.assertIn("stroking_color", payload["pages"][0]["tables"][0]["horizontal_segments"][0])
+        self.assertIn("linewidth", edge_payload["pages"][0]["all_horizontal_edges"][0])
 
     def test_long_legal_notes_row_spans_two_pages(self) -> None:
         markdown = self._extract_table_markdown().lower()

--- a/graph_pdf/tests/test_tables.py
+++ b/graph_pdf/tests/test_tables.py
@@ -129,19 +129,22 @@ class TableModuleTests(unittest.TestCase):
             {"x0": 200.0, "x1": 200.0, "top": 90.2, "bottom": 110.0},
         ]
 
+        horizontal_merged = _merge_horizontal_band_segments(horizontal, tolerance=1.0)
+        vertical_merged = _merge_vertical_band_segments(vertical, tolerance=1.0)
+
         self.assertEqual(
             [
                 {"x0": 10.0, "x1": 80.0, "top": 99.6, "bottom": 100.6},
                 {"x0": 90.5, "x1": 110.0, "top": 100.0, "bottom": 100.0},
             ],
-            _merge_horizontal_band_segments(horizontal, tolerance=1.0),
+            [{key: segment[key] for key in ("x0", "x1", "top", "bottom")} for segment in horizontal_merged],
         )
         self.assertEqual(
             [
                 {"x0": 199.6, "x1": 200.6, "top": 10.0, "bottom": 80.0},
                 {"x0": 200.0, "x1": 200.0, "top": 90.2, "bottom": 110.0},
             ],
-            _merge_vertical_band_segments(vertical, tolerance=1.0),
+            [{key: segment[key] for key in ("x0", "x1", "top", "bottom")} for segment in vertical_merged],
         )
 
     def test_extract_tables_skips_page_wide_fallback_by_default(self) -> None:


### PR DESCRIPTION
## Summary
- extend debug segment payloads with edge style metadata such as stroking color, non-stroking color, line width, dash, and orientation
- keep table detection behavior unchanged while making drawing debug output more informative
- add regression coverage for the expanded debug payload shape

## Validation
- python3 -m unittest discover -s tests
