### PR TITLE
Add font size and color profile mode

### DIFF
--- a/graph_pdf/README.md
+++ b/graph_pdf/README.md
@@ -43,6 +43,7 @@ python3 extractor/__main__.py sample.pdf \
 - `--force-table`: 표 영역 탐지 실패 시 더 공격적인 페이지 전체 표 추출 허용
 - `--debug`: 표 구조/edge 디버그 JSON 생성
 - `--debug-watermark`: 회전 문자 디버그 JSON 생성
+- `--profile-fonts`: body text 기준 `font_size + font_color` 조합 프로파일 JSON/CSV 생성
 
 ### 직접 실행 예시
 ```bash
@@ -55,6 +56,15 @@ python3 -m extractor sample.pdf \
   --debug-watermark
 ```
 
+폰트 스타일 조합만 먼저 훑고 싶으면 profile 모드로 실행할 수 있습니다.
+
+```bash
+python3 -m extractor sample.pdf \
+  --out-md-dir artifacts/manual/md \
+  --stem sample \
+  --profile-fonts
+```
+
 ### 직접 실행 산출물
 - `artifacts/manual/md/sample.txt`: 본문 텍스트
 - `artifacts/manual/md/sample.md`: 본문 markdown
@@ -63,7 +73,24 @@ python3 -m extractor sample.pdf \
 - `artifacts/manual/md/sample_debug.json`: 표 구조 + 원본 drawing 객체 + 텍스트 폰트 크기 프로파일 디버그 (`--debug`)
 - `artifacts/manual/md/sample_edges_debug.json`: edge 분해 결과 디버그 (`--debug`)
 - `artifacts/manual/md/sample_watermark_debug.json`: 회전 문자 디버그 (`--debug-watermark`)
+- `artifacts/manual/md/sample_font_profile.json`: body text의 `font_size + font_color` 조합 요약 (`--profile-fonts`)
+- `artifacts/manual/md/sample_font_profile.csv`: 동일 프로파일의 표 형태 출력 (`--profile-fonts`)
 - `artifacts/manual/images/*`: body 영역 이미지 추출 결과
+
+### font profile 모드
+이 모드는 표 추출 대신 문서의 body text line을 전체 순회하면서 스타일 분포를 집계합니다.
+
+- 집계 키: `font_size`, `font_color`
+- 제외 대상: 헤더, 푸터, 워터마크
+- 결과 필드:
+  - `font_size`
+  - `font_color`
+  - `line_count`
+  - `page_count`
+  - `sample_pages`
+  - `sample_texts`
+
+대용량 문서에서 먼저 어떤 스타일 조합이 존재하는지 확인한 뒤, 이후 구조화 규칙에서 `h1`~`h6` 기준을 잡는 용도로 사용할 수 있습니다.
 
 ## 파일별 역할
 - `run_demo.py`: 샘플 PDF를 생성하고 추출 파이프라인을 실행하는 진입 스크립트
@@ -73,6 +100,7 @@ python3 -m extractor sample.pdf \
 - `fixtures/demo_document.json`: 샘플 문서의 기대 본문/표 데이터 fixture
 - `extractor/__init__.py`: 외부에서 사용하는 공개 진입점 export
 - `extractor/__main__.py`: CLI 실행용 entrypoint
+- `extractor/font_profile.py`: body text 기준 `font_size + font_color` 프로파일 생성과 JSON/CSV 기록
 - `extractor/pipeline.py`: 전체 PDF 추출 orchestration, 페이지 순회, cross-page table merge, 결과 파일 기록
 - `extractor/text.py`: 워터마크/레이아웃 artifact 제거, body bounds 계산, 본문 line 추출과 정규화
 - `extractor/tables.py`: 표 영역 탐지, 표 추출, 셀 정규화, 페이지 간 표 continuation merge 판단, markdown table 렌더링

--- a/graph_pdf/extractor/__init__.py
+++ b/graph_pdf/extractor/__init__.py
@@ -5,6 +5,7 @@ from .debug import (
     _collect_rotated_text_debug,
     _collect_table_drawing_debug,
 )
+from .font_profile import profile_pdf_fonts
 from .images import _extract_embedded_images
 from .pipeline import extract_pdf_to_outputs
 from .shared import (
@@ -41,6 +42,7 @@ from .text import (
 # keep importing from `extractor` after the package split.
 __all__ = [
     "extract_pdf_to_outputs",
+    "profile_pdf_fonts",
     "_append_output_table",
     "_build_body_blocks",
     "_char_rotation_degrees",

--- a/graph_pdf/extractor/__main__.py
+++ b/graph_pdf/extractor/__main__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from .font_profile import profile_pdf_fonts
 from .pipeline import extract_pdf_to_outputs
 from .shared import _parse_pages_spec
 
@@ -18,7 +19,17 @@ def main() -> None:
     parser.add_argument("--force-table", action="store_true")
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--debug-watermark", action="store_true")
+    parser.add_argument("--profile-fonts", action="store_true")
     args = parser.parse_args()
+
+    if args.profile_fonts:
+        profile_pdf_fonts(
+            pdf_path=Path(args.pdf_path),
+            out_dir=Path(args.out_md_dir),
+            stem=args.stem,
+            pages=_parse_pages_spec(args.pages) if args.pages else None,
+        )
+        return
 
     extract_pdf_to_outputs(
         pdf_path=Path(args.pdf_path),

--- a/graph_pdf/extractor/font_profile.py
+++ b/graph_pdf/extractor/font_profile.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import pdfplumber
+
+from .shared import _normalize_debug_color
+from .tables import _extract_tables
+from .text import _extract_body_word_lines
+
+
+def _font_color_key(color: object) -> str:
+    normalized = _normalize_debug_color(color)
+    if isinstance(normalized, list):
+        return ",".join(f"{float(value):.3f}" for value in normalized)
+    if isinstance(normalized, (int, float)):
+        return f"{float(normalized):.3f}"
+    return str(normalized or "")
+
+
+def _style_key(line: dict) -> Tuple[float, str]:
+    font_size = round(float(line.get("dominant_font_size", line.get("size", 0.0)) or 0.0), 2)
+    font_color = _font_color_key(line.get("color"))
+    return font_size, font_color
+
+
+def profile_pdf_fonts(
+    pdf_path: Path,
+    out_dir: Path,
+    stem: str,
+    header_margin: float = 90.0,
+    footer_margin: float = 40.0,
+    pages: Optional[Sequence[int]] = None,
+    sample_limit: int = 3,
+) -> dict:
+    # This mode scans normalized body lines so large documents can be profiled without running table extraction.
+    out_dir.mkdir(parents=True, exist_ok=True)
+    selected_pages = set(int(page_no) for page_no in (pages or []))
+    style_map: Dict[Tuple[float, str], dict] = {}
+    scanned_pages = 0
+
+    with pdfplumber.open(str(pdf_path)) as pdf:
+        for page_no, page in enumerate(pdf.pages, start=1):
+            if selected_pages and page_no not in selected_pages:
+                continue
+
+            scanned_pages += 1
+            excluded_bboxes = [bbox for _rows, bbox in _extract_tables(page, force_table=False)]
+            line_payloads = _extract_body_word_lines(
+                page=page,
+                header_margin=header_margin,
+                footer_margin=footer_margin,
+                excluded_bboxes=excluded_bboxes,
+            )
+            for line in line_payloads:
+                font_size, font_color = _style_key(line)
+                if font_size <= 0.0:
+                    continue
+
+                style = style_map.setdefault(
+                    (font_size, font_color),
+                    {
+                        "font_size": font_size,
+                        "font_color": font_color,
+                        "line_count": 0,
+                        "sample_pages": [],
+                        "sample_texts": [],
+                    },
+                )
+                style["line_count"] += 1
+                if page_no not in style["sample_pages"]:
+                    style["sample_pages"].append(page_no)
+                text = str(line.get("text") or "").strip()
+                if text and text not in style["sample_texts"] and len(style["sample_texts"]) < sample_limit:
+                    style["sample_texts"].append(text)
+
+    styles: List[dict] = []
+    for entry in sorted(
+        style_map.values(),
+        key=lambda item: (-int(item["line_count"]), -float(item["font_size"]), str(item["font_color"])),
+    ):
+        styles.append(
+            {
+                "font_size": float(entry["font_size"]),
+                "font_color": str(entry["font_color"]),
+                "line_count": int(entry["line_count"]),
+                "page_count": len(entry["sample_pages"]),
+                "sample_pages": list(entry["sample_pages"]),
+                "sample_texts": list(entry["sample_texts"]),
+            }
+        )
+
+    payload = {
+        "pdf": str(pdf_path),
+        "page_count": scanned_pages,
+        "style_count": len(styles),
+        "styles": styles,
+    }
+
+    json_file = out_dir / f"{stem}_font_profile.json"
+    csv_file = out_dir / f"{stem}_font_profile.csv"
+    json_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    with csv_file.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=["font_size", "font_color", "line_count", "page_count", "sample_pages", "sample_texts"],
+        )
+        writer.writeheader()
+        for entry in styles:
+            writer.writerow(
+                {
+                    "font_size": f"{float(entry['font_size']):.2f}",
+                    "font_color": str(entry["font_color"]),
+                    "line_count": int(entry["line_count"]),
+                    "page_count": int(entry["page_count"]),
+                    "sample_pages": ",".join(str(page_no) for page_no in entry["sample_pages"]),
+                    "sample_texts": " || ".join(entry["sample_texts"]),
+                }
+            )
+
+    return {
+        "profile": payload,
+        "json_file": json_file,
+        "csv_file": csv_file,
+    }

--- a/graph_pdf/fixtures/demo_document.json
+++ b/graph_pdf/fixtures/demo_document.json
@@ -33,6 +33,7 @@
       "The first table must fit entirely inside body bounds and end before the footer region.",
       "After table, body lines must continue and never overlap following elements."
     ],
+    "accent_line": "Blue accent line marks a separate style bucket for font profile review.",
     "after_stage_table": [
       "Page 2 continues the flow if table rows spill over from the first table page.",
       "This paragraph is intentionally after the spanning table so table continuation remains earlier on the next page.",

--- a/graph_pdf/sample_generator.py
+++ b/graph_pdf/sample_generator.py
@@ -60,7 +60,13 @@ def _fixture_table_render_meta(
 
 def get_demo_text_lines() -> Tuple[str, ...]:
     body = load_demo_fixture()["body"]
-    return tuple(body["intro"] + body["after_item_table"] + body["after_stage_table"] + body["footer_lines"])
+    return tuple(
+        body["intro"]
+        + [body.get("accent_line", "")]
+        + body["after_item_table"]
+        + body["after_stage_table"]
+        + body["footer_lines"]
+    )
 
 
 def _fixture_layout() -> dict:
@@ -252,6 +258,38 @@ class DemoPdfBuilder:
         for text, indent in wrapped_items:
             self.canvas.drawString(self.margin_x + indent, self.cursor_y, text)
             self.cursor_y -= line_height
+
+    def add_body_heading(self, text: str, line_height: float = 22.0) -> None:
+        # A large heading gives the font-profile mode a stable non-body size bucket.
+        wrapped_lines = _wrap_visual_line(
+            str(text),
+            max(self.width - (self.margin_x * 2), 48.0),
+            "Helvetica-Bold",
+            20,
+        )
+        self._ensure_space(len(wrapped_lines) * line_height)
+        self.canvas.setFillColor(colors.black)
+        self.canvas.setFont("Helvetica-Bold", 20)
+        for line in wrapped_lines:
+            self.canvas.drawString(self.margin_x, self.cursor_y, line)
+            self.cursor_y -= line_height
+        self.canvas.setFont("Helvetica", 11)
+
+    def add_accent_body_text(self, text: str, line_height: float = 14.0) -> None:
+        # Accent-colored sample text gives the font profile mode a stable non-black style bucket.
+        wrapped_lines = _wrap_visual_line(
+            str(text),
+            max(self.width - (self.margin_x * 2), 48.0),
+            "Helvetica",
+            11,
+        )
+        self._ensure_space(len(wrapped_lines) * line_height)
+        self.canvas.setFillColor(colors.Color(0.0, 0.3, 0.7))
+        self.canvas.setFont("Helvetica", 11)
+        for line in wrapped_lines:
+            self.canvas.drawString(self.margin_x, self.cursor_y, line)
+            self.cursor_y -= line_height
+        self.canvas.setFillColor(colors.black)
 
     def add_gap(self, height: float) -> None:
         self.cursor_y -= max(0.0, float(height))
@@ -591,18 +629,22 @@ def create_demo_pdf(path: Path) -> None:
     body = builder.fixture["body"]
     tables = builder.fixture["tables"]
     intro_lines = tuple(body["intro"])
+    accent_line = str(body.get("accent_line") or "")
     after_item_table = tuple(body["after_item_table"])
     after_stage_table = tuple(body["after_stage_table"])
     footer_lines = tuple(body["footer_lines"])
 
+    builder.add_body_heading(intro_lines[0])
     builder.add_body_text(
         (
-            *intro_lines[:3],
+            *intro_lines[1:3],
             ("  - nested detail: line 2 confirms indentation", 12),
             ("    - deeper detail: line 3 confirms paragraph wrap and line breaks", 24),
             *intro_lines[5:],
         )
     )
+    if accent_line:
+        builder.add_accent_body_text(accent_line)
 
     builder._draw_table_block(
         header_rows=(tables["item"][0],),

--- a/graph_pdf/tests/test_font_profile.py
+++ b/graph_pdf/tests/test_font_profile.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import csv
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from extractor import profile_pdf_fonts
+from extractor.__main__ import main as cli_main
+from sample_generator import create_demo_pdf
+
+
+class FontProfileTests(unittest.TestCase):
+    def _build_pdf(self) -> tuple[Path, Path]:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        pdf_path = root / "sample.pdf"
+        create_demo_pdf(pdf_path)
+        return root, pdf_path
+
+    def test_profile_pdf_fonts_writes_sample_style_summary(self) -> None:
+        root, pdf_path = self._build_pdf()
+
+        result = profile_pdf_fonts(
+            pdf_path=pdf_path,
+            out_dir=root / "md",
+            stem="sample",
+        )
+
+        payload = json.loads(result["json_file"].read_text(encoding="utf-8"))
+        self.assertEqual(str(pdf_path), payload["pdf"])
+        self.assertEqual(4, payload["page_count"])
+        self.assertTrue(payload["styles"])
+
+        styles = {
+            (entry["font_size"], entry["font_color"]): entry
+            for entry in payload["styles"]
+        }
+        self.assertIn((20.0, "0.000,0.000,0.000"), styles)
+        self.assertIn((11.0, "0.000,0.300,0.700"), styles)
+        self.assertIn(
+            "Chapter 1: Deep Structure Verification",
+            styles[(20.0, "0.000,0.000,0.000")]["sample_texts"],
+        )
+        self.assertIn(
+            "Blue accent line marks a separate style bucket for font profile review.",
+            styles[(11.0, "0.000,0.300,0.700")]["sample_texts"],
+        )
+
+        with result["csv_file"].open(encoding="utf-8", newline="") as handle:
+            rows = list(csv.DictReader(handle))
+
+        self.assertTrue(rows)
+        self.assertEqual(
+            {"font_size", "font_color", "line_count", "page_count", "sample_pages", "sample_texts"},
+            set(rows[0].keys()),
+        )
+
+    def test_cli_profile_fonts_option_writes_profile_outputs(self) -> None:
+        root, pdf_path = self._build_pdf()
+
+        argv = [
+            "extractor",
+            str(pdf_path),
+            "--out-md-dir",
+            str(root / "md"),
+            "--stem",
+            "sample",
+            "--profile-fonts",
+        ]
+        with patch.object(sys, "argv", argv):
+            cli_main()
+
+        self.assertTrue((root / "md" / "sample_font_profile.json").exists())
+        self.assertTrue((root / "md" / "sample_font_profile.csv").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/graph_pdf/tests/test_public_api.py
+++ b/graph_pdf/tests/test_public_api.py
@@ -6,6 +6,9 @@ import extractor
 
 
 class ExtractorPublicApiTests(unittest.TestCase):
+    def test_font_profile_entrypoint_is_exposed(self) -> None:
+        self.assertTrue(callable(extractor.profile_pdf_fonts))
+
     def test_legacy_helpers_are_not_exposed(self) -> None:
         self.assertFalse(hasattr(extractor, "_normalize_body_lines"))
         self.assertFalse(hasattr(extractor, "_normalize_list_block_lines"))


### PR DESCRIPTION
## Summary
- add a standalone font profile mode that scans body text and aggregates font size + font color combinations
- expose the new profile entrypoint in the CLI and public API
- add sample-driven tests and README usage for the new profiling outputs

## Validation
- python3 -m unittest discover -s tests
