### PR TITLE
Merge single-column multi-row cells into one box table

### DIFF
--- a/graph_pdf/extractor/tables.py
+++ b/graph_pdf/extractor/tables.py
@@ -448,14 +448,14 @@ def _merge_touching_fill_rects(
     rects: Sequence[dict],
     tolerance: float = 1.0,
 ) -> List[Tuple[float, float, float, float]]:
-    # Adjacent fill-only rects often represent one visual box split into multiple PDF drawing objects.
+    # A single-column boxed region is represented by vertically stacked fill rects with the same x-span.
     merged: List[Tuple[float, float, float, float]] = []
     ordered = sorted(
         rects,
         key=lambda rect: (
-            round(float(rect.get("top", 0.0)), 1),
-            round(float(rect.get("bottom", 0.0)), 1),
             float(rect.get("x0", 0.0)),
+            float(rect.get("x1", 0.0)),
+            round(float(rect.get("top", 0.0)), 1),
         ),
     )
     for rect in ordered:
@@ -471,8 +471,8 @@ def _merge_touching_fill_rects(
 
         prev_x0, prev_top, prev_x1, prev_bottom = merged[-1]
         cur_x0, cur_top, cur_x1, cur_bottom = candidate
-        same_band = abs(prev_top - cur_top) <= tolerance and abs(prev_bottom - cur_bottom) <= tolerance
-        touching = cur_x0 <= prev_x1 + tolerance
+        same_band = abs(prev_x0 - cur_x0) <= tolerance and abs(prev_x1 - cur_x1) <= tolerance
+        touching = cur_top <= prev_bottom + tolerance
         if same_band and touching:
             merged[-1] = (
                 min(prev_x0, cur_x0),
@@ -612,9 +612,14 @@ def _looks_like_single_column_box_misclassification(rows: TableRows) -> bool:
     column_count = max((len(row) for row in rows), default=0)
     if column_count != 1:
         return False
-    if any(not _normalize_text(row[0]) for row in rows if row):
-        return False
-    return True
+    non_empty_rows = [row for row in rows if row and _normalize_text(row[0])]
+    return len(non_empty_rows) >= 2
+
+
+def _collapse_single_column_rows(rows: TableRows) -> str:
+    # Reclassified box tables should preserve the existing top-to-bottom row text as one cell.
+    parts = [str(row[0]).strip() for row in rows if row and _normalize_text(row[0])]
+    return "\n".join(parts).strip()
 
 
 def _extract_tables_from_crop(
@@ -696,18 +701,24 @@ def _extract_tables(
 
     reclassified: List[TableChunk] = []
     for crop_bbox in _single_column_box_regions(page):
-        cell_text = _extract_text_from_box_region(page, crop_bbox)
-        if not cell_text:
-            continue
-        replacement = [[cell_text]]
-        merged = [
-            (rows, bbox)
-            for rows, bbox in merged
-            if not (
+        matched_rows: TableRows | None = None
+        retained: List[TableChunk] = []
+        for rows, bbox in merged:
+            should_replace = (
                 _bbox_overlap_ratio(bbox, crop_bbox) >= 0.8
                 and _looks_like_single_column_box_misclassification(rows)
             )
-        ]
+            if should_replace and matched_rows is None:
+                matched_rows = rows
+                continue
+            retained.append((rows, bbox))
+        merged = retained
+        cell_text = _collapse_single_column_rows(matched_rows or [])
+        if not cell_text:
+            cell_text = _extract_text_from_box_region(page, crop_bbox)
+        if not cell_text:
+            continue
+        replacement = [[cell_text]]
         rows_key = tuple(tuple(row) for row in replacement)
         bbox_key = tuple(round(v, 2) for v in crop_bbox)
         key = (rows_key, bbox_key)

--- a/graph_pdf/sample_generator.py
+++ b/graph_pdf/sample_generator.py
@@ -259,24 +259,32 @@ class DemoPdfBuilder:
             self._start_new_page()
 
     def add_single_column_box(self, text: str) -> None:
-        # This shape uses thin filled rect strips instead of stroked lines for the top and bottom boundary.
+        # This shape is a 1-column multi-row table visually collapsed into one large cell.
         box_width = self.width - (2 * self.margin_x)
         box_height = 82.0
         self._ensure_space(box_height + 12.0)
 
         x0 = self.margin_x
         y0 = self.cursor_y - box_height
-        mid_x = x0 + (box_width / 2.0)
         strip_height = 1.0
+        content_height = box_height - (2 * strip_height)
+        row_height = content_height / 3.0
 
         self.canvas.setFillColor(colors.Color(0.2, 0.5, 0.9))
         self.canvas.rect(x0, self.cursor_y - strip_height, box_width, strip_height, stroke=0, fill=1)
         self.canvas.rect(x0, y0, box_width, strip_height, stroke=0, fill=1)
 
-        # Two touching fill-only rects simulate layout blocks that should still behave as one cell.
+        # Three stacked white rects simulate a one-column, multi-row table that should be merged vertically.
         self.canvas.setFillColor(colors.white)
-        self.canvas.rect(x0, y0 + strip_height, box_width / 2.0, box_height - (2 * strip_height), stroke=0, fill=1)
-        self.canvas.rect(mid_x, y0 + strip_height, box_width / 2.0, box_height - (2 * strip_height), stroke=0, fill=1)
+        for row_idx in range(3):
+            self.canvas.rect(
+                x0,
+                y0 + strip_height + (row_idx * row_height),
+                box_width,
+                row_height,
+                stroke=0,
+                fill=1,
+            )
 
         self.canvas.setFillColor(colors.black)
         self.canvas.setFont("Helvetica", 11)

--- a/graph_pdf/tests/test_tables.py
+++ b/graph_pdf/tests/test_tables.py
@@ -176,17 +176,26 @@ class TableModuleTests(unittest.TestCase):
                 },
                 {
                     "x0": 40.0,
-                    "x1": 290.0,
+                    "x1": 540.0,
                     "top": 121.0,
-                    "bottom": 148.0,
+                    "bottom": 130.0,
                     "fill": True,
                     "stroke": False,
                     "non_stroking_color": 1,
                 },
                 {
-                    "x0": 290.0,
+                    "x0": 40.0,
                     "x1": 540.0,
-                    "top": 121.0,
+                    "top": 130.0,
+                    "bottom": 139.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": 1,
+                },
+                {
+                    "x0": 40.0,
+                    "x1": 540.0,
+                    "top": 139.0,
                     "bottom": 148.0,
                     "fill": True,
                     "stroke": False,
@@ -220,11 +229,11 @@ class TableModuleTests(unittest.TestCase):
 
         with patch("extractor.tables._table_regions", return_value=[(40.0, 540.0, [{"top": 121.0}, {"top": 148.0}])]), patch(
             "extractor.tables._extract_tables_from_crop",
-            return_value=[([["Escalation lane summary"], ["Owner confirmed"]], table_bbox)],
+            return_value=[([["Escalation lane summary"], ["Owner confirmed"], ["Backup approver"]], table_bbox)],
         ):
             tables = _extract_tables(page)
 
-        self.assertEqual([([["Escalation lane summary"]], (40.0, 121.0, 540.0, 148.0))], tables)
+        self.assertEqual([([["Escalation lane summary\nOwner confirmed\nBackup approver"]], (40.0, 121.0, 540.0, 148.0))], tables)
 
     def test_table_text_from_rows_collapses_two_header_rows_into_single_markdown_header(self) -> None:
         rows = [
@@ -271,17 +280,26 @@ class TableModuleTests(unittest.TestCase):
                 },
                 {
                     "x0": 40.0,
-                    "x1": 290.0,
+                    "x1": 540.0,
                     "top": 121.0,
-                    "bottom": 148.0,
+                    "bottom": 130.0,
                     "fill": True,
                     "stroke": False,
                     "non_stroking_color": 1,
                 },
                 {
-                    "x0": 290.0,
+                    "x0": 40.0,
                     "x1": 540.0,
-                    "top": 121.0,
+                    "top": 130.0,
+                    "bottom": 139.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": 1,
+                },
+                {
+                    "x0": 40.0,
+                    "x1": 540.0,
+                    "top": 139.0,
                     "bottom": 148.0,
                     "fill": True,
                     "stroke": False,


### PR DESCRIPTION
## Summary
- rebuild the sample page-4 case as a true one-column multi-row table with stacked white rect cells and top/bottom boundary rect strips
- reclassify already-detected one-column multi-row tables into a single 1x1 cell when the surrounding rect pattern indicates one visual box
- preserve merged cell text by joining the existing extracted row values instead of re-extracting only part of the text from the crop

## Validation
- python3 -m unittest discover -s tests
