### PR TITLE
Derive debug font color from chars

### DIFF
--- a/graph_pdf/extractor/debug.py
+++ b/graph_pdf/extractor/debug.py
@@ -9,6 +9,7 @@ from .shared import (
     _merge_horizontal_band_segments,
     _merge_numeric_positions,
     _merge_vertical_band_segments,
+    _normalize_debug_color,
     _round_graphic_object,
     _round_segment,
 )
@@ -20,12 +21,16 @@ def _build_text_profile(line_payloads: List[dict]) -> dict:
     # Text-size histograms are meant for debugging future document-structure heuristics.
     font_size_counter: Counter[float] = Counter()
     fontname_counter: Counter[str] = Counter()
+    font_color_counter: Counter[str] = Counter()
     for line in line_payloads:
         for size in line.get("font_size_candidates", []):
             font_size_counter[round(float(size), 2)] += 1
         for fontname in line.get("fontnames", []):
             if str(fontname):
                 fontname_counter[str(fontname)] += 1
+        color_key = str(line.get("dominant_font_color") or "")
+        if color_key:
+            font_color_counter[color_key] += 1
 
     dominant_font_size = max(font_size_counter, key=font_size_counter.get) if font_size_counter else 0.0
     dominant_fontname = max(fontname_counter, key=fontname_counter.get) if fontname_counter else ""
@@ -35,10 +40,20 @@ def _build_text_profile(line_payloads: List[dict]) -> dict:
             f"{size:.2f}": count for size, count in sorted(font_size_counter.items())
         },
         "fontname_histogram": dict(sorted(fontname_counter.items())),
+        "font_color_histogram": dict(sorted(font_color_counter.items())),
         "font_size_candidates": sorted(font_size_counter),
         "dominant_font_size": dominant_font_size,
         "dominant_fontname": dominant_fontname,
     }
+
+
+def _color_key(color: object) -> str:
+    normalized = _normalize_debug_color(color)
+    if isinstance(normalized, list):
+        return ",".join(f"{float(value):.3f}" for value in normalized)
+    if isinstance(normalized, (int, float)):
+        return f"{float(normalized):.3f}"
+    return str(normalized or "")
 
 
 def _collect_rotated_text_debug(page: "pdfplumber.page.Page", page_no: int) -> List[dict]:
@@ -129,6 +144,8 @@ def _collect_table_drawing_debug(
         )
 
     line_payloads = _extract_body_word_lines(page=page, header_margin=header_margin, footer_margin=footer_margin)
+    for line in line_payloads:
+        line["dominant_font_color"] = _color_key(line.get("color"))
     raw_text_lines, normalized_text_lines = _extract_body_text_lines(page, header_margin=header_margin, footer_margin=footer_margin)
     text_profile = _build_text_profile(line_payloads)
 
@@ -165,6 +182,7 @@ def _collect_table_drawing_debug(
                     "fontname": str(line.get("fontname") or ""),
                     "fontnames": list(line.get("fontnames", [])),
                     "dominant_font_size": round(float(line.get("dominant_font_size", 0.0)), 2),
+                    "dominant_font_color": str(line.get("dominant_font_color") or ""),
                     "font_size_candidates": [
                         round(float(size), 2) for size in line.get("font_size_candidates", [])
                     ],

--- a/graph_pdf/extractor/debug.py
+++ b/graph_pdf/extractor/debug.py
@@ -28,7 +28,7 @@ def _build_text_profile(line_payloads: List[dict]) -> dict:
         for fontname in line.get("fontnames", []):
             if str(fontname):
                 fontname_counter[str(fontname)] += 1
-        color_key = str(line.get("dominant_font_color") or "")
+        color_key = str(line.get("font_color") or "")
         if color_key:
             font_color_counter[color_key] += 1
 
@@ -145,7 +145,7 @@ def _collect_table_drawing_debug(
 
     line_payloads = _extract_body_word_lines(page=page, header_margin=header_margin, footer_margin=footer_margin)
     for line in line_payloads:
-        line["dominant_font_color"] = _color_key(line.get("color"))
+        line["font_color"] = _color_key(line.get("color"))
     raw_text_lines, normalized_text_lines = _extract_body_text_lines(page, header_margin=header_margin, footer_margin=footer_margin)
     text_profile = _build_text_profile(line_payloads)
 
@@ -182,7 +182,7 @@ def _collect_table_drawing_debug(
                     "fontname": str(line.get("fontname") or ""),
                     "fontnames": list(line.get("fontnames", [])),
                     "dominant_font_size": round(float(line.get("dominant_font_size", 0.0)), 2),
-                    "dominant_font_color": str(line.get("dominant_font_color") or ""),
+                    "font_color": str(line.get("font_color") or ""),
                     "font_size_candidates": [
                         round(float(size), 2) for size in line.get("font_size_candidates", [])
                     ],

--- a/graph_pdf/extractor/text.py
+++ b/graph_pdf/extractor/text.py
@@ -13,6 +13,7 @@ from .shared import (
     WATERMARK_ROTATION_MIN_DEGREES,
     _bboxes_intersect,
     _char_rotation_degrees,
+    _normalize_debug_color,
     _normalize_text,
 )
 
@@ -303,6 +304,7 @@ def _extract_body_word_lines(
         return (float(word.get("x0", 0.0)), top, float(word.get("x1", 0.0)), bottom)
 
     filtered_words = []
+    filtered_chars = list(getattr(filtered_page, "chars", []) or [])
     for word in words:
         bbox = _word_bbox(word)
         # Excluded bboxes are used to suppress table text when generating the final body output.
@@ -339,12 +341,28 @@ def _extract_body_word_lines(
         size_candidates = [round(float(word.get("size", 0.0)), 2) for word in ordered if float(word.get("size", 0.0)) > 0.0]
         size_counter = Counter(size_candidates)
         dominant_font_size = max(size_counter, key=size_counter.get) if size_counter else 0.0
-        colors = [word.get("non_stroking_color") or word.get("stroking_color") for word in ordered]
-        normalized_colors = [color for color in colors if isinstance(color, tuple) and len(color) >= 3]
-        dominant_color = None
-        if normalized_colors:
-            color_keys = [tuple(round(float(value), 3) for value in color[:3]) for color in normalized_colors]
-            dominant_color = max(color_keys, key=color_keys.count)
+        line_top = min(float(word.get("top", 0.0)) for word in ordered)
+        line_bottom = max(float(word.get("bottom", 0.0)) for word in ordered)
+        line_x0 = float(ordered[0].get("x0", 0.0))
+        line_x1 = float(ordered[-1].get("x1", 0.0))
+        line_chars = [
+            char
+            for char in filtered_chars
+            if float(char.get("x1", 0.0)) > line_x0
+            and float(char.get("x0", 0.0)) < line_x1
+            and float(char.get("bottom", 0.0)) > line_top
+            and float(char.get("top", 0.0)) < line_bottom
+        ]
+        colors = [
+            _normalize_debug_color(char.get("non_stroking_color") or char.get("stroking_color"))
+            for char in line_chars
+        ]
+        color_keys = [
+            tuple(color) if isinstance(color, list) else color
+            for color in colors
+            if color not in (None, "")
+        ]
+        dominant_color = max(color_keys, key=color_keys.count) if color_keys else None
 
         first_cleaned = _repair_watermark_bleed(str(ordered[0].get("text") or "").strip())
         second_word = ordered[1] if len(ordered) > 1 else ordered[0]

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -241,7 +241,8 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertIn("font_color_histogram", payload["text_debug"]["profile"])
         self.assertIn("font_size_candidates", payload["text_debug"]["raw_line_boxes"][0])
         self.assertIn("dominant_font_size", payload["text_debug"]["raw_line_boxes"][0])
-        self.assertIn("dominant_font_color", payload["text_debug"]["raw_line_boxes"][0])
+        self.assertIn("font_color", payload["text_debug"]["raw_line_boxes"][0])
+        self.assertNotEqual("", payload["text_debug"]["raw_line_boxes"][0]["font_color"])
 
     def test_debug_writes_table_drawing_log(self) -> None:
         tmp = tempfile.TemporaryDirectory()

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -238,8 +238,10 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertIn("profile", payload["text_debug"])
         self.assertIn("dominant_font_size", payload["text_debug"]["profile"])
         self.assertIn("font_size_histogram", payload["text_debug"]["profile"])
+        self.assertIn("font_color_histogram", payload["text_debug"]["profile"])
         self.assertIn("font_size_candidates", payload["text_debug"]["raw_line_boxes"][0])
         self.assertIn("dominant_font_size", payload["text_debug"]["raw_line_boxes"][0])
+        self.assertIn("dominant_font_color", payload["text_debug"]["raw_line_boxes"][0])
 
     def test_debug_writes_table_drawing_log(self) -> None:
         tmp = tempfile.TemporaryDirectory()
@@ -264,6 +266,7 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertIn("stroking_color", payload["pages"][0]["tables"][0]["horizontal_segments"][0])
         self.assertIn("document_text_profile", payload)
         self.assertIn("font_size_histogram", payload["document_text_profile"])
+        self.assertIn("font_color_histogram", payload["pages"][0]["text_debug"]["profile"])
         self.assertIn("source_drawings", payload["pages"][0])
         self.assertIn("lines", payload["pages"][0]["source_drawings"])
         self.assertIn("profile", payload["pages"][0]["text_debug"])


### PR DESCRIPTION
## Summary
- add a single font_color field per debug text line for style comparison
- derive line text color from chars inside each line bbox instead of relying on word attrs alone
- keep page-level font color histograms and extend pipeline debug coverage

## Validation
- python3 -m unittest discover -s tests
