### PR TITLE
Store one sample page per font profile style

### DIFF
--- a/graph_pdf/README.md
+++ b/graph_pdf/README.md
@@ -87,7 +87,7 @@ python3 -m extractor sample.pdf \
   - `font_color`
   - `line_count`
   - `page_count`
-  - `sample_pages`
+  - `sample_page`
   - `sample_texts`
 
 대용량 문서에서 먼저 어떤 스타일 조합이 존재하는지 확인한 뒤, 이후 구조화 규칙에서 `h1`~`h6` 기준을 잡는 용도로 사용할 수 있습니다.

--- a/graph_pdf/extractor/font_profile.py
+++ b/graph_pdf/extractor/font_profile.py
@@ -66,13 +66,15 @@ def profile_pdf_fonts(
                         "font_size": font_size,
                         "font_color": font_color,
                         "line_count": 0,
-                        "sample_pages": [],
+                        "sample_page": 0,
                         "sample_texts": [],
+                        "seen_pages": set(),
                     },
                 )
                 style["line_count"] += 1
-                if page_no not in style["sample_pages"]:
-                    style["sample_pages"].append(page_no)
+                style["seen_pages"].add(page_no)
+                if not style["sample_page"]:
+                    style["sample_page"] = page_no
                 text = str(line.get("text") or "").strip()
                 if text and text not in style["sample_texts"] and len(style["sample_texts"]) < sample_limit:
                     style["sample_texts"].append(text)
@@ -87,8 +89,8 @@ def profile_pdf_fonts(
                 "font_size": float(entry["font_size"]),
                 "font_color": str(entry["font_color"]),
                 "line_count": int(entry["line_count"]),
-                "page_count": len(entry["sample_pages"]),
-                "sample_pages": list(entry["sample_pages"]),
+                "page_count": len(entry["seen_pages"]),
+                "sample_page": int(entry["sample_page"]),
                 "sample_texts": list(entry["sample_texts"]),
             }
         )
@@ -107,7 +109,7 @@ def profile_pdf_fonts(
     with csv_file.open("w", encoding="utf-8", newline="") as handle:
         writer = csv.DictWriter(
             handle,
-            fieldnames=["font_size", "font_color", "line_count", "page_count", "sample_pages", "sample_texts"],
+            fieldnames=["font_size", "font_color", "line_count", "page_count", "sample_page", "sample_texts"],
         )
         writer.writeheader()
         for entry in styles:
@@ -117,7 +119,7 @@ def profile_pdf_fonts(
                     "font_color": str(entry["font_color"]),
                     "line_count": int(entry["line_count"]),
                     "page_count": int(entry["page_count"]),
-                    "sample_pages": ",".join(str(page_no) for page_no in entry["sample_pages"]),
+                    "sample_page": int(entry["sample_page"]),
                     "sample_texts": " || ".join(entry["sample_texts"]),
                 }
             )

--- a/graph_pdf/tests/test_font_profile.py
+++ b/graph_pdf/tests/test_font_profile.py
@@ -50,13 +50,16 @@ class FontProfileTests(unittest.TestCase):
             "Blue accent line marks a separate style bucket for font profile review.",
             styles[(11.0, "0.000,0.300,0.700")]["sample_texts"],
         )
+        self.assertEqual(1, styles[(11.0, "0.000,0.300,0.700")]["sample_page"])
+        self.assertGreaterEqual(styles[(11.0, "0.000,0.300,0.700")]["page_count"], 1)
+        self.assertNotIn("Laptop 12 $120", styles[(11.0, "0.000,0.000,0.000")]["sample_texts"])
 
         with result["csv_file"].open(encoding="utf-8", newline="") as handle:
             rows = list(csv.DictReader(handle))
 
         self.assertTrue(rows)
         self.assertEqual(
-            {"font_size", "font_color", "line_count", "page_count", "sample_pages", "sample_texts"},
+            {"font_size", "font_color", "line_count", "page_count", "sample_page", "sample_texts"},
             set(rows[0].keys()),
         )
 


### PR DESCRIPTION
## Summary
- change font profile output to keep a single representative sample page per style while preserving page_count
- keep table text excluded from profiling and align tests with the slimmer output shape
- update README to document sample_page instead of sample_pages

## Validation
- python3 -m unittest discover -s tests
