### PR TITLE
Reconstruct drawing exports without watermark text

### DIFF
--- a/graph_pdf/extractor/images.py
+++ b/graph_pdf/extractor/images.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+from functools import lru_cache
 from pathlib import Path
 import math
 from typing import List, Optional, Sequence, Tuple
 
 import pdfplumber
-from PIL import ImageDraw
+from PIL import Image, ImageDraw, ImageFont
 from pypdf import PdfReader
 
+from .shared import _bboxes_intersect, _char_rotation_degrees
 from .text import _detect_body_bounds, _is_non_watermark_obj
 
 
@@ -47,27 +49,220 @@ def _image_intersects_body(
     return bottom > body_top and top < body_bottom
 
 
-def _erase_watermark_chars_from_page_image(
-    page_image: "pdfplumber.display.PageImage",
-    page: "pdfplumber.page.Page",
-    resolution: float,
+def _bbox_for_obj(obj: dict) -> Tuple[float, float, float, float]:
+    return (
+        float(obj.get("x0", 0.0)),
+        float(obj.get("top", 0.0)),
+        float(obj.get("x1", obj.get("x0", 0.0))),
+        float(obj.get("bottom", obj.get("top", 0.0))),
+    )
+
+
+def _pdf_color_to_rgb(color: object, default: Tuple[int, int, int] = (0, 0, 0)) -> Tuple[int, int, int]:
+    if isinstance(color, (int, float)):
+        gray = float(color)
+        if gray <= 1.0:
+            level = int(round(max(0.0, min(gray, 1.0)) * 255))
+            return (level, level, level)
+        level = int(round(max(0.0, min(gray, 255.0))))
+        return (level, level, level)
+
+    if isinstance(color, (tuple, list)) and color:
+        values = [float(value) for value in color[:3]]
+        if len(values) == 1:
+            level = values[0]
+            if level <= 1.0:
+                level = round(max(0.0, min(level, 1.0)) * 255)
+            return (int(level), int(level), int(level))
+        if max(values) <= 1.0:
+            return tuple(int(round(max(0.0, min(value, 1.0)) * 255)) for value in values[:3])
+        return tuple(int(round(max(0.0, min(value, 255.0)))) for value in values[:3])
+
+    return default
+
+
+def _scale_point(x: float, y: float, left: float, top: float, scale: float) -> Tuple[float, float]:
+    return ((float(x) - left) * scale, (float(y) - top) * scale)
+
+
+def _pil_font_path(fontname: str) -> Path | None:
+    lower = str(fontname or "").lower()
+    is_bold = "bold" in lower
+    is_italic = "italic" in lower or "oblique" in lower
+    candidates = {
+        (False, False): Path("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"),
+        (True, False): Path("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"),
+        (False, True): Path("/usr/share/fonts/truetype/dejavu/DejaVuSans-Oblique.ttf"),
+        (True, True): Path("/usr/share/fonts/truetype/dejavu/DejaVuSans-BoldOblique.ttf"),
+    }
+    path = candidates[(is_bold, is_italic)]
+    return path if path.exists() else None
+
+
+@lru_cache(maxsize=64)
+def _load_pil_font(fontname: str, size: int) -> ImageFont.ImageFont | ImageFont.FreeTypeFont:
+    font_path = _pil_font_path(fontname)
+    if font_path is None:
+        return ImageFont.load_default()
+    return ImageFont.truetype(str(font_path), max(1, int(size)))
+
+
+def _sample_cubic_bezier(
+    start: Tuple[float, float],
+    control1: Tuple[float, float],
+    control2: Tuple[float, float],
+    end: Tuple[float, float],
+    steps: int = 24,
+) -> List[Tuple[float, float]]:
+    points: List[Tuple[float, float]] = []
+    for step in range(steps + 1):
+        t = step / steps
+        one_minus_t = 1.0 - t
+        x = (
+            (one_minus_t**3) * start[0]
+            + 3.0 * (one_minus_t**2) * t * control1[0]
+            + 3.0 * one_minus_t * (t**2) * control2[0]
+            + (t**3) * end[0]
+        )
+        y = (
+            (one_minus_t**3) * start[1]
+            + 3.0 * (one_minus_t**2) * t * control1[1]
+            + 3.0 * one_minus_t * (t**2) * control2[1]
+            + (t**3) * end[1]
+        )
+        points.append((x, y))
+    return points
+
+
+def _path_points(path: Sequence[tuple]) -> List[Tuple[float, float]]:
+    points: List[Tuple[float, float]] = []
+    current: Tuple[float, float] | None = None
+    subpath_start: Tuple[float, float] | None = None
+
+    for step in path:
+        operator = step[0]
+        if operator == "m" and len(step) >= 2:
+            current = (float(step[1][0]), float(step[1][1]))
+            subpath_start = current
+            points.append(current)
+            continue
+        if operator == "l" and len(step) >= 2:
+            current = (float(step[1][0]), float(step[1][1]))
+            points.append(current)
+            continue
+        if operator == "c" and len(step) >= 4 and current is not None:
+            control1 = (float(step[1][0]), float(step[1][1]))
+            control2 = (float(step[2][0]), float(step[2][1]))
+            end = (float(step[3][0]), float(step[3][1]))
+            points.extend(_sample_cubic_bezier(current, control1, control2, end)[1:])
+            current = end
+            continue
+        if operator == "h" and subpath_start is not None:
+            current = subpath_start
+            points.append(subpath_start)
+
+    return points
+
+
+def _draw_graphic_path(
+    draw: ImageDraw.ImageDraw,
+    obj: dict,
+    region_bbox: Tuple[float, float, float, float],
+    scale: float,
 ) -> None:
-    # pdfplumber filtered pages still rasterize the original PDF content, so mask watermark chars directly.
-    watermark_chars = [char for char in getattr(page, "chars", []) if not _is_non_watermark_obj(char)]
-    if not watermark_chars:
+    left, top, _right, _bottom = region_bbox
+    stroke_color = _pdf_color_to_rgb(obj.get("stroking_color"), default=(0, 0, 0))
+    fill_color = _pdf_color_to_rgb(obj.get("non_stroking_color"), default=(255, 255, 255))
+    line_width = max(1, int(round(float(obj.get("linewidth", 1.0)) * scale)))
+    points = _path_points(obj.get("path") or [])
+    if not points:
         return
 
+    scaled_points = [_scale_point(x, y, left, top, scale) for x, y in points]
+    if obj.get("fill") and len(scaled_points) >= 3:
+        draw.polygon(scaled_points, fill=fill_color)
+    if obj.get("stroke") and len(scaled_points) >= 2:
+        draw.line(scaled_points, fill=stroke_color, width=line_width)
+
+
+def _draw_rect(
+    draw: ImageDraw.ImageDraw,
+    rect: dict,
+    region_bbox: Tuple[float, float, float, float],
+    scale: float,
+) -> None:
+    left, top, _right, _bottom = region_bbox
+    x0, y0, x1, y1 = _bbox_for_obj(rect)
+    scaled_bbox = (
+        (x0 - left) * scale,
+        (y0 - top) * scale,
+        (x1 - left) * scale,
+        (y1 - top) * scale,
+    )
+    fill = _pdf_color_to_rgb(rect.get("non_stroking_color"), default=(255, 255, 255)) if rect.get("fill") else None
+    outline = _pdf_color_to_rgb(rect.get("stroking_color"), default=(0, 0, 0)) if rect.get("stroke") else None
+    width = max(1, int(round(float(rect.get("linewidth", 1.0)) * scale)))
+    draw.rectangle(scaled_bbox, fill=fill, outline=outline, width=width if outline is not None else 0)
+
+
+def _draw_char(
+    image: Image.Image,
+    char: dict,
+    region_bbox: Tuple[float, float, float, float],
+    scale: float,
+) -> None:
+    if not _is_non_watermark_obj(char):
+        return
+    text = str(char.get("text") or "")
+    if not text:
+        return
+
+    left, top, _right, _bottom = region_bbox
+    x0, char_top, _x1, _char_bottom = _bbox_for_obj(char)
+    font_size = max(1, int(round(float(char.get("size", 0.0)) * scale)))
+    font = _load_pil_font(str(char.get("fontname") or ""), font_size)
+    fill = _pdf_color_to_rgb(char.get("non_stroking_color") or char.get("stroking_color"), default=(0, 0, 0))
+    x = (x0 - left) * scale
+    y = (char_top - top) * scale
+    angle = _char_rotation_degrees(char)
+
+    if abs(angle) <= 0.1:
+        ImageDraw.Draw(image).text((x, y), text, font=font, fill=fill)
+        return
+
+    padding = max(4, font_size)
+    layer = Image.new("RGBA", (font_size * 4, font_size * 4), (255, 255, 255, 0))
+    layer_draw = ImageDraw.Draw(layer)
+    layer_draw.text((padding, padding), text, font=font, fill=(*fill, 255))
+    rotated = layer.rotate(-angle, expand=True)
+    image.alpha_composite(rotated, (int(round(x - padding)), int(round(y - padding))))
+
+
+def _render_drawing_region_image(
+    page: "pdfplumber.page.Page",
+    bbox: Tuple[float, float, float, float],
+    resolution: float,
+) -> Image.Image:
+    left, top, right, bottom = bbox
     scale = float(resolution) / 72.0
-    draw = ImageDraw.Draw(page_image.original)
-    image_width, image_height = page_image.original.size
-    for char in watermark_chars:
-        left_px = max(0, min(int(math.floor(float(char.get("x0", 0.0)) * scale)) - 1, image_width))
-        top_px = max(0, min(int(math.floor(float(char.get("top", 0.0)) * scale)) - 1, image_height))
-        right_px = max(0, min(int(math.ceil(float(char.get("x1", char.get("x0", 0.0))) * scale)) + 1, image_width))
-        bottom_px = max(0, min(int(math.ceil(float(char.get("bottom", char.get("top", 0.0))) * scale)) + 1, image_height))
-        if right_px <= left_px or bottom_px <= top_px:
-            continue
-        draw.rectangle((left_px, top_px, right_px, bottom_px), fill="white")
+    width_px = max(1, int(math.ceil((right - left) * scale)))
+    height_px = max(1, int(math.ceil((bottom - top) * scale)))
+    image = Image.new("RGBA", (width_px, height_px), (255, 255, 255, 255))
+    draw = ImageDraw.Draw(image)
+
+    for rect in getattr(page, "rects", []):
+        if _bboxes_intersect(_bbox_for_obj(rect), bbox):
+            _draw_rect(draw, rect, bbox, scale)
+
+    for obj in [*getattr(page, "lines", []), *getattr(page, "curves", [])]:
+        if _bboxes_intersect(_bbox_for_obj(obj), bbox):
+            _draw_graphic_path(draw, obj, bbox, scale)
+
+    for char in getattr(page, "chars", []):
+        if _bboxes_intersect(_bbox_for_obj(char), bbox):
+            _draw_char(image, char, bbox, scale)
+
+    return image.convert("RGB")
 
 
 def _extract_embedded_images(
@@ -125,15 +320,8 @@ def _extract_embedded_images(
                 if right <= left or bottom_y <= top_y:
                     continue
                 try:
-                    page_image = plumber_page.to_image(resolution=180)
-                    _erase_watermark_chars_from_page_image(
-                        page_image=page_image,
+                    region_image = _render_drawing_region_image(
                         page=plumber_page,
-                        resolution=180.0,
-                    )
-                    region_image = _crop_page_region(
-                        page_image=page_image,
-                        page_height=height,
                         bbox=(left, top_y, right, bottom_y),
                         resolution=180.0,
                     )

--- a/graph_pdf/tests/test_images.py
+++ b/graph_pdf/tests/test_images.py
@@ -5,12 +5,35 @@ import unittest
 from pathlib import Path
 from types import SimpleNamespace
 
-from PIL import Image
+from PIL import Image, ImageChops
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 
 from extractor.images import _crop_page_region, _extract_embedded_images
+
+
+def _build_flow_label_pdf(pdf_path: Path, include_watermark: bool) -> None:
+    c = canvas.Canvas(str(pdf_path), pagesize=letter)
+    c.setLineWidth(1.0)
+    c.rect(140.0, 260.0, 300.0, 240.0)
+    c.line(160.0, 280.0, 340.0, 480.0)
+    c.line(160.0, 480.0, 420.0, 280.0)
+    c.bezier(140.0, 390.0, 140.0, 250.0, 440.0, 470.0, 440.0, 270.0)
+    c.setFillColor(colors.black)
+    c.setFont("Helvetica-Bold", 20)
+    c.drawString(225.0, 388.0, "NODE")
+
+    if include_watermark:
+        c.saveState()
+        c.setFillColor(colors.Color(0.92, 0.92, 0.92))
+        c.setFont("Helvetica-Bold", 44)
+        c.translate(300.0, 405.0)
+        c.rotate(55)
+        c.drawCentredString(0, 0, "CONFIDENTIAL")
+        c.restoreState()
+
+    c.save()
 
 
 class CropPageRegionTests(unittest.TestCase):
@@ -32,29 +55,33 @@ class CropPageRegionTests(unittest.TestCase):
         self.assertEqual((10, 10, 10), cropped.getpixel((0, 0)))
         self.assertEqual((29, 29, 29), cropped.getpixel((0, 19)))
 
-    def test_extract_embedded_images_removes_watermark_from_drawing_crop(self) -> None:
+    def test_extract_embedded_images_preserves_label_text_while_excluding_watermark(self) -> None:
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
         root = Path(tmp.name)
-        pdf_path = root / "watermark_only.pdf"
+        clean_pdf_path = root / "label_only.pdf"
+        watermark_pdf_path = root / "label_with_watermark.pdf"
+        drawing_region = (140.0, 292.0, 440.0, 532.0)
+        _build_flow_label_pdf(clean_pdf_path, include_watermark=False)
+        _build_flow_label_pdf(watermark_pdf_path, include_watermark=True)
 
-        c = canvas.Canvas(str(pdf_path), pagesize=letter)
-        c.saveState()
-        c.setFillColor(colors.Color(0.92, 0.92, 0.92))
-        c.setFont("Helvetica-Bold", 44)
-        c.translate(letter[0] / 2.0, letter[1] / 2.0)
-        c.rotate(55)
-        c.drawCentredString(0, 0, "CONFIDENTIAL")
-        c.restoreState()
-        c.save()
-
-        image_files = _extract_embedded_images(
-            pdf_path=pdf_path,
-            out_image_dir=root / "images",
-            stem="watermark_only",
-            drawing_regions_by_page={1: [(0.0, 0.0, float(letter[0]), float(letter[1]))]},
+        clean_files = _extract_embedded_images(
+            pdf_path=clean_pdf_path,
+            out_image_dir=root / "images_clean",
+            stem="label_only",
+            drawing_regions_by_page={1: [drawing_region]},
+        )
+        watermark_files = _extract_embedded_images(
+            pdf_path=watermark_pdf_path,
+            out_image_dir=root / "images_watermark",
+            stem="label_with_watermark",
+            drawing_regions_by_page={1: [drawing_region]},
         )
 
-        self.assertEqual(1, len(image_files))
-        image = Image.open(image_files[0]).convert("L")
-        self.assertEqual((255, 255), image.getextrema())
+        self.assertEqual(1, len(clean_files))
+        self.assertEqual(1, len(watermark_files))
+        clean_image = Image.open(clean_files[0]).convert("L")
+        watermark_image = Image.open(watermark_files[0]).convert("L")
+        self.assertEqual(clean_image.size, watermark_image.size)
+        self.assertLess(watermark_image.getextrema()[0], 255)
+        self.assertIsNone(ImageChops.difference(clean_image, watermark_image).getbbox())


### PR DESCRIPTION
## Summary
- Replace drawing image export raster crops with object reconstruction for drawing regions.
- Preserve diagram-internal text while excluding watermark text from the rendered drawing image.
- Add regression coverage that proves a watermarked drawing export matches the non-watermarked version when only watermark text differs.

## Root Cause
- `page.to_image()` rasterized the original PDF page content, so watermark text survived even when text extraction filtered it.
- Masking after rasterization was not acceptable because it can destroy overlapping diagram text.

## Changes
- `graph_pdf/extractor/images.py`
  - Reconstruct drawing region PNGs from PDF objects instead of cropping a rasterized page image.
  - Render `rect`, `line`, `curve`, and non-watermark `char` objects inside the selected drawing bbox.
  - Exclude only watermark chars using the existing `_is_non_watermark_obj` rule.
- `graph_pdf/tests/test_images.py`
  - Add a PDF-backed regression test that preserves diagram label text while excluding watermark text.

## Validation
- `python3 -m unittest tests.test_images.CropPageRegionTests.test_extract_embedded_images_preserves_label_text_while_excluding_watermark`
- `python3 -m unittest discover -s tests -p 'test_*.py'`
