### PR TITLE
Expand extractor debug payload for drawings and text profiles

### DIFF
--- a/graph_pdf/README.md
+++ b/graph_pdf/README.md
@@ -60,8 +60,8 @@ python3 -m extractor sample.pdf \
 - `artifacts/manual/md/sample.md`: 본문 markdown
 - `artifacts/manual/md/sample_table.md`: 표 markdown
 - `artifacts/manual/md/sample_summary.json`: 추출 요약
-- `artifacts/manual/md/sample_debug.json`: 표 구조 디버그 (`--debug`)
-- `artifacts/manual/md/sample_edges_debug.json`: edge 디버그 (`--debug`)
+- `artifacts/manual/md/sample_debug.json`: 표 구조 + 원본 drawing 객체 + 텍스트 폰트 크기 프로파일 디버그 (`--debug`)
+- `artifacts/manual/md/sample_edges_debug.json`: edge 분해 결과 디버그 (`--debug`)
 - `artifacts/manual/md/sample_watermark_debug.json`: 회전 문자 디버그 (`--debug-watermark`)
 - `artifacts/manual/images/*`: body 영역 이미지 추출 결과
 
@@ -76,7 +76,7 @@ python3 -m extractor sample.pdf \
 - `extractor/pipeline.py`: 전체 PDF 추출 orchestration, 페이지 순회, cross-page table merge, 결과 파일 기록
 - `extractor/text.py`: 워터마크/레이아웃 artifact 제거, body bounds 계산, 본문 line 추출과 정규화
 - `extractor/tables.py`: 표 영역 탐지, 표 추출, 셀 정규화, 페이지 간 표 continuation merge 판단, markdown table 렌더링
-- `extractor/debug.py`: 표 선분/그리드 디버그와 회전 문자 디버그 payload 생성
+- `extractor/debug.py`: 표 선분/그리드, 원본 drawing 객체, 텍스트 스타일/폰트 크기 디버그 payload 생성
 - `extractor/images.py`: body 영역과 겹치는 embedded image만 저장
 - `extractor/shared.py`: 공통 타입, 상수, geometry/segment helper
 - `tests/test_text.py`: 본문/워터마크/바운드 계산 관련 테스트
@@ -108,7 +108,7 @@ python3 -m extractor sample.pdf \
 ## pipeline 흐름
 1. `extract_pdf_to_outputs(...)`가 PDF를 열고 출력 디렉터리를 준비합니다.
 2. 선택된 페이지 범위가 있으면 그 페이지들만 순회합니다.
-3. `debug=True`면 표 구조/edge 디버그 payload를 수집합니다.
+3. `debug=True`면 표 구조, 원본 drawing 객체, 텍스트 폰트 크기 프로파일, edge 디버그 payload를 수집합니다.
 4. `debug_watermark=True`면 회전된 문자 디버그 payload를 수집합니다.
 5. `extractor.tables._extract_tables(...)`가 현재 페이지의 표 후보를 찾고 행 데이터를 정규화합니다.
 6. `extractor.text._extract_body_text(...)`가 전체 body text를 구합니다.

--- a/graph_pdf/extractor/debug.py
+++ b/graph_pdf/extractor/debug.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from typing import List
 
 from .shared import (
@@ -8,10 +9,36 @@ from .shared import (
     _merge_horizontal_band_segments,
     _merge_numeric_positions,
     _merge_vertical_band_segments,
+    _round_graphic_object,
     _round_segment,
 )
 from .tables import _table_regions
 from .text import _detect_body_bounds, _extract_body_text_lines, _extract_body_word_lines
+
+
+def _build_text_profile(line_payloads: List[dict]) -> dict:
+    # Text-size histograms are meant for debugging future document-structure heuristics.
+    font_size_counter: Counter[float] = Counter()
+    fontname_counter: Counter[str] = Counter()
+    for line in line_payloads:
+        for size in line.get("font_size_candidates", []):
+            font_size_counter[round(float(size), 2)] += 1
+        for fontname in line.get("fontnames", []):
+            if str(fontname):
+                fontname_counter[str(fontname)] += 1
+
+    dominant_font_size = max(font_size_counter, key=font_size_counter.get) if font_size_counter else 0.0
+    dominant_fontname = max(fontname_counter, key=fontname_counter.get) if fontname_counter else ""
+    return {
+        "line_count": len(line_payloads),
+        "font_size_histogram": {
+            f"{size:.2f}": count for size, count in sorted(font_size_counter.items())
+        },
+        "fontname_histogram": dict(sorted(fontname_counter.items())),
+        "font_size_candidates": sorted(font_size_counter),
+        "dominant_font_size": dominant_font_size,
+        "dominant_fontname": dominant_fontname,
+    }
 
 
 def _collect_rotated_text_debug(page: "pdfplumber.page.Page", page_no: int) -> List[dict]:
@@ -103,13 +130,29 @@ def _collect_table_drawing_debug(
 
     line_payloads = _extract_body_word_lines(page=page, header_margin=header_margin, footer_margin=footer_margin)
     raw_text_lines, normalized_text_lines = _extract_body_text_lines(page, header_margin=header_margin, footer_margin=footer_margin)
+    text_profile = _build_text_profile(line_payloads)
 
     return {
         "page": page_no,
         "body_bounds": [round(body_top, 2), round(body_bottom, 2)],
         "table_count": len(tables),
         "tables": tables,
+        "source_drawings": {
+            "lines": [
+                _round_graphic_object(line, body_top=body_top, body_bottom=body_bottom)
+                for line in getattr(page, "lines", [])
+            ],
+            "rects": [
+                _round_graphic_object(rect, body_top=body_top, body_bottom=body_bottom)
+                for rect in getattr(page, "rects", [])
+            ],
+            "curves": [
+                _round_graphic_object(curve, body_top=body_top, body_bottom=body_bottom)
+                for curve in getattr(page, "curves", [])
+            ],
+        },
         "text_debug": {
+            "profile": text_profile,
             "raw_lines": raw_text_lines,
             "raw_line_boxes": [
                 {
@@ -118,6 +161,13 @@ def _collect_table_drawing_debug(
                     "x1": round(float(line.get("x1", 0.0)), 2),
                     "top": round(float(line.get("top", 0.0)), 2),
                     "bottom": round(float(line.get("bottom", 0.0)), 2),
+                    "size": round(float(line.get("size", 0.0)), 2),
+                    "fontname": str(line.get("fontname") or ""),
+                    "fontnames": list(line.get("fontnames", [])),
+                    "dominant_font_size": round(float(line.get("dominant_font_size", 0.0)), 2),
+                    "font_size_candidates": [
+                        round(float(size), 2) for size in line.get("font_size_candidates", [])
+                    ],
                     "text_start_x": round(float(line.get("text_start_x", line.get("x0", 0.0))), 2),
                     "marker_candidate": bool(line.get("marker_candidate")),
                 }

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 import json
 from pathlib import Path
 from typing import List, Optional, Sequence, Tuple
@@ -22,6 +23,38 @@ from .tables import (
     _vertical_axes_for_bbox,
 )
 from .text import _detect_body_bounds, _extract_body_text
+
+
+def _document_text_profile(debug_pages: Sequence[dict]) -> dict:
+    # Document-level text profile lets later structure rules pick thresholds from observed font sizes.
+    font_size_counter: Counter[float] = Counter()
+    fontname_counter: Counter[str] = Counter()
+    pages_using_size: dict[float, set[int]] = {}
+    for page in debug_pages:
+        page_no = int(page.get("page", 0))
+        page_profile = page.get("text_debug", {}).get("profile", {})
+        for size_text, count in page_profile.get("font_size_histogram", {}).items():
+            size = round(float(size_text), 2)
+            font_size_counter[size] += int(count)
+            pages_using_size.setdefault(size, set()).add(page_no)
+        for fontname, count in page_profile.get("fontname_histogram", {}).items():
+            if str(fontname):
+                fontname_counter[str(fontname)] += int(count)
+
+    dominant_font_size = max(font_size_counter, key=font_size_counter.get) if font_size_counter else 0.0
+    dominant_fontname = max(fontname_counter, key=fontname_counter.get) if fontname_counter else ""
+    return {
+        "font_size_histogram": {
+            f"{size:.2f}": count for size, count in sorted(font_size_counter.items())
+        },
+        "fontname_histogram": dict(sorted(fontname_counter.items())),
+        "font_size_candidates": sorted(font_size_counter),
+        "dominant_font_size": dominant_font_size,
+        "dominant_fontname": dominant_fontname,
+        "pages_using_size": {
+            f"{size:.2f}": sorted(page_numbers) for size, page_numbers in sorted(pages_using_size.items())
+        },
+    }
 
 
 def _body_excluded_bboxes(
@@ -223,7 +256,18 @@ def extract_pdf_to_outputs(
     debug_edges_file: Optional[Path] = None
     if debug:
         debug_file = out_md_dir / f"{stem}_debug.json"
-        debug_file.write_text(json.dumps({"pdf": str(pdf_path), "pages": table_debug_pages}, ensure_ascii=False, indent=2), encoding="utf-8")
+        debug_file.write_text(
+            json.dumps(
+                {
+                    "pdf": str(pdf_path),
+                    "document_text_profile": _document_text_profile(table_debug_pages),
+                    "pages": table_debug_pages,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
         debug_edges_file = out_md_dir / f"{stem}_edges_debug.json"
         debug_edges_file.write_text(json.dumps({"pdf": str(pdf_path), "pages": edge_debug_pages}, ensure_ascii=False, indent=2), encoding="utf-8")
 

--- a/graph_pdf/extractor/shared.py
+++ b/graph_pdf/extractor/shared.py
@@ -87,8 +87,8 @@ def _round_segment(
     body_bottom: float | None = None,
 ) -> dict:
     # Debug payloads use rounded values so JSON stays readable and stable across runs.
-    stroking_color = edge.get("stroking_color")
-    non_stroking_color = edge.get("non_stroking_color")
+    stroking_color = _normalize_debug_color(edge.get("stroking_color"))
+    non_stroking_color = _normalize_debug_color(edge.get("non_stroking_color"))
     payload = {
         "x0": round(float(edge["x0"]), 2),
         "x1": round(float(edge["x1"]), 2),
@@ -99,12 +99,51 @@ def _round_segment(
         "dash": edge.get("dash"),
         "object_type": edge.get("object_type"),
         "orientation": edge.get("orientation"),
-        "stroking_color": list(stroking_color) if isinstance(stroking_color, tuple) else stroking_color,
-        "non_stroking_color": list(non_stroking_color) if isinstance(non_stroking_color, tuple) else non_stroking_color,
+        "stroking_color": stroking_color,
+        "non_stroking_color": non_stroking_color,
     }
     if body_top is not None and body_bottom is not None:
         payload["in_body_bounds"] = (
             float(edge["bottom"]) > body_top and float(edge["top"]) < body_bottom
+        )
+    return payload
+
+
+def _normalize_debug_color(color: object) -> object:
+    if isinstance(color, tuple):
+        return [round(float(value), 3) for value in color]
+    if isinstance(color, list):
+        return [round(float(value), 3) for value in color]
+    if isinstance(color, (int, float)):
+        return round(float(color), 3)
+    return color
+
+
+def _round_graphic_object(
+    obj: dict,
+    body_top: float | None = None,
+    body_bottom: float | None = None,
+) -> dict:
+    # Drawing debug exposes original objects with the same rounded coordinate style as edge debug.
+    payload = {
+        "x0": round(float(obj.get("x0", 0.0)), 2),
+        "x1": round(float(obj.get("x1", obj.get("x0", 0.0))), 2),
+        "top": round(float(obj.get("top", 0.0)), 2),
+        "bottom": round(float(obj.get("bottom", obj.get("top", 0.0))), 2),
+        "width": round(float(obj.get("width", 0.0)), 2),
+        "height": round(float(obj.get("height", 0.0)), 2),
+        "linewidth": round(float(obj.get("linewidth", 0.0)), 2),
+        "stroke": bool(obj.get("stroke", False)),
+        "fill": bool(obj.get("fill", False)),
+        "dash": obj.get("dash"),
+        "evenodd": bool(obj.get("evenodd", False)),
+        "object_type": obj.get("object_type"),
+        "stroking_color": _normalize_debug_color(obj.get("stroking_color")),
+        "non_stroking_color": _normalize_debug_color(obj.get("non_stroking_color")),
+    }
+    if body_top is not None and body_bottom is not None:
+        payload["in_body_bounds"] = (
+            float(obj.get("bottom", 0.0)) > body_top and float(obj.get("top", 0.0)) < body_bottom
         )
     return payload
 

--- a/graph_pdf/extractor/text.py
+++ b/graph_pdf/extractor/text.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 import re
 from typing import List, Sequence, Tuple
 
@@ -335,6 +336,9 @@ def _extract_body_word_lines(
 
         fontnames = [str(word.get("fontname") or "") for word in ordered if str(word.get("fontname") or "")]
         dominant_font = max(fontnames, key=fontnames.count) if fontnames else ""
+        size_candidates = [round(float(word.get("size", 0.0)), 2) for word in ordered if float(word.get("size", 0.0)) > 0.0]
+        size_counter = Counter(size_candidates)
+        dominant_font_size = max(size_counter, key=size_counter.get) if size_counter else 0.0
         colors = [word.get("non_stroking_color") or word.get("stroking_color") for word in ordered]
         normalized_colors = [color for color in colors if isinstance(color, tuple) and len(color) >= 3]
         dominant_color = None
@@ -385,6 +389,9 @@ def _extract_body_word_lines(
                 "bottom": max(float(word.get("bottom", 0.0)) for word in ordered),
                 "size": sum(float(word.get("size", 0.0)) for word in ordered) / max(len(ordered), 1),
                 "fontname": dominant_font,
+                "fontnames": sorted(set(fontnames)),
+                "dominant_font_size": dominant_font_size,
+                "font_size_candidates": sorted(size_counter),
                 "color": dominant_color,
                 "is_bold": bool(re.search(r"bold", dominant_font, flags=re.IGNORECASE)),
                 "is_italic": bool(re.search(r"(italic|oblique)", dominant_font, flags=re.IGNORECASE)),

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -220,6 +220,16 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertIn("stroking_color", payload["tables"][0]["horizontal_segments"][0])
         self.assertIn("linewidth", payload["tables"][0]["horizontal_segments"][0])
         self.assertIn("stroke", payload["tables"][0]["horizontal_segments"][0])
+        self.assertIn("source_drawings", payload)
+        self.assertIn("lines", payload["source_drawings"])
+        self.assertIn("rects", payload["source_drawings"])
+        self.assertIn("curves", payload["source_drawings"])
+        self.assertTrue(payload["source_drawings"]["lines"])
+        self.assertIn("profile", payload["text_debug"])
+        self.assertIn("dominant_font_size", payload["text_debug"]["profile"])
+        self.assertIn("font_size_histogram", payload["text_debug"]["profile"])
+        self.assertIn("font_size_candidates", payload["text_debug"]["raw_line_boxes"][0])
+        self.assertIn("dominant_font_size", payload["text_debug"]["raw_line_boxes"][0])
 
     def test_debug_writes_table_drawing_log(self) -> None:
         tmp = tempfile.TemporaryDirectory()
@@ -242,6 +252,11 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertEqual(3, len(edge_payload["pages"]))
         self.assertIn("text_debug", payload["pages"][0])
         self.assertIn("stroking_color", payload["pages"][0]["tables"][0]["horizontal_segments"][0])
+        self.assertIn("document_text_profile", payload)
+        self.assertIn("font_size_histogram", payload["document_text_profile"])
+        self.assertIn("source_drawings", payload["pages"][0])
+        self.assertIn("lines", payload["pages"][0]["source_drawings"])
+        self.assertIn("profile", payload["pages"][0]["text_debug"])
         self.assertIn("linewidth", edge_payload["pages"][0]["all_horizontal_edges"][0])
 
     def test_long_legal_notes_row_spans_two_pages(self) -> None:


### PR DESCRIPTION
## Summary
- add original drawing object dumps to extractor debug output so line/rect/curve sources can be compared against derived edges
- add page-level and document-level text font-size profiles plus line-level font metadata in text debug output
- update README debug documentation and extend pipeline tests for the expanded payload

## Validation
- python3 -m unittest discover -s tests
