### PR TITLE
Detect single-column box boundaries from thin rect strips

### DIFF
--- a/graph_pdf/extractor/tables.py
+++ b/graph_pdf/extractor/tables.py
@@ -485,6 +485,16 @@ def _merge_touching_fill_rects(
     return merged
 
 
+def _thin_strip_rects(rects: Sequence[dict], max_height: float = 1.5) -> List[dict]:
+    # Some PDFs use filled rect strips instead of stroked lines for box boundaries.
+    return [
+        rect
+        for rect in rects
+        if bool(rect.get("fill"))
+        and float(rect.get("bottom", 0.0)) - float(rect.get("top", 0.0)) <= max_height
+    ]
+
+
 def _single_column_box_regions(page: pdfplumber.page.PageObject) -> List[Tuple[float, float, float, float]]:
     # Detect box-like regions that visually behave as one cell even if the PDF uses multiple fill rects inside.
     body_top, body_bottom = _detect_body_bounds(page, header_margin=90.0, footer_margin=40.0)
@@ -492,30 +502,35 @@ def _single_column_box_regions(page: pdfplumber.page.PageObject) -> List[Tuple[f
         rect
         for rect in getattr(page, "rects", [])
         if bool(rect.get("fill"))
-        and not bool(rect.get("stroke"))
         and float(rect.get("bottom", 0.0)) > body_top
         and float(rect.get("top", 0.0)) < body_bottom
     ]
+    boundary_rects = _thin_strip_rects(fill_rects)
+    content_rects = [
+        rect
+        for rect in fill_rects
+        if rect not in boundary_rects and not bool(rect.get("stroke"))
+    ]
     candidates: List[Tuple[float, float, float, float]] = []
-    for bbox in _merge_touching_fill_rects(fill_rects):
+    for bbox in _merge_touching_fill_rects(content_rects):
         x0, top, x1, bottom = bbox
         width = x1 - x0
         if width < 120.0:
             continue
 
-        stroke_horizontal = [
-            edge
-            for edge in page.horizontal_edges
-            if bool(edge.get("stroke"))
-            and float(edge.get("x0", 0.0)) <= x0 + 1.0
-            and float(edge.get("x1", 0.0)) >= x1 - 1.0
-            and (
-                abs(float(edge.get("top", 0.0)) - top) <= 1.5
-                or abs(float(edge.get("top", 0.0)) - bottom) <= 1.5
-            )
-        ]
-        horizontal_positions = _merge_numeric_positions([float(edge["top"]) for edge in stroke_horizontal], tolerance=1.0)
-        if len(horizontal_positions) != 2:
+        top_strip = any(
+            float(rect.get("x0", 0.0)) <= x0 + 1.0
+            and float(rect.get("x1", 0.0)) >= x1 - 1.0
+            and abs(float(rect.get("bottom", 0.0)) - top) <= 1.5
+            for rect in boundary_rects
+        )
+        bottom_strip = any(
+            float(rect.get("x0", 0.0)) <= x0 + 1.0
+            and float(rect.get("x1", 0.0)) >= x1 - 1.0
+            and abs(float(rect.get("top", 0.0)) - bottom) <= 1.5
+            for rect in boundary_rects
+        )
+        if not top_strip or not bottom_strip:
             continue
 
         internal_verticals = _merge_numeric_positions(

--- a/graph_pdf/sample_generator.py
+++ b/graph_pdf/sample_generator.py
@@ -259,7 +259,7 @@ class DemoPdfBuilder:
             self._start_new_page()
 
     def add_single_column_box(self, text: str) -> None:
-        # This shape looks like a single highlighted row visually, but the text spans multiple visual lines.
+        # This shape uses thin filled rect strips instead of stroked lines for the top and bottom boundary.
         box_width = self.width - (2 * self.margin_x)
         box_height = 82.0
         self._ensure_space(box_height + 12.0)
@@ -267,16 +267,16 @@ class DemoPdfBuilder:
         x0 = self.margin_x
         y0 = self.cursor_y - box_height
         mid_x = x0 + (box_width / 2.0)
+        strip_height = 1.0
 
-        self.canvas.setStrokeColor(colors.Color(0.2, 0.5, 0.9))
-        self.canvas.setLineWidth(1.0)
-        self.canvas.line(x0, self.cursor_y, x0 + box_width, self.cursor_y)
-        self.canvas.line(x0, y0, x0 + box_width, y0)
+        self.canvas.setFillColor(colors.Color(0.2, 0.5, 0.9))
+        self.canvas.rect(x0, self.cursor_y - strip_height, box_width, strip_height, stroke=0, fill=1)
+        self.canvas.rect(x0, y0, box_width, strip_height, stroke=0, fill=1)
 
         # Two touching fill-only rects simulate layout blocks that should still behave as one cell.
         self.canvas.setFillColor(colors.white)
-        self.canvas.rect(x0, y0, box_width / 2.0, box_height, stroke=0, fill=1)
-        self.canvas.rect(mid_x, y0, box_width / 2.0, box_height, stroke=0, fill=1)
+        self.canvas.rect(x0, y0 + strip_height, box_width / 2.0, box_height - (2 * strip_height), stroke=0, fill=1)
+        self.canvas.rect(mid_x, y0 + strip_height, box_width / 2.0, box_height - (2 * strip_height), stroke=0, fill=1)
 
         self.canvas.setFillColor(colors.black)
         self.canvas.setFont("Helvetica", 11)

--- a/graph_pdf/tests/test_tables.py
+++ b/graph_pdf/tests/test_tables.py
@@ -195,26 +195,43 @@ class TableModuleTests(unittest.TestCase):
             rects=[
                 {
                     "x0": 40.0,
-                    "x1": 290.0,
+                    "x1": 540.0,
                     "top": 120.0,
+                    "bottom": 121.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": (0.2, 0.5, 0.9),
+                },
+                {
+                    "x0": 40.0,
+                    "x1": 290.0,
+                    "top": 121.0,
                     "bottom": 148.0,
                     "fill": True,
                     "stroke": False,
+                    "non_stroking_color": 1,
                 },
                 {
                     "x0": 290.0,
                     "x1": 540.0,
-                    "top": 120.0,
+                    "top": 121.0,
                     "bottom": 148.0,
                     "fill": True,
                     "stroke": False,
+                    "non_stroking_color": 1,
+                },
+                {
+                    "x0": 40.0,
+                    "x1": 540.0,
+                    "top": 148.0,
+                    "bottom": 149.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": (0.2, 0.5, 0.9),
                 },
             ],
-            horizontal_edges=[
-                {"x0": 40.0, "x1": 540.0, "top": 120.0, "bottom": 120.0, "stroke": True},
-                {"x0": 40.0, "x1": 540.0, "top": 148.0, "bottom": 148.0, "stroke": True},
-            ],
+            horizontal_edges=[],
             vertical_edges=[],
         )
 
-        self.assertEqual([(40.0, 120.0, 540.0, 148.0)], _single_column_box_regions(page))
+        self.assertEqual([(40.0, 121.0, 540.0, 148.0)], _single_column_box_regions(page))


### PR DESCRIPTION
## Summary
- update the single-column box detector to use thin filled rect strips as the top/bottom boundary signal instead of stroked horizontal lines
- rebuild the sample page-4 callout case with colored 1pt rect strips to match the real document shape more closely
- refresh the focused box-detection unit test for the new rect-strip boundary condition

## Validation
- python3 -m unittest discover -s tests
