### PR TITLE
Reclassify misdetected single-column box tables

### DIFF
--- a/graph_pdf/extractor/tables.py
+++ b/graph_pdf/extractor/tables.py
@@ -586,6 +586,37 @@ def _extract_text_from_box_region(
     return "\n".join(lines)
 
 
+def _bbox_area(bbox: Tuple[float, float, float, float]) -> float:
+    x0, y0, x1, y1 = bbox
+    return max(0.0, x1 - x0) * max(0.0, y1 - y0)
+
+
+def _bbox_overlap_ratio(
+    a: Tuple[float, float, float, float],
+    b: Tuple[float, float, float, float],
+) -> float:
+    ix0 = max(a[0], b[0])
+    iy0 = max(a[1], b[1])
+    ix1 = min(a[2], b[2])
+    iy1 = min(a[3], b[3])
+    intersection = _bbox_area((ix0, iy0, ix1, iy1))
+    if intersection <= 0.0:
+        return 0.0
+    return intersection / max(min(_bbox_area(a), _bbox_area(b)), 1.0)
+
+
+def _looks_like_single_column_box_misclassification(rows: TableRows) -> bool:
+    # Reclassify only sparse one-column outputs that are likely a visual box broken into multiple table rows.
+    if not rows or len(rows) < 2:
+        return False
+    column_count = max((len(row) for row in rows), default=0)
+    if column_count != 1:
+        return False
+    if any(not _normalize_text(row[0]) for row in rows if row):
+        return False
+    return True
+
+
 def _extract_tables_from_crop(
     page: pdfplumber.page.PageObject,
     crop_bbox: Tuple[float, float, float, float],
@@ -663,17 +694,28 @@ def _extract_tables(
                 seen_keys.add(key)
                 merged.append((table, crop_box))
 
+    reclassified: List[TableChunk] = []
     for crop_bbox in _single_column_box_regions(page):
         cell_text = _extract_text_from_box_region(page, crop_bbox)
         if not cell_text:
             continue
-        table = [[cell_text]]
-        rows_key = tuple(tuple(row) for row in table)
+        replacement = [[cell_text]]
+        merged = [
+            (rows, bbox)
+            for rows, bbox in merged
+            if not (
+                _bbox_overlap_ratio(bbox, crop_bbox) >= 0.8
+                and _looks_like_single_column_box_misclassification(rows)
+            )
+        ]
+        rows_key = tuple(tuple(row) for row in replacement)
         bbox_key = tuple(round(v, 2) for v in crop_bbox)
         key = (rows_key, bbox_key)
         if key not in seen_keys:
             seen_keys.add(key)
-            merged.append((table, crop_bbox))
+            reclassified.append((replacement, crop_bbox))
+
+    merged.extend(reclassified)
 
     if merged or not force_table:
         return merged

--- a/graph_pdf/tests/test_tables.py
+++ b/graph_pdf/tests/test_tables.py
@@ -159,6 +159,73 @@ class TableModuleTests(unittest.TestCase):
         )
         self.assertEqual([], _extract_tables(page))
 
+    def test_extract_tables_reclassifies_single_column_box_overlapping_detected_table(self) -> None:
+        table_bbox = (40.0, 119.0, 540.0, 150.0)
+        page = SimpleNamespace(
+            width=600.0,
+            height=800.0,
+            rects=[
+                {
+                    "x0": 40.0,
+                    "x1": 540.0,
+                    "top": 120.0,
+                    "bottom": 121.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": (0.2, 0.5, 0.9),
+                },
+                {
+                    "x0": 40.0,
+                    "x1": 290.0,
+                    "top": 121.0,
+                    "bottom": 148.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": 1,
+                },
+                {
+                    "x0": 290.0,
+                    "x1": 540.0,
+                    "top": 121.0,
+                    "bottom": 148.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": 1,
+                },
+                {
+                    "x0": 40.0,
+                    "x1": 540.0,
+                    "top": 148.0,
+                    "bottom": 149.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": (0.2, 0.5, 0.9),
+                },
+            ],
+            horizontal_edges=[],
+            vertical_edges=[],
+            chars=[],
+            filter=lambda fn: page,
+            crop=lambda bbox: SimpleNamespace(
+                extract_words=lambda **kwargs: [
+                    {"text": "Escalation", "x0": 50.0, "x1": 100.0, "top": 126.0, "bottom": 134.0},
+                    {"text": "lane", "x0": 104.0, "x1": 130.0, "top": 126.0, "bottom": 134.0},
+                    {"text": "summary", "x0": 134.0, "x1": 190.0, "top": 126.0, "bottom": 134.0},
+                ]
+            ),
+            extract_tables=lambda **kwargs: [],
+        )
+
+        from unittest.mock import patch
+
+        with patch("extractor.tables._table_regions", return_value=[(40.0, 540.0, [{"top": 121.0}, {"top": 148.0}])]), patch(
+            "extractor.tables._extract_tables_from_crop",
+            return_value=[([["Escalation lane summary"], ["Owner confirmed"]], table_bbox)],
+        ):
+            tables = _extract_tables(page)
+
+        self.assertEqual([([["Escalation lane summary"]], (40.0, 121.0, 540.0, 148.0))], tables)
+
     def test_table_text_from_rows_collapses_two_header_rows_into_single_markdown_header(self) -> None:
         rows = [
             ["Stage", "Team", "Notes"],


### PR DESCRIPTION
## Summary
- replace the old add-on fallback with reclassification logic for box-like single-column regions that were already detected as sparse tables
- drop overlapping one-column multi-row table results when a matching box candidate should be emitted as a 1x1 table instead
- add focused coverage for reclassifying an already-detected table into a single-cell box table

## Validation
- python3 -m unittest discover -s tests
