### PR TITLE
Remove watermark from drawing image exports

### DIFF
--- a/graph_pdf/extractor/images.py
+++ b/graph_pdf/extractor/images.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
+import math
 from typing import List, Optional, Sequence, Tuple
 
 import pdfplumber
+from PIL import ImageDraw
 from pypdf import PdfReader
 
-from .text import _detect_body_bounds
+from .text import _detect_body_bounds, _is_non_watermark_obj
 
 
 def _crop_page_region(
@@ -43,6 +45,29 @@ def _image_intersects_body(
     top = float(image_meta.get("top", 0.0))
     bottom = float(image_meta.get("bottom", top))
     return bottom > body_top and top < body_bottom
+
+
+def _erase_watermark_chars_from_page_image(
+    page_image: "pdfplumber.display.PageImage",
+    page: "pdfplumber.page.Page",
+    resolution: float,
+) -> None:
+    # pdfplumber filtered pages still rasterize the original PDF content, so mask watermark chars directly.
+    watermark_chars = [char for char in getattr(page, "chars", []) if not _is_non_watermark_obj(char)]
+    if not watermark_chars:
+        return
+
+    scale = float(resolution) / 72.0
+    draw = ImageDraw.Draw(page_image.original)
+    image_width, image_height = page_image.original.size
+    for char in watermark_chars:
+        left_px = max(0, min(int(math.floor(float(char.get("x0", 0.0)) * scale)) - 1, image_width))
+        top_px = max(0, min(int(math.floor(float(char.get("top", 0.0)) * scale)) - 1, image_height))
+        right_px = max(0, min(int(math.ceil(float(char.get("x1", char.get("x0", 0.0))) * scale)) + 1, image_width))
+        bottom_px = max(0, min(int(math.ceil(float(char.get("bottom", char.get("top", 0.0))) * scale)) + 1, image_height))
+        if right_px <= left_px or bottom_px <= top_px:
+            continue
+        draw.rectangle((left_px, top_px, right_px, bottom_px), fill="white")
 
 
 def _extract_embedded_images(
@@ -101,6 +126,11 @@ def _extract_embedded_images(
                     continue
                 try:
                     page_image = plumber_page.to_image(resolution=180)
+                    _erase_watermark_chars_from_page_image(
+                        page_image=page_image,
+                        page=plumber_page,
+                        resolution=180.0,
+                    )
                     region_image = _crop_page_region(
                         page_image=page_image,
                         page_height=height,

--- a/graph_pdf/tests/test_images.py
+++ b/graph_pdf/tests/test_images.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 
 from PIL import Image
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
 
-from extractor.images import _crop_page_region
+from extractor.images import _crop_page_region, _extract_embedded_images
 
 
 class CropPageRegionTests(unittest.TestCase):
@@ -26,3 +31,30 @@ class CropPageRegionTests(unittest.TestCase):
         self.assertEqual((60, 20), cropped.size)
         self.assertEqual((10, 10, 10), cropped.getpixel((0, 0)))
         self.assertEqual((29, 29, 29), cropped.getpixel((0, 19)))
+
+    def test_extract_embedded_images_removes_watermark_from_drawing_crop(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        pdf_path = root / "watermark_only.pdf"
+
+        c = canvas.Canvas(str(pdf_path), pagesize=letter)
+        c.saveState()
+        c.setFillColor(colors.Color(0.92, 0.92, 0.92))
+        c.setFont("Helvetica-Bold", 44)
+        c.translate(letter[0] / 2.0, letter[1] / 2.0)
+        c.rotate(55)
+        c.drawCentredString(0, 0, "CONFIDENTIAL")
+        c.restoreState()
+        c.save()
+
+        image_files = _extract_embedded_images(
+            pdf_path=pdf_path,
+            out_image_dir=root / "images",
+            stem="watermark_only",
+            drawing_regions_by_page={1: [(0.0, 0.0, float(letter[0]), float(letter[1]))]},
+        )
+
+        self.assertEqual(1, len(image_files))
+        image = Image.open(image_files[0]).convert("L")
+        self.assertEqual((255, 255), image.getextrema())


### PR DESCRIPTION
## Summary
- Remove watermark glyphs from drawing image exports before cropping PNG output.
- Add a regression test that builds a watermark-only PDF page and verifies the exported drawing crop is fully white.

## Root Cause
- `pdfplumber` object filtering removed watermark chars from extracted text, but `page.filter(...).to_image()` still rasterized the original PDF page content.
- As a result, drawing image crops kept the watermark even though text extraction had already filtered it.

## Changes
- `graph_pdf/extractor/images.py`
  - Mask watermark char bounding boxes directly on the rendered page image before cropping drawing regions.
- `graph_pdf/tests/test_images.py`
  - Add PDF-backed regression coverage for watermark-free drawing exports.

## Validation
- `python3 -m unittest tests.test_images tests.test_pipeline.PipelineExtractionTests.test_flow_diagram_text_is_filtered_and_rendered_as_drawing tests.test_pipeline.PipelineExtractionTests.test_extract_embedded_images_respects_selected_pages tests.test_pipeline.PipelineExtractionTests.test_debug_watermark_writes_rotated_text_log`
- `python3 -m unittest discover -s tests -p 'test_*.py'`
