### PR TITLE
Expand drawing render bounds for connected lines

### DIFF
--- a/graph_pdf/extractor/images.py
+++ b/graph_pdf/extractor/images.py
@@ -10,7 +10,7 @@ from PIL import Image, ImageDraw, ImageFont
 from pypdf import PdfReader
 
 from .shared import _bboxes_intersect, _char_rotation_degrees
-from .text import _detect_body_bounds, _is_non_watermark_obj
+from .text import _detect_body_bounds, _is_non_watermark_obj, _selected_drawing_image_groups
 
 
 def _crop_page_region(
@@ -56,6 +56,42 @@ def _bbox_for_obj(obj: dict) -> Tuple[float, float, float, float]:
         float(obj.get("x1", obj.get("x0", 0.0))),
         float(obj.get("bottom", obj.get("top", 0.0))),
     )
+
+
+def _union_bboxes(bboxes: Sequence[Tuple[float, float, float, float]]) -> Tuple[float, float, float, float]:
+    return (
+        min(bbox[0] for bbox in bboxes),
+        min(bbox[1] for bbox in bboxes),
+        max(bbox[2] for bbox in bboxes),
+        max(bbox[3] for bbox in bboxes),
+    )
+
+
+def _expanded_drawing_render_bbox(
+    page: "pdfplumber.page.Page",
+    image_bbox: Tuple[float, float, float, float],
+    header_margin: float,
+    footer_margin: float,
+) -> Tuple[float, float, float, float]:
+    groups = _selected_drawing_image_groups(
+        page=page,
+        header_margin=header_margin,
+        footer_margin=footer_margin,
+    )
+    for group in groups:
+        if not _bboxes_intersect(group["image_bbox"], image_bbox):
+            continue
+        object_bboxes = [tuple(obj["bbox"]) for obj in group["objects"]]
+        render_bbox = _union_bboxes(object_bboxes)
+        text_bboxes = [
+            _bbox_for_obj(char)
+            for char in getattr(page, "chars", [])
+            if _is_non_watermark_obj(char) and _bboxes_intersect(_bbox_for_obj(char), render_bbox)
+        ]
+        if text_bboxes:
+            render_bbox = _union_bboxes([render_bbox, *text_bboxes])
+        return render_bbox
+    return image_bbox
 
 
 def _pdf_color_to_rgb(color: object, default: Tuple[int, int, int] = (0, 0, 0)) -> Tuple[int, int, int]:
@@ -284,10 +320,12 @@ def _extract_embedded_images(
             if selected_pages and page_idx not in selected_pages:
                 continue
 
+            header_margin = 90.0
+            footer_margin = 40.0
             body_top, body_bottom = _detect_body_bounds(
                 plumber_page,
-                header_margin=90.0,
-                footer_margin=40.0,
+                header_margin=header_margin,
+                footer_margin=footer_margin,
             )
             allowed_names = {
                 str(image_meta.get("name") or "")
@@ -319,10 +357,22 @@ def _extract_embedded_images(
                 bottom_y = max(0.0, min(float(bottom), height))
                 if right <= left or bottom_y <= top_y:
                     continue
+                render_left, render_top, render_right, render_bottom = _expanded_drawing_render_bbox(
+                    page=plumber_page,
+                    image_bbox=(left, top_y, right, bottom_y),
+                    header_margin=header_margin,
+                    footer_margin=footer_margin,
+                )
+                render_left = max(0.0, min(float(render_left), width))
+                render_right = max(0.0, min(float(render_right), width))
+                render_top = max(0.0, min(float(render_top), height))
+                render_bottom = max(0.0, min(float(render_bottom), height))
+                if render_right <= render_left or render_bottom <= render_top:
+                    continue
                 try:
                     region_image = _render_drawing_region_image(
                         page=plumber_page,
-                        bbox=(left, top_y, right, bottom_y),
+                        bbox=(render_left, render_top, render_right, render_bottom),
                         resolution=180.0,
                     )
                     drawing_image_idx += 1

--- a/graph_pdf/tests/test_images.py
+++ b/graph_pdf/tests/test_images.py
@@ -85,3 +85,33 @@ class CropPageRegionTests(unittest.TestCase):
         self.assertEqual(clean_image.size, watermark_image.size)
         self.assertLess(watermark_image.getextrema()[0], 255)
         self.assertIsNone(ImageChops.difference(clean_image, watermark_image).getbbox())
+
+    def test_extract_embedded_images_expands_curve_bbox_to_connected_line_bounds(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        pdf_path = root / "group_bounds.pdf"
+        _build_flow_label_pdf(pdf_path, include_watermark=False)
+
+        curve_region = (140.0, 402.0, 440.0, 522.0)
+        full_group_region = (140.0, 292.0, 440.0, 532.0)
+
+        curve_files = _extract_embedded_images(
+            pdf_path=pdf_path,
+            out_image_dir=root / "images_curve",
+            stem="curve_region",
+            drawing_regions_by_page={1: [curve_region]},
+        )
+        full_group_files = _extract_embedded_images(
+            pdf_path=pdf_path,
+            out_image_dir=root / "images_full",
+            stem="full_region",
+            drawing_regions_by_page={1: [full_group_region]},
+        )
+
+        self.assertEqual(1, len(curve_files))
+        self.assertEqual(1, len(full_group_files))
+        curve_image = Image.open(curve_files[0]).convert("L")
+        full_group_image = Image.open(full_group_files[0]).convert("L")
+        self.assertEqual(full_group_image.size, curve_image.size)
+        self.assertIsNone(ImageChops.difference(curve_image, full_group_image).getbbox())


### PR DESCRIPTION
## Summary
- Expand drawing export render bounds from the selected curve bbox to the full connected drawing group bounds.
- Keep rendering from the reconstruction pipeline, including diagram text while excluding watermark text.
- Add regression coverage so curve-seeded exports still include connected line content.

## Root Cause
- Image-group selection uses the largest curve bbox as the seed region.
- The reconstruction renderer used that seed bbox directly, so connected `line`/`rect` objects that extended above the curve bbox were clipped out of the exported PNG.

## Changes
- `graph_pdf/extractor/images.py`
  - Expand render bbox to the union of the matched drawing group's objects and overlapping non-watermark chars before rendering.
- `graph_pdf/tests/test_images.py`
  - Add regression test showing curve-bbox export matches full-group export for a connected drawing.

## Validation
- `python3 -m unittest tests.test_images.CropPageRegionTests.test_extract_embedded_images_expands_curve_bbox_to_connected_line_bounds`
- `python3 -m unittest discover -s tests -p 'test_*.py'`
