### PR TITLE
Add raw dump import/export support and document new CLI options

### DIFF
--- a/graph_pdf/README.md
+++ b/graph_pdf/README.md
@@ -44,6 +44,9 @@ python3 extractor/__main__.py sample.pdf \
 - `--debug`: 표 구조/edge 디버그 JSON 생성
 - `--debug-watermark`: 회전 문자 디버그 JSON 생성
 - `--profile-fonts`: body text 기준 `font_size + font_color` 조합 프로파일 JSON/CSV 생성
+- `--add-heading <path>`: 외부 JSON의 `font_size -> h1~h6` 규칙으로 body markdown heading 추가
+- `--raw <path>`: 선택 페이지 기준 원본 PDF raw dump 파일 생성
+- `--from-raw <path>`: raw dump 파일을 입력으로 읽어 기존 추출 파이프라인 실행
 
 ### 직접 실행 예시
 ```bash
@@ -65,6 +68,37 @@ python3 -m extractor sample.pdf \
   --profile-fonts
 ```
 
+font size 기준 heading을 markdown에 반영하려면 외부 heading JSON을 같이 넘기면 됩니다.
+
+```bash
+python3 -m extractor sample.pdf \
+  --out-md-dir artifacts/manual/md \
+  --out-image-dir artifacts/manual/images \
+  --stem sample \
+  --add-heading fixtures/font_heading_profile.sample.json
+```
+
+샘플 heading JSON은 `fixtures/font_heading_profile.sample.json`에 있습니다. 현재는 `heading_rules[].match.font_size`와 `assign.tag` 또는 `assign.markdown_prefix`만 사용하며, 매칭되지 않는 font size는 일반 문단으로 유지됩니다.
+
+문서 전체를 raw dump로 저장하려면 `--raw`를 사용합니다.
+
+```bash
+python3 -m extractor sample.pdf \
+  --raw artifacts/manual/raw/sample.raw.dump
+```
+
+raw dump에는 문서 PDF 자체의 base64와 함께 페이지별 `content stream`, `resources`, `embedded images`, `chars`, `lines`, `rects`, `curves`, `images`, `horizontal_edges`, `vertical_edges`, `words`가 포함됩니다.
+
+PDF 대신 raw dump를 입력으로 재실행하려면 `--from-raw`를 사용합니다. 이 경우 positional `pdf_path` 없이 실행할 수 있습니다.
+
+```bash
+python3 -m extractor \
+  --from-raw artifacts/manual/raw/sample.raw.dump \
+  --out-md-dir artifacts/manual/md \
+  --out-image-dir artifacts/manual/images \
+  --stem sample
+```
+
 ### 직접 실행 산출물
 - `artifacts/manual/md/sample.txt`: 본문 텍스트
 - `artifacts/manual/md/sample.md`: 본문 markdown
@@ -76,6 +110,7 @@ python3 -m extractor sample.pdf \
 - `artifacts/manual/md/sample_font_profile.json`: body text의 `font_size + font_color` 조합 요약 (`--profile-fonts`)
 - `artifacts/manual/md/sample_font_profile.csv`: 동일 프로파일의 표 형태 출력 (`--profile-fonts`)
 - `artifacts/manual/images/*`: body 영역 이미지 추출 결과
+- `artifacts/manual/raw/sample.raw.dump`: 문서 전체 raw dump 예시 (`--raw`)
 
 ### font profile 모드
 이 모드는 표 추출 대신 문서의 body text line을 전체 순회하면서 스타일 분포를 집계합니다.
@@ -98,10 +133,12 @@ python3 -m extractor sample.pdf \
 - `sample_generator.py`: 본문, 표, 워터마크, 이미지가 포함된 테스트용 샘플 PDF 생성기
 - `sample_fixture.py`: 샘플 PDF 검증용 fixture 로더
 - `fixtures/demo_document.json`: 샘플 문서의 기대 본문/표 데이터 fixture
+- `fixtures/font_heading_profile.sample.json`: `--add-heading`용 font size 기반 heading 규칙 샘플
 - `extractor/__init__.py`: 외부에서 사용하는 공개 진입점 export
 - `extractor/__main__.py`: CLI 실행용 entrypoint
 - `extractor/font_profile.py`: body text 기준 `font_size + font_color` 프로파일 생성과 JSON/CSV 기록
 - `extractor/pipeline.py`: 전체 PDF 추출 orchestration, 페이지 순회, cross-page table merge, 결과 파일 기록
+- `extractor/raw.py`: PDF -> raw dump export와 raw dump -> 임시 PDF materialize helper
 - `extractor/text.py`: 워터마크/레이아웃 artifact 제거, body bounds 계산, 본문 line 추출과 정규화
 - `extractor/tables.py`: 표 영역 탐지, 표 추출, 셀 정규화, 페이지 간 표 continuation merge 판단, markdown table 렌더링
 - `extractor/debug.py`: 표 선분/그리드, 원본 drawing 객체, 텍스트 스타일/폰트 크기 디버그 payload 생성
@@ -110,6 +147,7 @@ python3 -m extractor sample.pdf \
 - `tests/test_text.py`: 본문/워터마크/바운드 계산 관련 테스트
 - `tests/test_tables.py`: 표 탐지/병합/세그먼트 처리 관련 테스트
 - `tests/test_pipeline.py`: end-to-end 추출 결과와 debug/image 산출물 테스트
+- `tests/test_raw.py`: raw dump export/import과 CLI raw 옵션 테스트
 - `tests/test_public_api.py`: 제거된 레거시 helper가 공개 API로 다시 노출되지 않는지 확인
 - `tests/test_refactor_boundaries.py`: 공개 진입점과 모듈 경계 smoke test
 - `docs/extractor-refactor-removals.md`: 이번 리팩토링에서 제거한 레거시 동작 기록
@@ -138,14 +176,16 @@ python3 -m extractor sample.pdf \
 2. 선택된 페이지 범위가 있으면 그 페이지들만 순회합니다.
 3. `debug=True`면 표 구조, 원본 drawing 객체, 텍스트 폰트 크기 프로파일, edge 디버그 payload를 수집합니다.
 4. `debug_watermark=True`면 회전된 문자 디버그 payload를 수집합니다.
-5. `extractor.tables._extract_tables(...)`가 현재 페이지의 표 후보를 찾고 행 데이터를 정규화합니다.
-6. `extractor.text._extract_body_text(...)`가 전체 body text를 구합니다.
-7. 표 bbox를 제외한 body text를 다시 계산해 최종 본문 markdown에 사용합니다.
-8. 표가 있으면 이전 페이지의 pending table과 이어붙일 수 있는지 검사합니다.
-9. 이어붙일 수 있으면 pending table을 확장하고, 아니면 이전 pending table을 flush한 뒤 현재 표를 새 pending 상태로 둡니다.
-10. 모든 페이지를 처리한 뒤 남은 pending table을 flush합니다.
-11. 본문 markdown, table markdown, summary json, optional debug json을 기록합니다.
-12. 마지막으로 body 영역과 겹치는 embedded image만 별도 파일로 저장합니다.
+5. `--from-raw`가 주어지면 raw dump의 문서 PDF base64를 임시 PDF로 복원한 뒤 같은 파이프라인을 재사용합니다.
+6. `extractor.tables._extract_tables(...)`가 현재 페이지의 표 후보를 찾고 행 데이터를 정규화합니다.
+7. `extractor.text._extract_body_text(...)`가 전체 body text를 구합니다.
+8. `--add-heading`이 있으면 외부 JSON의 `font_size -> heading level` 규칙으로 markdown heading prefix를 추가합니다.
+9. 표 bbox를 제외한 body text를 다시 계산해 최종 본문 markdown에 사용합니다.
+10. 표가 있으면 이전 페이지의 pending table과 이어붙일 수 있는지 검사합니다.
+11. 이어붙일 수 있으면 pending table을 확장하고, 아니면 이전 pending table을 flush한 뒤 현재 표를 새 pending 상태로 둡니다.
+12. 모든 페이지를 처리한 뒤 남은 pending table을 flush합니다.
+13. 본문 markdown, table markdown, summary json, optional debug json을 기록합니다.
+14. 마지막으로 body 영역과 겹치는 embedded image만 별도 파일로 저장합니다.
 
 ## 산출물 예시 위치
 - 텍스트/마크다운: `graph_pdf/artifacts/run_demo/md/demo.txt`, `demo.md`

--- a/graph_pdf/extractor/__main__.py
+++ b/graph_pdf/extractor/__main__.py
@@ -5,13 +5,14 @@ from pathlib import Path
 
 from .font_profile import profile_pdf_fonts
 from .pipeline import extract_pdf_to_outputs
+from .raw import dump_pdf_to_raw_file, materialize_raw_dump
 from .shared import _parse_pages_spec
 
 
 def main() -> None:
     # Keep the CLI intentionally thin so the real behavior lives in pipeline.py.
     parser = argparse.ArgumentParser()
-    parser.add_argument("pdf_path")
+    parser.add_argument("pdf_path", nargs="?")
     parser.add_argument("--out-md-dir", default="graph_pdf/artifacts/md")
     parser.add_argument("--out-image-dir", default="graph_pdf/artifacts/images")
     parser.add_argument("--stem", default="output")
@@ -20,26 +21,56 @@ def main() -> None:
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--debug-watermark", action="store_true")
     parser.add_argument("--profile-fonts", action="store_true")
+    parser.add_argument("--add-heading")
+    parser.add_argument("--raw")
+    parser.add_argument("--from-raw")
     args = parser.parse_args()
 
-    if args.profile_fonts:
-        profile_pdf_fonts(
+    selected_pages = _parse_pages_spec(args.pages) if args.pages else None
+    if args.raw and args.from_raw:
+        parser.error("--raw and --from-raw cannot be used together")
+    if args.raw and not args.pdf_path:
+        parser.error("pdf_path is required when using --raw")
+    if not args.pdf_path and not args.from_raw:
+        parser.error("pdf_path is required unless --from-raw is provided")
+
+    if args.raw:
+        dump_pdf_to_raw_file(
             pdf_path=Path(args.pdf_path),
-            out_dir=Path(args.out_md_dir),
-            stem=args.stem,
-            pages=_parse_pages_spec(args.pages) if args.pages else None,
+            raw_path=Path(args.raw),
+            pages=selected_pages,
         )
         return
 
+    if args.profile_fonts:
+        if args.from_raw:
+            with materialize_raw_dump(Path(args.from_raw)) as (materialized_pdf_path, _raw_payload):
+                profile_pdf_fonts(
+                    pdf_path=materialized_pdf_path,
+                    out_dir=Path(args.out_md_dir),
+                    stem=args.stem,
+                    pages=selected_pages,
+                )
+        else:
+            profile_pdf_fonts(
+                pdf_path=Path(args.pdf_path),
+                out_dir=Path(args.out_md_dir),
+                stem=args.stem,
+                pages=selected_pages,
+            )
+        return
+
     extract_pdf_to_outputs(
-        pdf_path=Path(args.pdf_path),
+        pdf_path=Path(args.pdf_path) if args.pdf_path else None,
         out_md_dir=Path(args.out_md_dir),
         out_image_dir=Path(args.out_image_dir),
         stem=args.stem,
-        pages=_parse_pages_spec(args.pages) if args.pages else None,
+        pages=selected_pages,
         force_table=args.force_table,
         debug=args.debug,
         debug_watermark=args.debug_watermark,
+        add_heading=Path(args.add_heading) if args.add_heading else None,
+        from_raw=Path(args.from_raw) if args.from_raw else None,
     )
 
 

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -9,6 +9,7 @@ import pdfplumber
 
 from .debug import _collect_page_edge_debug, _collect_rotated_text_debug, _collect_table_drawing_debug
 from .images import _extract_embedded_images
+from .raw import materialize_raw_dump
 from .shared import TableRows, _merge_numeric_positions
 from .tables import (
     _append_output_table,
@@ -23,6 +24,38 @@ from .tables import (
     _vertical_axes_for_bbox,
 )
 from .text import _detect_body_bounds, _extract_body_text, _extract_drawing_image_bboxes
+
+
+def _heading_level_from_rule(rule: dict) -> int | None:
+    assign = rule.get("assign") or {}
+    tag = str(assign.get("tag") or "").strip().lower()
+    if len(tag) == 2 and tag.startswith("h") and tag[1].isdigit():
+        level = int(tag[1])
+        if 1 <= level <= 6:
+            return level
+
+    markdown_prefix = str(assign.get("markdown_prefix") or "")
+    sharp_count = len(markdown_prefix.strip())
+    return sharp_count if 1 <= sharp_count <= 6 else None
+
+
+def _load_heading_levels(add_heading: Path | None) -> dict[float, int] | None:
+    if add_heading is None:
+        return None
+
+    payload = json.loads(Path(add_heading).read_text(encoding="utf-8"))
+    heading_levels: dict[float, int] = {}
+    for rule in payload.get("heading_rules", []):
+        if not bool(rule.get("enabled", True)):
+            continue
+        match = rule.get("match") or {}
+        if "font_size" not in match:
+            continue
+        level = _heading_level_from_rule(rule)
+        if level is None:
+            continue
+        heading_levels[round(float(match["font_size"]), 2)] = level
+    return heading_levels
 
 
 def _document_text_profile(debug_pages: Sequence[dict]) -> dict:
@@ -76,7 +109,7 @@ def _body_excluded_bboxes(
 
 
 def extract_pdf_to_outputs(
-    pdf_path: Path,
+    pdf_path: Path | None,
     out_md_dir: Path,
     out_image_dir: Path,
     stem: str,
@@ -86,7 +119,27 @@ def extract_pdf_to_outputs(
     force_table: bool = False,
     debug: bool = False,
     debug_watermark: bool = False,
+    add_heading: Path | None = None,
+    from_raw: Path | None = None,
 ) -> dict:
+    if from_raw is not None:
+        with materialize_raw_dump(from_raw) as (materialized_pdf_path, _raw_payload):
+            return extract_pdf_to_outputs(
+                pdf_path=materialized_pdf_path,
+                out_md_dir=out_md_dir,
+                out_image_dir=out_image_dir,
+                stem=stem,
+                header_margin=header_margin,
+                footer_margin=footer_margin,
+                pages=pages,
+                force_table=force_table,
+                debug=debug,
+                debug_watermark=debug_watermark,
+                add_heading=add_heading,
+                from_raw=None,
+            )
+    if pdf_path is None:
+        raise ValueError("pdf_path is required when from_raw is not provided")
     out_md_dir.mkdir(parents=True, exist_ok=True)
 
     output_text: List[str] = []
@@ -96,6 +149,7 @@ def extract_pdf_to_outputs(
     rotated_debug: List[dict] = []
     selected_pages = set(int(page_no) for page_no in (pages or []))
     drawing_regions_by_page: dict[int, list[Tuple[float, float, float, float]]] = {}
+    heading_levels = _load_heading_levels(add_heading)
 
     pending_table: Optional[TableRows] = None
     pending_page: Optional[int] = None
@@ -152,6 +206,7 @@ def extract_pdf_to_outputs(
                     image_regions=image_regions,
                     body_top=footer_margin,
                 ),
+                heading_levels=heading_levels,
             )
             if page_text.strip():
                 output_text.append(f"### Page {page_idx}\n{page_text}")

--- a/graph_pdf/extractor/raw.py
+++ b/graph_pdf/extractor/raw.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import base64
+import json
+import tempfile
+from contextlib import contextmanager
+from io import BytesIO
+from pathlib import Path
+from typing import Iterator, Optional, Sequence
+
+import pdfplumber
+from pypdf import PdfReader, PdfWriter
+from pypdf.generic import ArrayObject, BooleanObject, ByteStringObject, DictionaryObject, FloatObject, IndirectObject, NameObject, NullObject, NumberObject, StreamObject, TextStringObject
+
+
+def _object_to_json_safe(value: object) -> object:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, bytes):
+        return {"type": "bytes", "base64": base64.b64encode(value).decode("ascii")}
+    if isinstance(value, tuple):
+        return [_object_to_json_safe(item) for item in value]
+    if isinstance(value, list):
+        return [_object_to_json_safe(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _object_to_json_safe(item) for key, item in value.items()}
+    return str(value)
+
+
+def _serialize_pdf_object(
+    value: object,
+    *,
+    seen: set[tuple[int, int]] | None = None,
+    depth: int = 0,
+    max_depth: int = 16,
+) -> object:
+    seen = seen or set()
+    if depth > max_depth:
+        return {"type": "max_depth"}
+    if value is None or isinstance(value, (bool, int, float, str, BooleanObject, FloatObject, NumberObject, NameObject, TextStringObject)):
+        if isinstance(value, (FloatObject, NumberObject)):
+            return float(value)
+        return str(value) if isinstance(value, NameObject) else value
+    if isinstance(value, NullObject):
+        return None
+    if isinstance(value, ByteStringObject):
+        return {"type": "bytes", "base64": base64.b64encode(bytes(value)).decode("ascii")}
+    if isinstance(value, IndirectObject):
+        ref = (int(value.idnum), int(value.generation))
+        if ref in seen:
+            return {"type": "indirect_ref", "idnum": ref[0], "generation": ref[1]}
+        seen.add(ref)
+        return {
+            "type": "indirect",
+            "idnum": ref[0],
+            "generation": ref[1],
+            "value": _serialize_pdf_object(value.get_object(), seen=seen, depth=depth + 1, max_depth=max_depth),
+        }
+    if isinstance(value, StreamObject):
+        return {
+            "type": "stream",
+            "dict": {
+                str(key): _serialize_pdf_object(item, seen=seen, depth=depth + 1, max_depth=max_depth)
+                for key, item in value.items()
+            },
+            "data_base64": base64.b64encode(value.get_data()).decode("ascii"),
+        }
+    if isinstance(value, DictionaryObject):
+        return {
+            str(key): _serialize_pdf_object(item, seen=seen, depth=depth + 1, max_depth=max_depth)
+            for key, item in value.items()
+        }
+    if isinstance(value, ArrayObject):
+        return [_serialize_pdf_object(item, seen=seen, depth=depth + 1, max_depth=max_depth) for item in value]
+    if isinstance(value, (list, tuple)):
+        return [_serialize_pdf_object(item, seen=seen, depth=depth + 1, max_depth=max_depth) for item in value]
+    if isinstance(value, bytes):
+        return {"type": "bytes", "base64": base64.b64encode(value).decode("ascii")}
+    return str(value)
+
+
+def _page_content_stream_base64(reader_page) -> str:
+    contents = reader_page.get_contents()
+    if contents is None:
+        return ""
+    if hasattr(contents, "get_data"):
+        return base64.b64encode(contents.get_data()).decode("ascii")
+    return ""
+
+
+def _page_embedded_images(reader_page) -> list[dict]:
+    payload: list[dict] = []
+    for image_file in getattr(reader_page, "images", []):
+        payload.append(
+            {
+                "name": str(getattr(image_file, "name", "") or ""),
+                "data_base64": base64.b64encode(bytes(getattr(image_file, "data", b""))).decode("ascii"),
+            }
+        )
+    return payload
+
+
+def _page_object_dump(plumber_page: "pdfplumber.page.Page") -> dict:
+    return {
+        "chars": _object_to_json_safe(list(getattr(plumber_page, "chars", []) or [])),
+        "lines": _object_to_json_safe(list(getattr(plumber_page, "lines", []) or [])),
+        "rects": _object_to_json_safe(list(getattr(plumber_page, "rects", []) or [])),
+        "curves": _object_to_json_safe(list(getattr(plumber_page, "curves", []) or [])),
+        "images": _object_to_json_safe(list(getattr(plumber_page, "images", []) or [])),
+        "horizontal_edges": _object_to_json_safe(list(getattr(plumber_page, "horizontal_edges", []) or [])),
+        "vertical_edges": _object_to_json_safe(list(getattr(plumber_page, "vertical_edges", []) or [])),
+        "words": _object_to_json_safe(
+            plumber_page.extract_words(
+                x_tolerance=1.5,
+                y_tolerance=2.0,
+                keep_blank_chars=False,
+                extra_attrs=["size", "fontname"],
+            )
+            or []
+        ),
+    }
+
+
+def _subset_pdf_bytes(pdf_path: Path, page_numbers: Sequence[int]) -> bytes:
+    reader = PdfReader(str(pdf_path))
+    writer = PdfWriter()
+    for page_no in page_numbers:
+        writer.add_page(reader.pages[page_no - 1])
+    buffer = BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+def dump_pdf_to_raw_file(
+    pdf_path: Path,
+    raw_path: Path,
+    pages: Optional[Sequence[int]] = None,
+) -> Path:
+    selected_pages = [int(page_no) for page_no in (pages or [])]
+    with pdfplumber.open(str(pdf_path)) as plumber_pdf:
+        total_pages = len(plumber_pdf.pages)
+        if not selected_pages:
+            selected_pages = list(range(1, total_pages + 1))
+
+    subset_pdf = _subset_pdf_bytes(pdf_path, selected_pages)
+    reader = PdfReader(BytesIO(subset_pdf))
+    page_payloads: list[dict] = []
+    with pdfplumber.open(BytesIO(subset_pdf)) as plumber_pdf:
+        for raw_index, (reader_page, plumber_page) in enumerate(zip(reader.pages, plumber_pdf.pages), start=1):
+            original_page_no = selected_pages[raw_index - 1]
+            page_payloads.append(
+                {
+                    "raw_page_number": raw_index,
+                    "source_page_number": original_page_no,
+                    "width": float(plumber_page.width),
+                    "height": float(plumber_page.height),
+                    "rotation": int(reader_page.get("/Rotate", 0) or 0),
+                    "mediabox": [float(value) for value in reader_page.mediabox],
+                    "cropbox": [float(value) for value in reader_page.cropbox],
+                    "content_stream_base64": _page_content_stream_base64(reader_page),
+                    "resources": _serialize_pdf_object(reader_page.get("/Resources")),
+                    "embedded_images": _page_embedded_images(reader_page),
+                    "objects": _page_object_dump(plumber_page),
+                }
+            )
+
+    payload = {
+        "schema_version": "1.0",
+        "source_pdf": str(pdf_path),
+        "source_name": pdf_path.name,
+        "selected_pages": selected_pages,
+        "page_count": len(page_payloads),
+        "document_pdf_base64": base64.b64encode(subset_pdf).decode("ascii"),
+        "pages": page_payloads,
+    }
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    raw_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return raw_path
+
+
+def load_raw_payload(raw_path: Path) -> dict:
+    return json.loads(Path(raw_path).read_text(encoding="utf-8"))
+
+
+@contextmanager
+def materialize_raw_dump(raw_path: Path) -> Iterator[tuple[Path, dict]]:
+    payload = load_raw_payload(raw_path)
+    pdf_bytes = base64.b64decode(str(payload.get("document_pdf_base64") or ""))
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pdf_name = Path(str(payload.get("source_name") or "raw_document.pdf")).with_suffix(".pdf").name
+        materialized_path = Path(tmpdir) / pdf_name
+        materialized_path.write_bytes(pdf_bytes)
+        yield materialized_path, payload

--- a/graph_pdf/extractor/text.py
+++ b/graph_pdf/extractor/text.py
@@ -389,6 +389,7 @@ def _extract_body_text(
     header_margin: float,
     footer_margin: float,
     excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
+    heading_levels: dict[float, int] | None = None,
 ) -> str:
     # Most callers want page text as joined logical lines rather than raw line payloads.
     _raw_lines, normalized_lines = _extract_body_text_lines(
@@ -396,6 +397,7 @@ def _extract_body_text(
         header_margin=header_margin,
         footer_margin=footer_margin,
         excluded_bboxes=excluded_bboxes,
+        heading_levels=heading_levels,
     )
     return "\n".join(normalized_lines)
 
@@ -405,6 +407,7 @@ def _extract_body_text_lines(
     header_margin: float,
     footer_margin: float,
     excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
+    heading_levels: dict[float, int] | None = None,
 ) -> Tuple[List[str], List[str]]:
     # Return both the raw visual lines and the normalized logical lines for debug and downstream reuse.
     line_payloads = _extract_body_word_lines(
@@ -414,13 +417,20 @@ def _extract_body_text_lines(
         excluded_bboxes=excluded_bboxes,
     )
     raw_lines = [str(line["text"]) for line in line_payloads]
-    blocks = _build_body_blocks(line_payloads)
+    blocks = _build_body_blocks(line_payloads, heading_levels=heading_levels)
 
     normalized_lines: List[str] = []
     for block in blocks:
         block_lines = [str(line["text"]) for line in block["lines"]]
         if block["kind"] == "heading":
-            normalized_lines.extend(block_lines)
+            if heading_levels is None:
+                normalized_lines.extend(block_lines)
+                continue
+            for line in block["lines"]:
+                text = str(line.get("text") or "").strip()
+                level = _line_heading_level(line, heading_levels)
+                if text and level is not None:
+                    normalized_lines.append(f"{'#' * level} {text}")
             continue
         joined = _join_non_heading_block_lines(block_lines)
         if joined:
@@ -468,8 +478,24 @@ def _is_body_heading_line(line: str) -> bool:
     return bool(re.match(r"^(?:chapter|section|appendix)\b", text, flags=re.IGNORECASE))
 
 
-def _line_kind(line: dict) -> str:
+def _line_font_size(line: dict) -> float:
+    return round(float(line.get("dominant_font_size", line.get("size", 0.0)) or 0.0), 2)
+
+
+def _line_heading_level(line: dict, heading_levels: dict[float, int] | None = None) -> int | None:
+    if heading_levels is None:
+        return None
+    level = heading_levels.get(_line_font_size(line))
+    if level is None:
+        return None
+    level = int(level)
+    return level if 1 <= level <= 6 else None
+
+
+def _line_kind(line: dict, heading_levels: dict[float, int] | None = None) -> str:
     # The current body flow distinguishes only headings and paragraphs.
+    if heading_levels is not None:
+        return "heading" if _line_heading_level(line, heading_levels) is not None else "paragraph"
     if _is_body_heading_line(str(line.get("text") or "").strip()):
         return "heading"
     return "paragraph"
@@ -481,7 +507,7 @@ def _should_merge_paragraph_lines(previous: dict, line: dict) -> bool:
     return line_gap <= 5.0
 
 
-def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
+def _build_body_blocks(lines: Sequence[dict], heading_levels: dict[float, int] | None = None) -> List[dict]:
     # Collapse adjacent body lines into coarse logical blocks before converting them to page text.
     if not lines:
         return []
@@ -489,7 +515,7 @@ def _build_body_blocks(lines: Sequence[dict]) -> List[dict]:
     blocks: List[dict] = []
     current_block: dict | None = None
     for line in lines:
-        kind = _line_kind(line)
+        kind = _line_kind(line, heading_levels=heading_levels)
         if current_block is None:
             current_block = {"kind": kind, "lines": [line]}
             continue

--- a/graph_pdf/fixtures/font_heading_profile.sample.json
+++ b/graph_pdf/fixtures/font_heading_profile.sample.json
@@ -1,0 +1,174 @@
+{
+  "schema_version": "1.0",
+  "description": "Sample dynamic mapping from font profile styles to markdown heading tags.",
+  "profile_source": {
+    "pdf": "sample.pdf",
+    "font_profile_json": "artifacts/manual/md/sample_font_profile.json",
+    "grouping_key": [
+      "font_size"
+    ],
+    "generated_at": "2026-03-24T00:00:00+09:00"
+  },
+  "defaults": {
+    "body_tag": null,
+    "emit_unmapped_as_paragraph": true,
+    "unknown_profile_action": "keep_text"
+  },
+  "heading_rules": [
+    {
+      "rule_id": "title-black-20",
+      "enabled": true,
+      "priority": 100,
+      "match": {
+        "font_size": 20.0
+      },
+      "assign": {
+        "tag": "h1",
+        "markdown_prefix": "# ",
+        "semantic_role": "document_title"
+      },
+      "notes": "Main chapter title style."
+    },
+    {
+      "rule_id": "section-black-16",
+      "enabled": true,
+      "priority": 90,
+      "match": {
+        "font_size": 16.0
+      },
+      "assign": {
+        "tag": "h2",
+        "markdown_prefix": "## ",
+        "semantic_role": "section_heading"
+      },
+      "notes": "Section heading style."
+    },
+    {
+      "rule_id": "subsection-black-13",
+      "enabled": true,
+      "priority": 80,
+      "match": {
+        "font_size": 13.0
+      },
+      "assign": {
+        "tag": "h3",
+        "markdown_prefix": "### ",
+        "semantic_role": "subsection_heading"
+      },
+      "notes": "Subsection heading style."
+    }
+  ],
+  "fallback_rules": [
+    {
+      "rule_id": "fallback-h1",
+      "enabled": true,
+      "priority": 50,
+      "match": {
+        "min_font_size": 18.0
+      },
+      "assign": {
+        "tag": "h1",
+        "markdown_prefix": "# ",
+        "semantic_role": "large_heading"
+      }
+    },
+    {
+      "rule_id": "fallback-h2",
+      "enabled": true,
+      "priority": 40,
+      "match": {
+        "min_font_size": 15.0,
+        "max_font_size": 17.99
+      },
+      "assign": {
+        "tag": "h2",
+        "markdown_prefix": "## ",
+        "semantic_role": "medium_heading"
+      }
+    },
+    {
+      "rule_id": "fallback-h3",
+      "enabled": true,
+      "priority": 30,
+      "match": {
+        "min_font_size": 12.0,
+        "max_font_size": 14.99
+      },
+      "assign": {
+        "tag": "h3",
+        "markdown_prefix": "### ",
+        "semantic_role": "small_heading"
+      }
+    }
+  ],
+  "profiles": [
+    {
+      "profile_id": "20.00",
+      "font_size": 20.0,
+      "line_count": 1,
+      "page_count": 1,
+      "sample_page": 1,
+      "sample_texts": [
+        "Chapter 1: Deep Structure Verification"
+      ],
+      "assigned_tag": "h1",
+      "assignment_source": "exact_rule",
+      "matched_rule_id": "title-black-20"
+    },
+    {
+      "profile_id": "16.00",
+      "font_size": 16.0,
+      "line_count": 4,
+      "page_count": 2,
+      "sample_page": 1,
+      "sample_texts": [
+        "Overview",
+        "Data Sources"
+      ],
+      "assigned_tag": "h2",
+      "assignment_source": "exact_rule",
+      "matched_rule_id": "section-black-16"
+    },
+    {
+      "profile_id": "13.00",
+      "font_size": 13.0,
+      "line_count": 7,
+      "page_count": 3,
+      "sample_page": 2,
+      "sample_texts": [
+        "Normalization Notes",
+        "Fallback Logic"
+      ],
+      "assigned_tag": "h3",
+      "assignment_source": "exact_rule",
+      "matched_rule_id": "subsection-black-13"
+    },
+    {
+      "profile_id": "11.00",
+      "font_size": 11.0,
+      "line_count": 128,
+      "page_count": 5,
+      "sample_page": 1,
+      "sample_texts": [
+        "This paragraph remains body text.",
+        "The extractor keeps this as normal prose."
+      ],
+      "assigned_tag": null,
+      "assignment_source": "default_body",
+      "matched_rule_id": null
+    },
+    {
+      "profile_id": "11.00-accent",
+      "font_size": 11.0,
+      "line_count": 9,
+      "page_count": 2,
+      "sample_page": 1,
+      "sample_texts": [
+        "Blue accent line marks a separate style bucket for font profile review."
+      ],
+      "assigned_tag": null,
+      "assignment_source": "default_body",
+      "matched_rule_id": null
+    }
+  ]
+}

--- a/graph_pdf/tests/test_font_profile.py
+++ b/graph_pdf/tests/test_font_profile.py
@@ -122,6 +122,31 @@ class FontProfileTests(unittest.TestCase):
         self.assertTrue((root / "md" / "sample_font_profile.json").exists())
         self.assertTrue((root / "md" / "sample_font_profile.csv").exists())
 
+    def test_cli_add_heading_option_passes_heading_json_to_pipeline(self) -> None:
+        root, pdf_path = self._build_pdf()
+        heading_json = root / "heading.json"
+        heading_json.write_text(
+            json.dumps({"heading_rules": [{"match": {"font_size": 20.0}, "assign": {"tag": "h1"}}]}),
+            encoding="utf-8",
+        )
+
+        argv = [
+            "extractor",
+            str(pdf_path),
+            "--out-md-dir",
+            str(root / "md"),
+            "--out-image-dir",
+            str(root / "images"),
+            "--stem",
+            "sample",
+            "--add-heading",
+            str(heading_json),
+        ]
+        with patch.object(sys, "argv", argv), patch("extractor.__main__.extract_pdf_to_outputs") as mock_extract:
+            cli_main()
+
+        self.assertEqual(heading_json, mock_extract.call_args.kwargs["add_heading"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -48,6 +48,21 @@ def _build_flow_diagram_pdf(pdf_path: Path) -> tuple[str, tuple[str, ...]]:
     return outside_text, hidden_text
 
 
+def _build_heading_pdf(pdf_path: Path) -> tuple[str, str]:
+    title = "Sized Heading Title"
+    paragraph = "This paragraph should remain normal body text."
+
+    c = canvas.Canvas(str(pdf_path), pagesize=letter)
+    c.setFont("Helvetica-Bold", 20)
+    c.drawString(72, 700, title)
+    c.setFont("Helvetica", 11)
+    c.drawString(72, 672, paragraph)
+    c.drawString(72, 656, "Continuation line for the body paragraph.")
+    c.save()
+
+    return title, paragraph
+
+
 class PipelineExtractionTests(unittest.TestCase):
     def _build_pdf(self) -> Path:
         tmp = tempfile.TemporaryDirectory()
@@ -209,6 +224,39 @@ class PipelineExtractionTests(unittest.TestCase):
         drawing_images = [Path(path) for path in result["image_files"] if "_drawing_" in Path(path).name]
         self.assertEqual(1, len(drawing_images))
         self.assertTrue(drawing_images[0].exists())
+
+    def test_add_heading_uses_external_font_size_mapping_for_markdown(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        pdf_path = root / "heading.pdf"
+        title, paragraph = _build_heading_pdf(pdf_path)
+        heading_json = root / "heading.json"
+        heading_json.write_text(
+            json.dumps(
+                {
+                    "heading_rules": [
+                        {
+                            "match": {"font_size": 20.0},
+                            "assign": {"tag": "h1"},
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = extract_pdf_to_outputs(
+            pdf_path=pdf_path,
+            out_md_dir=root / "md",
+            out_image_dir=root / "images",
+            stem="heading",
+            add_heading=heading_json,
+        )
+
+        self.assertIn(f"# {title}", result["markdown"])
+        self.assertIn(paragraph, result["markdown"])
+        self.assertNotIn(f"# {paragraph}", result["markdown"])
 
     def test_spanning_stage_table_merges_into_one_block(self) -> None:
         markdown = self._extract_table_markdown()

--- a/graph_pdf/tests/test_raw.py
+++ b/graph_pdf/tests/test_raw.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from extractor.__main__ import main as cli_main
+from extractor.pipeline import extract_pdf_to_outputs
+from sample_generator import create_demo_pdf
+
+
+class RawDumpTests(unittest.TestCase):
+    def _build_pdf(self) -> tuple[Path, Path]:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        pdf_path = root / "sample.pdf"
+        create_demo_pdf(pdf_path)
+        return root, pdf_path
+
+    def test_dump_pdf_to_raw_file_writes_document_base64_and_page_payloads(self) -> None:
+        from extractor.raw import dump_pdf_to_raw_file
+
+        root, pdf_path = self._build_pdf()
+        raw_path = root / "sample.raw.dump"
+
+        dump_pdf_to_raw_file(pdf_path=pdf_path, raw_path=raw_path, pages=[1, 2])
+
+        payload = json.loads(raw_path.read_text(encoding="utf-8"))
+        self.assertEqual("1.0", payload["schema_version"])
+        self.assertEqual(str(pdf_path), payload["source_pdf"])
+        self.assertEqual([1, 2], payload["selected_pages"])
+        self.assertTrue(payload["document_pdf_base64"])
+        self.assertEqual(2, len(payload["pages"]))
+        self.assertIn("chars", payload["pages"][0]["objects"])
+        self.assertIn("lines", payload["pages"][0]["objects"])
+        self.assertIn("rects", payload["pages"][0]["objects"])
+        self.assertIn("curves", payload["pages"][0]["objects"])
+        self.assertIn("images", payload["pages"][0]["objects"])
+        self.assertIn("content_stream_base64", payload["pages"][0])
+        self.assertIn("resources", payload["pages"][0])
+
+    def test_extract_pdf_to_outputs_from_raw_matches_pdf_text_outputs(self) -> None:
+        from extractor.raw import dump_pdf_to_raw_file
+
+        root, pdf_path = self._build_pdf()
+        raw_path = root / "sample.raw.dump"
+        dump_pdf_to_raw_file(pdf_path=pdf_path, raw_path=raw_path)
+
+        pdf_result = extract_pdf_to_outputs(
+            pdf_path=pdf_path,
+            out_md_dir=root / "pdf_md",
+            out_image_dir=root / "pdf_images",
+            stem="pdf_sample",
+        )
+        raw_result = extract_pdf_to_outputs(
+            pdf_path=pdf_path,
+            out_md_dir=root / "raw_md",
+            out_image_dir=root / "raw_images",
+            stem="raw_sample",
+            from_raw=raw_path,
+        )
+
+        self.assertEqual(pdf_result["markdown"], raw_result["markdown"])
+        self.assertEqual(pdf_result["table_markdown"], raw_result["table_markdown"])
+        self.assertEqual(len(pdf_result["image_files"]), len(raw_result["image_files"]))
+
+    def test_cli_raw_and_from_raw_options_work_end_to_end(self) -> None:
+        root, pdf_path = self._build_pdf()
+        raw_path = root / "sample.raw.dump"
+
+        export_argv = [
+            "extractor",
+            str(pdf_path),
+            "--raw",
+            str(raw_path),
+            "--pages",
+            "1-2",
+        ]
+        with patch.object(sys, "argv", export_argv):
+            cli_main()
+
+        self.assertTrue(raw_path.exists())
+
+        import_argv = [
+            "extractor",
+            str(pdf_path),
+            "--from-raw",
+            str(raw_path),
+            "--out-md-dir",
+            str(root / "md"),
+            "--out-image-dir",
+            str(root / "images"),
+            "--stem",
+            "sample",
+        ]
+        with patch.object(sys, "argv", import_argv):
+            cli_main()
+
+        self.assertTrue((root / "md" / "sample.md").exists())
+        self.assertTrue((root / "md" / "sample_summary.json").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/graph_pdf/tests/test_text.py
+++ b/graph_pdf/tests/test_text.py
@@ -8,6 +8,7 @@ from extractor.shared import _parse_pages_spec
 from extractor.text import (
     _build_body_blocks,
     _detect_body_bounds,
+    _extract_body_text_lines,
     _extract_body_word_lines,
     _extract_drawing_image_bboxes,
     _is_gray_color,
@@ -59,6 +60,25 @@ class TextModuleTests(unittest.TestCase):
             ["This line introduces the uncommon term", "ProtoLexeme expands into explanation"],
             [line["text"] for line in blocks[1]["lines"]],
         )
+
+    def test_extract_body_text_lines_applies_font_size_heading_map_and_leaves_unmapped_sizes_as_paragraph(self) -> None:
+        page = SimpleNamespace()
+        line_payloads = [
+            {"text": "Sized Title", "top": 90.0, "bottom": 102.0, "dominant_font_size": 20.0, "size": 20.0},
+            {"text": "Body line", "top": 120.0, "bottom": 132.0, "dominant_font_size": 11.0, "size": 11.0},
+            {"text": "continues here", "top": 134.0, "bottom": 146.0, "dominant_font_size": 11.0, "size": 11.0},
+        ]
+
+        with patch("extractor.text._extract_body_word_lines", return_value=line_payloads):
+            raw_lines, normalized_lines = _extract_body_text_lines(
+                page=page,
+                header_margin=90.0,
+                footer_margin=40.0,
+                heading_levels={20.0: 1},
+            )
+
+        self.assertEqual(["Sized Title", "Body line", "continues here"], raw_lines)
+        self.assertEqual(["# Sized Title", "Body line continues here"], normalized_lines)
 
     def test_extract_body_word_lines_marks_marker_candidate_and_text_start(self) -> None:
         filtered_page = SimpleNamespace(


### PR DESCRIPTION
## Summary
- add `--raw` and `--from-raw` support so PDFs can be dumped to a reusable raw fixture file and later re-run through the existing extraction pipeline
- add `--add-heading` font-size heading mapping support and document the new options in the README
- add raw export/import regression tests and keep heading-related tests covered

## Validation
- python3 -m unittest discover -s tests -p 'test_*.py'

## Notes
- raw dump stores document PDF bytes as base64 plus per-page content stream, resources, embedded image payloads, and parsed page objects
- `--from-raw` can be used without a positional `pdf_path`
