### PR TITLE
Treat single-column box regions as one-cell tables

### DIFF
--- a/graph_pdf/extractor/tables.py
+++ b/graph_pdf/extractor/tables.py
@@ -20,6 +20,7 @@ from .text import (
     _filter_page_for_extraction,
     _is_layout_artifact,
     _normalize_cell_lines,
+    _repair_watermark_bleed,
 )
 
 
@@ -443,6 +444,134 @@ def _table_regions(
     return sorted(groups, key=lambda item: min(float(edge["top"]) for edge in item[2]))
 
 
+def _merge_touching_fill_rects(
+    rects: Sequence[dict],
+    tolerance: float = 1.0,
+) -> List[Tuple[float, float, float, float]]:
+    # Adjacent fill-only rects often represent one visual box split into multiple PDF drawing objects.
+    merged: List[Tuple[float, float, float, float]] = []
+    ordered = sorted(
+        rects,
+        key=lambda rect: (
+            round(float(rect.get("top", 0.0)), 1),
+            round(float(rect.get("bottom", 0.0)), 1),
+            float(rect.get("x0", 0.0)),
+        ),
+    )
+    for rect in ordered:
+        candidate = (
+            float(rect.get("x0", 0.0)),
+            float(rect.get("top", 0.0)),
+            float(rect.get("x1", 0.0)),
+            float(rect.get("bottom", 0.0)),
+        )
+        if not merged:
+            merged.append(candidate)
+            continue
+
+        prev_x0, prev_top, prev_x1, prev_bottom = merged[-1]
+        cur_x0, cur_top, cur_x1, cur_bottom = candidate
+        same_band = abs(prev_top - cur_top) <= tolerance and abs(prev_bottom - cur_bottom) <= tolerance
+        touching = cur_x0 <= prev_x1 + tolerance
+        if same_band and touching:
+            merged[-1] = (
+                min(prev_x0, cur_x0),
+                min(prev_top, cur_top),
+                max(prev_x1, cur_x1),
+                max(prev_bottom, cur_bottom),
+            )
+            continue
+        merged.append(candidate)
+    return merged
+
+
+def _single_column_box_regions(page: pdfplumber.page.PageObject) -> List[Tuple[float, float, float, float]]:
+    # Detect box-like regions that visually behave as one cell even if the PDF uses multiple fill rects inside.
+    body_top, body_bottom = _detect_body_bounds(page, header_margin=90.0, footer_margin=40.0)
+    fill_rects = [
+        rect
+        for rect in getattr(page, "rects", [])
+        if bool(rect.get("fill"))
+        and not bool(rect.get("stroke"))
+        and float(rect.get("bottom", 0.0)) > body_top
+        and float(rect.get("top", 0.0)) < body_bottom
+    ]
+    candidates: List[Tuple[float, float, float, float]] = []
+    for bbox in _merge_touching_fill_rects(fill_rects):
+        x0, top, x1, bottom = bbox
+        width = x1 - x0
+        height = bottom - top
+        if width < 120.0 or height < 36.0:
+            continue
+
+        stroke_horizontal = [
+            edge
+            for edge in page.horizontal_edges
+            if bool(edge.get("stroke"))
+            and float(edge.get("x0", 0.0)) <= x0 + 1.0
+            and float(edge.get("x1", 0.0)) >= x1 - 1.0
+            and (
+                abs(float(edge.get("top", 0.0)) - top) <= 1.5
+                or abs(float(edge.get("top", 0.0)) - bottom) <= 1.5
+            )
+        ]
+        horizontal_positions = _merge_numeric_positions([float(edge["top"]) for edge in stroke_horizontal], tolerance=1.0)
+        if len(horizontal_positions) != 2:
+            continue
+
+        internal_verticals = _merge_numeric_positions(
+            [
+                float(edge["x0"])
+                for edge in page.vertical_edges
+                if bool(edge.get("stroke"))
+                and float(edge.get("x0", 0.0)) > x0 + 2.0
+                and float(edge.get("x0", 0.0)) < x1 - 2.0
+                and float(edge.get("top", 0.0)) <= bottom
+                and float(edge.get("bottom", 0.0)) >= top
+            ],
+            tolerance=1.0,
+        )
+        if internal_verticals:
+            continue
+        candidates.append(bbox)
+    return candidates
+
+
+def _extract_text_from_box_region(
+    page: pdfplumber.page.PageObject,
+    bbox: Tuple[float, float, float, float],
+) -> str:
+    # Box-like regions should collapse into one cell, preserving visual line breaks inside the box.
+    filtered_page = _filter_page_for_extraction(page)
+    words = (
+        filtered_page
+        .crop(bbox)
+        .extract_words(x_tolerance=1.5, y_tolerance=2.0, keep_blank_chars=False)
+        or []
+    )
+    grouped_lines: List[List[dict]] = []
+    for word in sorted(words, key=lambda item: (float(item.get("top", 0.0)), float(item.get("x0", 0.0)))):
+        cleaned = _repair_watermark_bleed(str(word.get("text") or "").strip())
+        if not cleaned or _is_layout_artifact(cleaned):
+            continue
+        if not grouped_lines or abs(float(word.get("top", 0.0)) - float(grouped_lines[-1][0].get("top", 0.0))) > 2.5:
+            grouped_lines.append([word])
+            continue
+        grouped_lines[-1].append(word)
+
+    lines: List[str] = []
+    for words_in_line in grouped_lines:
+        ordered = sorted(words_in_line, key=lambda item: float(item.get("x0", 0.0)))
+        text = " ".join(
+            _repair_watermark_bleed(str(word.get("text") or "").strip())
+            for word in ordered
+            if _repair_watermark_bleed(str(word.get("text") or "").strip())
+        ).strip()
+        if text:
+            lines.append(text)
+    return "\n".join(lines)
+
+
 def _extract_tables_from_crop(
     page: pdfplumber.page.PageObject,
     crop_bbox: Tuple[float, float, float, float],
@@ -519,6 +648,18 @@ def _extract_tables(
             if key not in seen_keys:
                 seen_keys.add(key)
                 merged.append((table, crop_box))
+
+    for crop_bbox in _single_column_box_regions(page):
+        cell_text = _extract_text_from_box_region(page, crop_bbox)
+        if not cell_text:
+            continue
+        table = [[cell_text]]
+        rows_key = tuple(tuple(row) for row in table)
+        bbox_key = tuple(round(v, 2) for v in crop_bbox)
+        key = (rows_key, bbox_key)
+        if key not in seen_keys:
+            seen_keys.add(key)
+            merged.append((table, crop_bbox))
 
     if merged or not force_table:
         return merged

--- a/graph_pdf/fixtures/demo_document.json
+++ b/graph_pdf/fixtures/demo_document.json
@@ -103,9 +103,18 @@
         ["Ops", "OK", "Archive path\n- cleanup\n- index refresh"],
         ["Support", "REVIEW", "Escalation owner confirmed.\nRegional fallback documented.\nLaunch blackout window approved."]
       ]
+    },
+    {
+      "id": "callout",
+      "columns": ["Notice"],
+      "rows": [
+        [
+          "Escalation lane summary Owner confirmed for regional review and exception routing.\nBackup approver stays on the same visual box and must not become a second table row."
+        ]
+      ]
     }
   ],
   "expectations": {
-    "page_count": 3
+    "page_count": 4
   }
 }

--- a/graph_pdf/sample_generator.py
+++ b/graph_pdf/sample_generator.py
@@ -258,6 +258,35 @@ class DemoPdfBuilder:
         if self.cursor_y < self.body_bottom + 8:
             self._start_new_page()
 
+    def add_single_column_box(self, text: str) -> None:
+        # This shape looks like a single highlighted row visually, but the text spans multiple visual lines.
+        box_width = self.width - (2 * self.margin_x)
+        box_height = 82.0
+        self._ensure_space(box_height + 12.0)
+
+        x0 = self.margin_x
+        y0 = self.cursor_y - box_height
+        mid_x = x0 + (box_width / 2.0)
+
+        self.canvas.setStrokeColor(colors.Color(0.2, 0.5, 0.9))
+        self.canvas.setLineWidth(1.0)
+        self.canvas.line(x0, self.cursor_y, x0 + box_width, self.cursor_y)
+        self.canvas.line(x0, y0, x0 + box_width, y0)
+
+        # Two touching fill-only rects simulate layout blocks that should still behave as one cell.
+        self.canvas.setFillColor(colors.white)
+        self.canvas.rect(x0, y0, box_width / 2.0, box_height, stroke=0, fill=1)
+        self.canvas.rect(mid_x, y0, box_width / 2.0, box_height, stroke=0, fill=1)
+
+        self.canvas.setFillColor(colors.black)
+        self.canvas.setFont("Helvetica", 11)
+        text_y = self.cursor_y - 16.0
+        for line in _split_cell_lines(text):
+            self.canvas.drawString(x0 + 8.0, text_y, line)
+            text_y -= 16.0
+
+        self.cursor_y = y0 - 18.0
+
     def _draw_table_block(
         self,
         header_rows: Sequence[TableRow],
@@ -618,5 +647,7 @@ def create_demo_pdf(path: Path) -> None:
     builder.add_gap(24.0)
 
     builder.add_body_text(footer_lines)
+    builder._start_new_page()
+    builder.add_single_column_box(tables["callout"][1][0][0])
 
     builder.save()

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -92,6 +92,16 @@ class PipelineExtractionTests(unittest.TestCase):
             markdown,
         )
 
+    def test_single_column_box_like_region_is_emitted_as_one_cell_table(self) -> None:
+        markdown = self._extract_table_markdown()
+        self.assertIn("| Column 1 |", markdown)
+        self.assertIn(
+            "| Escalation lane summary Owner confirmed for regional review and exception routing.<br>Backup approver stays on the same visual box and must not become a second table row. |",
+            markdown,
+        )
+        self.assertNotIn("| Escalation lane summary |", markdown)
+        self.assertNotIn("| Owner confirmed for regional review and exception routing. |", markdown)
+
     def test_extract_can_limit_to_selected_pages(self) -> None:
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
@@ -151,7 +161,7 @@ class PipelineExtractionTests(unittest.TestCase):
     def test_spanning_stage_table_merges_into_one_block(self) -> None:
         markdown = self._extract_table_markdown()
         blocks = self._table_blocks(markdown)
-        self.assertEqual(3, len(blocks))
+        self.assertEqual(4, len(blocks))
         stage_block = next((block for block in blocks if "Phase A" in block), "")
         self.assertTrue(stage_block)
         self.assertIn("Release Notes", stage_block)
@@ -170,7 +180,7 @@ class PipelineExtractionTests(unittest.TestCase):
             raw_image_count = sum(len(page.images) for page in pdf.pages)
 
         result = self._extract_result()
-        self.assertEqual(5, raw_image_count)
+        self.assertEqual(6, raw_image_count)
         self.assertEqual(2, len(result["image_files"]))
 
     def test_debug_watermark_writes_rotated_text_log(self) -> None:
@@ -248,8 +258,8 @@ class PipelineExtractionTests(unittest.TestCase):
 
         payload = json.loads(result["debug_file"].read_text(encoding="utf-8"))
         edge_payload = json.loads(result["debug_edges_file"].read_text(encoding="utf-8"))
-        self.assertEqual(3, len(payload["pages"]))
-        self.assertEqual(3, len(edge_payload["pages"]))
+        self.assertEqual(4, len(payload["pages"]))
+        self.assertEqual(4, len(edge_payload["pages"]))
         self.assertIn("text_debug", payload["pages"][0])
         self.assertIn("stroking_color", payload["pages"][0]["tables"][0]["horizontal_segments"][0])
         self.assertIn("document_text_profile", payload)
@@ -267,7 +277,7 @@ class PipelineExtractionTests(unittest.TestCase):
     def test_demo_pdf_has_rotated_gray_watermark_on_every_page(self) -> None:
         pdf_path = self._build_pdf()
         with pdfplumber.open(str(pdf_path)) as pdf:
-            self.assertEqual(len(pdf.pages), 3)
+            self.assertEqual(len(pdf.pages), 4)
             for page in pdf.pages:
                 watermark_chars = [
                     char


### PR DESCRIPTION
## Summary
- add a 4-page sample PDF case for visually single-column box regions that should stay as one cell
- detect fill-only rect boxes with only top/bottom stroke lines and collapse them into 1x1 table output
- update pipeline tests and fixture expectations for the new sample case

## Validation
- python3 -m unittest discover -s tests
