### PR TITLE
Fix drawing crop coordinates for pdfplumber page objects

### DIFF
--- a/graph_pdf/extractor/images.py
+++ b/graph_pdf/extractor/images.py
@@ -16,7 +16,7 @@ def _crop_page_region(
     resolution: float,
 ) -> "Image":
     # `PageImage` removed `.crop()` in current versions, so crop via Pillow with
-    # explicit point-to-pixel conversion using the same PDF coordinate system.
+    # explicit point-to-pixel conversion using pdfplumber's top-origin coordinates.
     x0, top, x1, bottom = bbox
     left = float(min(x0, x1))
     right = float(max(x0, x1))
@@ -27,11 +27,10 @@ def _crop_page_region(
     image_width, image_height = page_image.original.size
     left_px = max(0, min(int(round(left * scale)), image_width))
     right_px = max(0, min(int(round(right * scale)), image_width))
-    top_px = max(0, min(int(round((page_height - y1) * scale)), image_height))
-    bottom_px = max(0, min(int(round((page_height - y0) * scale)), image_height))
+    top_px = max(0, min(int(round(y0 * scale)), image_height))
+    bottom_px = max(0, min(int(round(y1 * scale)), image_height))
 
-    # The `PageImage.original` coordinate origin is top-left, so we convert from
-    # PDF y-coordinates (bottom-origin) accordingly.
+    # `PageImage.original` uses top-left origin, matching pdfplumber `top`/`bottom`.
     return page_image.original.crop((left_px, top_px, right_px, bottom_px))
 
 

--- a/graph_pdf/sample.pdf
+++ b/graph_pdf/sample.pdf
@@ -1,8 +1,8 @@
-%PDF-1.4
+%PDF-1.3
 %“Œ‹ž ReportLab Generated PDF document (opensource)
 1 0 obj
 <<
-/F1 2 0 R /F2 3 0 R
+/F1 2 0 R
 >>
 endobj
 2 0 obj
@@ -12,128 +12,57 @@ endobj
 endobj
 3 0 obj
 <<
-/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+/Contents 7 0 R /MediaBox [ 0 0 612 792 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
 >>
 endobj
 4 0 obj
 <<
-/BitsPerComponent 8 /ColorSpace /DeviceRGB /Filter [ /ASCII85Decode /FlateDecode ] /Height 1 /Length 16 /Subtype /Image 
-  /Type /XObject /Width 1
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
 >>
-stream
-Gb"ZWn/hW4rrN-~>endstream
 endobj
 5 0 obj
 <<
-/Contents 11 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
-/ExtGState <<
-/gRLs0 <<
-/ca .13
->>
->> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
-/FormXob.c4a6dfcd9d5d51256cad05922c13aab3 4 0 R
->>
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
+/Author (anonymous) /CreationDate (D:20260323175342+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260323175342+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
 6 0 obj
 <<
-/Contents 12 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
-/ExtGState <<
-/gRLs0 <<
-/ca .13
->>
->> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
-/FormXob.c4a6dfcd9d5d51256cad05922c13aab3 4 0 R
->>
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
 >>
 endobj
 7 0 obj
 <<
-/Contents 13 0 R /MediaBox [ 0 0 612 792 ] /Parent 10 0 R /Resources <<
-/ExtGState <<
-/gRLs0 <<
-/ca .13
->>
->> /Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /XObject <<
-/FormXob.c4a6dfcd9d5d51256cad05922c13aab3 4 0 R
->>
->> /Rotate 0 /Trans <<
-
->> 
-  /Type /Page
->>
-endobj
-8 0 obj
-<<
-/PageMode /UseNone /Pages 10 0 R /Type /Catalog
->>
-endobj
-9 0 obj
-<<
-/Author (anonymous) /CreationDate (D:20260317142616+09'00') /Creator (anonymous) /Keywords () /ModDate (D:20260317142616+09'00') /Producer (ReportLab PDF Library - \(opensource\)) 
-  /Subject (unspecified) /Title (untitled) /Trapped /False
->>
-endobj
-10 0 obj
-<<
-/Count 3 /Kids [ 5 0 R 6 0 R 7 0 R ] /Type /Pages
->>
-endobj
-11 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2130
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 362
 >>
 stream
-Gat=,968iG&AJ$Cm(nIk9G;f1oI[&+1_Vh.3bk-76p_N$P$gRJNrFHN!K`ICJSmLdB4,\`Nt8iEG0M/JJ'@gt2?9qIE;c('MdX("Q37LFn)2I]+uBpYF"n#T7Nc`DEL/[[E<_=PK4P/B^!jXK_Yrk+\.t!T?NdQc^4Dk7>qM^N4'da4@JL]jIlO2K%?6Nt/NU%'"`'rCi%$qc,7NST!;N=73Cq][n,:V*=-Y+(&@9KVHbL*-cAO#X(_lLNg%l*<<g8[D%Fk<KFp"hqY-#2tJ/3J\T"P'#q)Jl?.Q*mECUb&D_0\(3bZQ;uM1Nhg4a7[8K<=\/H>UE^[G\/7RUd#+`TW*+<Qc/q^O_AXL#rKS>4I/j'J("c\G447NpphoI\`Gq`KA!c7;FM.$DE#m@95=6Enf'Gh>I-o-mBLX0XIo@%sNF-S)3:0A.5XbNIoqs=cb7FdLbK@?tfaFiOBf@`$,*o)5ct=+BMF-"H6o"n+HY"jdV$dYO:?-bocE3r-8pmDs.quZoJjeR\I.P"=h$4X*!r9Xb&=e=g]l_U.VJN7;5fn.SPaK.Tt!k.Y_/M7SB%[s$OuEC6"^NMhCV$QPDErJ)9aVD@1=XQ4i?/TQfM%dfTL[>-;GYWFWZPQfX?,ZeW\EA35U5`-GW1?n_.EoiSbV[S)/d.'`2J:fNt[4,:N9GJ&YXb^)A[_cD`X:*oD:PuRO2XD9AZ:(,JqgPt*Yb[tdS6?oe:)g&hY3^B33WMd0H[,;CZBY2r+JmL=7&iJgOVLu\=$I'#`MEN$[)]b0\_::F4;QIMRa[B*W?W()6.odSu!<mr"`+I^<Y^V++m*V6OY-,_td0TQtGJ#4$X='S`bTVm"Vl`CVUQRKfE+=edJl9!lW>iFN$A"VUhCO>=78@!>aYC&Y;\gI?+aABEaNIg8q.iB!LpYK2U:hapkp&q0]&0Mn9t/KJ^%dK&8G*X:OX=7O3F["rmg1!R'o$RU8,jt`rRe#niW?Ks@i;e/h;K_X(kGj8J[G^rc:f@=n<ojR+"i,qX76th\GpZ>4Za\A?nFq:0Z8R:(CRM:L94fQ@^#(iQuIj#<\]o:@=@kq,"/Ae0O>d8]J^;(h>r)hAKtun%=VZWPFXB.T-@nck2G,";QOBs1s-h7du&t8Z#O3n-_/9Q1e3\iQppuP+I_m&Z%@dIPl#;WGiB4dM:fM-cWUJ;@Q:n8k/R]R_2GeWZoW*&j246bj#0(+DAu[+G)Yd#[qU!?:.CGSRb_TOJc[V[g@au?<2@u%],n^IMU)Ui,08&;*(!OS$n->@n#GuQ9^n%)/35F!'uc$Z-&Y)s6\JPoJp^7'dlbhm*i6P.r;pMG&K=Xj`*oLPp2I8mj^du9&=q0Zlp65^B(<>u3(eNlq?=rBRKV<C0oo\efI6,Ejqf.MEFDQ>W`hD24_r/rVR'qsU!"jR8XQIG`U?K[![@iOAo7Cp).T?nrm=jC*:MMN`k:TX=I;-/GJ/e-SP^cUk&]!C?$`<n@Z29]Mrc47iMg^fk%N'$N'=P5BCfM+!be^V=1TFA-'IBMX@^0)1:^d^hlS@Ml)jDkpO\HKe)>$f9rBm.BfXM0Sp8g$-Zkc$ZCDoWQie%LZU^I,k`*Qj=5YT$SQGjd!r#G.]P^CiY4-9\lWrW<6HC5gIk9[5/(Ek2&Epdm[+bD[g:8pZoXZbk^;:qs;u5/IrJe-R*$nP8L[?=p2Khu:G.:dMSCOmjf)fRjg%M]a[O!`)FDq"?KGRYjYngq`E1N[<)pAM9Y89"LUV0ipZn_B?<Gbn[CS!RVg$XNudpb85!IIXK@oL!?Ffh5`nO+r7g6]Aq<fC;dXo<Bc`8"&ZBu#[rCQCs$,u-7;rR!%f&Rjt>mZ6"0EcR:*lUk8AFuQdsg6d9S@e+nae*/OtfQI2+Z*Bqf3rb7hNQkLi=Y@@PI7]dcBb#"BNkum"HIR6MGbh+fcppLL7-`ktV`$\Yl%W[`C0:"4ptL1o2t7NNe!h=[ZP%&"KXC)o,Eu+F07m_8kpV'SELbjl1eSBM[ABCeP7bD'/OnlLGb#5)ULqoKqUtabP.uL$rXfNP5QZG'Z5J"?-RSp5I/.)dAd2J;144ZE-37(;:CL!N8>coh-$1]^frGt)e"c+2HG6H@l!O2CiZJ#(9`Y~>endstream
-endobj
-12 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2157
->>
-stream
-GasargN)%,&:O:Slsh\YRGaW]94C!-N$hJ=:"ra*KHsS4_18=up$93i!L->Q^lqUs$O6op`F@/29H_,87/^D_!'Y5WlBVDV@C$%KY@?/>_9M*d:^F>@0RuCh69U=c'$V,eOJOCB:@QFS6+[6#YA`BgSN-P`BZ7nOkio'^)"`1i-2SE8s1md+=%JK>OfS`PW*gA,\:B-JETQXCYic&V,A9*e]Z$N?TmrU_M;qT(XA*KAB+VceNItV=7!@b8?76>c4SJ6:Tk?P!YiTA!;/lfV*c(JVBRc2[k(?m`#NWOL416(Df>b(!X2,MiB\f<b8&dSL.''Lodp1Q[g+JmBc;mMFm*K!3h(g,A@*`"'k^[QQkWfpiZ>:7d58_j@s.-)Jb+"puOhfF7X"H"5hulV0N>d&g?e]Ls0>CkqM@du:,O9)oJ(Fq0n#%!1e]'[A_H!b6CmAOnA6@rh+@uj*JJjlD.)8W@@OTP5EZ#)OMNAOLHi<kRF*%BCr>j\Nr;$0NYLsf-TiDrYC/kO2K#XMs89T.!`T_<T?'R-=X'JjC<Dk+g9[]))5uNAE8Kpd9&R9BfR9n)8V[G=eHR2+]VXqunFFZPdTcR*>%lqCT&CN[?2EqW6pXcU*'[c2qi.fY.6<j\)LAQS33I`cIOdS'^9D-ht4Hms_d*1E]5*P'<Sroca1[$n`K;05=JI)N@Z69i.ApZP,08PJ<?B4/(;/3P+UDG_[fj9^$1LY10Q_P?QOg.03jtiee(<DUqRD`]a3I7qQ0\ad5?!t.e"4rmnlRHSFZ(25[`(j$:4f)(u/d&+UV*E!6^(n169r8.IGWW.<H9GHKU6oB@Je*5gG7<AY^Q<+dH]kI0``])oJ6sqf`4*-RJrZ*kc8]++:/1mV:0NsbmqX2OLGPA\*1YMU[YgX*#(Y3Toc7uJqN8Tp0RE)1h(Hg0V@SMeqgk&'T;sjA,8UdFY<QONn*Bp=DV+6.G^O?.dP'X"J.f%jC8R1P#X.$&!+bK\\`'oI*`_d<THb+eJn`BlBa[10oTaGLn0c_br_Rf6l7>m"^:e_NfV1j86K8[X61Mk`_9&6[DBE'_RbaV2EA:*:[Np(oecLpBcd2;O=bqqsM#,dr*>]ds)M!cWhDAGq8R:+2H)!n^]&r)U:=F"66ciL]C9C9c9$jD,7rJr.*Y03?bS[b]Lm&DY=1=M*5Wrj5Tm?q1%taR4CQNc\C]H4'#'sebhT,c(5I\r1(?^BTFg!Cm;4<!ga=LGSgSXE/<F\JMQC+/2V-6]6PSJ(3>6(6[h&BscWg;FXg;*)n$W-8W<AQbfD8i-;rf0q:p9t4HlmBl-bfa#BA(5?c?\lYj,]$gL2T:m7i>R,/[Th%<rg8]jNs]'@HKR@UVjE4kl/iF<8n\7R-Og^k$jW"K)2W6D'9<W,!#"nsZD:3I=Tn]Ym['@klaHIPL@kf7rkYCZ&$-`SAnU:DB^>q!7L(Ig.b;,>UV\7>(4^$:0S?iRTP`41*_k,G*hBY<WKU#GC+N$7PffcF,F'%;U8P*_q%"UFi,fSZff[`nS8=i_UiRo1m#amJG`,NjO[glQ!81Paa&e5g^VjVB"$HuS12-bFD0SFVMT@&ml\5m2C_iSUe_#Y^lSq(*bhHcUFm]\?O%`^W)Er<mP83\T^L?(u8dg`<^cJR?:^t^S'9)nU]Y6)oW20Y?o8`*VUb>0m\P)3AS](!_[V+T^:3F:ogLe8Zm13Dr7A["+9O5qL&s$!qJ1O;05)g0ZqTN/m=tmtcHF2*%A/-Wu(HRP"]W"O_FmRLK$]o'4])^&n[NTV%4OeYH#oVH=Yo_9hB_V[e"9ZlDcj@FeANodqO!4$!VZl!%<9GuU]43SbW29`sb<0cqN?bH857/bk.6O>=!Qb.dA0\OoF;T-l5>\UtDT@sroRs-FWI94Skd:a4kar]5[S8%=kb86Rq'o3cdt=hl+fRsI/O1W7!MrG86]@!dEKe<cMADkRh5VN,OOoJ]1s/L51S2r+7r+eWd0iY4/IM`rgL4?R:?<dq7iO#[X]O?Y@_8HCM+8U=@&@F'BUm"l7j'BkhMsU\"q*`_2,sp2FDYAYdWgP!^/3<R<bU7ml`+:QR*r^22`.qQ7n`Ge*r*E"YHYLiO7GNMFU'.@*?j&VcV>G4G*EH&q-l+64dW6KIX.cQKT#j1=3qFS~>endstream
-endobj
-13 0 obj
-<<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2805
->>
-stream
-Gat=.>Bf*U&q801i6cn.,1+;P^L]@GCnJu:mRd<"lonkbgR?2MKB/hTIf1$)OQ)X*c^pZf+Ort^nPKu7$7.G);"M.U'(V(m\Tsj$1:#RFRRSaZ4HfTd<GW4]J)p[8!O+iuDs<oDaiQ<aalZ,05:PG1aHsLDE[Qm1r(HNWW"5]aa0lbZP:'@d^Q?]YAFnC\9![(tq4^:#PpjaL.amo?o_]Zm`ODGSYMquXaTe?K^:UHr9@G;_hPW#S01^+$R`9?S::t0(0.@C*Gj[bWRX^[%So!Mf.Co:MP^'1GCXE)tFbt_U.=9Ee6QX4L&,&^rdrteYU?>Mc*]shXP(W;iAnP[D/U.pG9tH:h[I[nT<EG/&oE3d)7O[*qXX3F]5f%IY`QL&M>0YreX(OSZ;][B5]kYd0Z'ZM&[^<0*HlZPj\+\qP=4*HKpC!++Z[[;f@^>H=N%nge7ktj^L+%tcAYM%M/%VSq,M0293Csk$mlH5#SdshM`G%_S:@,WBr3X"aqK2U*T'h+(GlR)?$pTAG&C[Km,?Y5rJeOgDk!?$-J)iL;;P'5eU0O$fR8K:3"Y\nPbud7FcF4+jP8CUeX8N"E@b9Da:KKfs^hjQkZRkC-VK(O/D3e\uWL?R,"8g<$r+chLGBpLY3f->a7dsn13b(4eI=diRXukt1dQ>"`LB+!J-$7>G(G!n8W?bcQ#)R62O^tGT5g+p]8mORD(AcbMZ.'4D]o9'L0=,LC)\Ut!'>':qpUiiRl)o</R<VLA>H^QeigT5qMbjk$$8H'$nlk\k,.`BXga"TXl(r.g-IJ)Yf:MX*Ch6leha;Hs4NOgAL&0^-$XPqSo!K7p?5uBIb*[h81llZVXTQAsPitE**ea3Qn@I=4g4gJ>/bZh(#?dChK61:gC->>KP_?*s:q_AjbGKnZaYHIcLE'^l=uE.(`J;K7&OWrd!"<c_Pk\:8ekVL_=.N*AAe*oQ,ZDRlcAbtf9EE+DAS8G6$(Y]4mL`a"r`Cn";^g=Af3>6HmPMl1mjA,o1tUG=f`7eO3B#^=lk00FM9^A=gIYCN=d`P/FXCG@"I0'?m/DekMe>Au!FU#<7,FQ#(h,j+Ju`XDqGcb4.><d2]g-hs.L?\ta1()O]nJ/\gr\J-)FtpRi4V<WQq9\9R&q2H9cc!In657'(C"P#&GG`k^eS)rMn]'MJJg(oc5TtIH.2oP^dq=@Q3li7'e^8k!F?pG)VJ0q*h-<(i8NSp3^.+b%VC$%6rR.D#\:Ya<u'MOZ"ld*knk0##idADH4ebjrdJ6k=c17_#:qj9`R:j.""[KPcn(X%),YUh/V&_]g/`@H#<E9:L(7"&!LERuej9j3NA*C\UB>`Z4#h4H2!B!"WgU.1=r[N!5E"u7a]1o+$:34^aimY&!)VEhV<eoJHn/rrM0--^]frnl@EZhtETf']l`VJ$28oSgJI^!eqY5r2m/c/B;)T/B#jbb^iVR)QYAg@%5gNjj@3qBO=[NUlHF#J([0P@:fN%2B7g>INbh3"+O>OA'rh2)[&<uP_qQY=.O;RUZ;Uq`6A0sB_!4ZnrOK',T]RXE)YgE1#DNqGp7IL9RTEY4!YFR;;@AcB@dVOYY#6;0d':bM!0qMA95"a[sa4-X"oo])KJXieg`@*Mm]kU<H7J@&>`,#0@WngM;.QGI6\ub1ckQ<*`.=&;)8jR@!+C14#_.k`.%Yo@$K)eo!De`0pW1%/TJR&r7Ccd'>dCQrU2iZ[+Xnkd&NPX$$\13NOC-!QKW[m;3bAc\"kgCGj-s_r\F2:-7H580.I]IdAWb^"sj7c7sPbbH7d&eBBKp!^q4QG*E9(F6'*Fa#h7%c5GE>D9B(D%"[`"Hk.>Cs/^56[3FZC8+b`e^a]T%U\DNdb,[d?^VuH+KCo_k8iqPd.Ws\od7CR(766\'B]O<J7sFb;d(Rje-LbYJ$qZ+Pc"5TWj_0#lck.(j5AE>Eedf)q_J`pGd/-q*qiCS06Cc]5EVs;u/tmJ"2HKH_]=[3lGigR`6VHJYQV=45)5pE@6[k*XmDn'RD4`&PF[sLOfr$T'gOcrYpag3E'XNQqHV2.D=KdeK9A0:*3[&XH=b<DJg\S@E_7`JmkUGOh`Y_,VG$1e0/:IDFW5-k,rlf50P@LK])"[#t-J=5RbP,1S-i7isA+-RQsP?cclH@6]F%B+DR.FA`.0.jNf"c5Msa;iLhYf@8Q.o*:.K*hgM)!_*MXe`Lr<a=o,$Zl-Af82F^di]ZM)e$Y)Zk&.CqNN:_fY,B%"L@1EmuF#+AWqQ:@olY\T^0s_u3hV_'e%,^W7*/60V2)F2FLm`3!`)mMe@X;nr35dJ8-57Y)#tk@:`?TpL!B'E&7NBoh8.5hgL!J&[kLOTCQ!lBqUh=jgLO61ipP1a=_\U)gi'mC]@2Lf+LL:s6An3TS)9E7r%"3r!SsqH9$%b+6G)ef2-k%bRV`upR`f(<M(l"Is)%:"E#/_:q+<m]GAq7^t.E+4o>B`\]ZZ1ehL+7c"Z"O`-YG\go.WFo6neokgfF/*MQ\2Peh_QpK)H(2r%1;?fXo%Y#Q2UV8>Y0c-;"p%#L)g7`Jet4-[:.9M."Ym+R?>uQB&k_+0l/%CH>[?bj?DA/m=pk239g>++5diS"=i9djfiA4_0B!8$q&9a<Y::''u=Qa0ekgMZZrjd`S2::ec3?l57J*0NTQ'\2teUPqIjcM%r^9jOQ+&[s*km^9??bSaG8[g*Zb5+`S?gmHXl3QY.V@u46rBG"N[&&ch:pdXJ:d(*>)#D^Wn]7*T>h!T4mXE9*pDDp?&Zdjt3A4>sRZcFlj%9RhAK!rWahtGRF~>endstream
+GarW4:JZU.&B4*cMK`#1a=aj`;%&@/##*]pD76Zc;&5TPMBC_aBku72PM+&2oA9CRnE;SG$Oo3*gs-cSLKK04D?03c=?&gr/GEHL_qDjMj9RmZ6K;fe[lql+DN*)t8M_X(/b[rmUFou>Q;rR`C1")X"\R<HB4TDh&mCauZL&V*)WD4ck'rHVh:Uc\+>;HG,<]jFWHDtj\ugS4.ohmG\[KBmfiQG\gm4XX)VWR@T6g!@FA=iqo)TNae4IP*(f48*G[Pg4a,0ts.fXtUeo3rUK.\-n:4GQPa")K0MAL0O_SLu]"eUr+MUQ,h*Yr4QAl3sO,fAPi,Z-Zsng$j]$gb<c?\4V52N.2)X<,YG-a8=Y~>endstream
 endobj
 xref
-0 14
+0 8
 0000000000 65535 f 
 0000000061 00000 n 
-0000000102 00000 n 
-0000000209 00000 n 
-0000000321 00000 n 
-0000000522 00000 n 
-0000000818 00000 n 
-0000001114 00000 n 
-0000001410 00000 n 
-0000001479 00000 n 
-0000001740 00000 n 
-0000001812 00000 n 
-0000004034 00000 n 
-0000006283 00000 n 
+0000000092 00000 n 
+0000000199 00000 n 
+0000000392 00000 n 
+0000000460 00000 n 
+0000000721 00000 n 
+0000000780 00000 n 
 trailer
 <<
 /ID 
-[<96009fa78c4e1acebb3f40d0c147ed56><96009fa78c4e1acebb3f40d0c147ed56>]
+[<84b5c9f8be6aff496947620b1855157f><84b5c9f8be6aff496947620b1855157f>]
 % ReportLab generated PDF document -- digest (opensource)
 
-/Info 9 0 R
-/Root 8 0 R
-/Size 14
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
 >>
 startxref
-9180
+1232
 %%EOF

--- a/graph_pdf/tests/test_images.py
+++ b/graph_pdf/tests/test_images.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from PIL import Image
+
+from extractor.images import _crop_page_region
+
+
+class CropPageRegionTests(unittest.TestCase):
+    def test_crop_page_region_uses_pdfplumber_top_coordinates(self) -> None:
+        source = Image.new("RGB", (100, 100))
+        for y in range(100):
+            for x in range(100):
+                source.putpixel((x, y), (y, y, y))
+        page_image = SimpleNamespace(original=source)
+
+        cropped = _crop_page_region(
+            page_image=page_image,
+            page_height=100.0,
+            bbox=(20.0, 10.0, 80.0, 30.0),
+            resolution=72.0,
+        )
+
+        self.assertEqual((60, 20), cropped.size)
+        self.assertEqual((10, 10, 10), cropped.getpixel((0, 0)))
+        self.assertEqual((29, 29, 29), cropped.getpixel((0, 19)))


### PR DESCRIPTION
## Summary
- Fix drawing image crop coordinates in `_crop_page_region` to match `pdfplumber` `top`/`bottom` coordinates.
- Add regression test `tests/test_images.py` to assert that cropped pixel rows are mapped from top-origin coordinates.

## Why
- The previous `page_height - y` transform treated `top/bottom` as bottom-origin coordinates, which can shift or crop drawing regions incorrectly.
- This aligns drawing exports with actual PDF object placement and avoids the “page-cropped” appearance.

## Changes
- `graph_pdf/extractor/images.py`
  - Update `_crop_page_region` Y conversion to use top-origin mapping.
  - Update the coordinate-system comment for future maintenance.
- `graph_pdf/tests/test_images.py`
  - Add focused regression test for `_crop_page_region`.

## Validation
- `python3 -m unittest tests.test_images tests.test_pipeline.PipelineExtractionTests.test_flow_diagram_text_is_filtered_and_rendered_as_drawing tests.test_pipeline.PipelineExtractionTests.test_extract_embedded_images_respects_selected_pages`
- `python3 -m unittest discover -s tests -p 'test_*.py'`
