### PR TITLE
Add raw dump import/export support and document new CLI options

### DIFF
--- a/graph_pdf/extractor/raw.py
+++ b/graph_pdf/extractor/raw.py
@@ -37,6 +37,8 @@ def _serialize_pdf_object(
     seen = seen or set()
     if depth > max_depth:
         return {"type": "max_depth"}
+    if isinstance(value, BooleanObject):
+        return bool(value)
     if value is None or isinstance(value, (bool, int, float, str, BooleanObject, FloatObject, NumberObject, NameObject, TextStringObject)):
         if isinstance(value, (FloatObject, NumberObject)):
             return float(value)

--- a/graph_pdf/tests/test_raw.py
+++ b/graph_pdf/tests/test_raw.py
@@ -7,6 +7,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from pypdf.generic import BooleanObject
+
 from extractor.__main__ import main as cli_main
 from extractor.pipeline import extract_pdf_to_outputs
 from sample_generator import create_demo_pdf
@@ -42,6 +44,15 @@ class RawDumpTests(unittest.TestCase):
         self.assertIn("images", payload["pages"][0]["objects"])
         self.assertIn("content_stream_base64", payload["pages"][0])
         self.assertIn("resources", payload["pages"][0])
+
+    def test_serialize_pdf_object_converts_boolean_object_to_plain_bool(self) -> None:
+        from extractor.raw import _serialize_pdf_object
+
+        payload = {"flag": _serialize_pdf_object(BooleanObject(True))}
+
+        encoded = json.dumps(payload)
+
+        self.assertEqual('{"flag": true}', encoded)
 
     def test_extract_pdf_to_outputs_from_raw_matches_pdf_text_outputs(self) -> None:
         from extractor.raw import dump_pdf_to_raw_file


### PR DESCRIPTION
## Summary
- add `--raw` and `--from-raw` support so PDFs can be dumped to a reusable raw fixture file and later re-run through the existing extraction pipeline
- add `--add-heading` font-size heading mapping support and document the new options in the README
- add raw export/import regression tests and keep heading-related tests covered

## Validation
- python3 -m unittest discover -s tests -p 'test_*.py'

## Notes
- raw dump stores document PDF bytes as base64 plus per-page content stream, resources, embedded image payloads, and parsed page objects
- `--from-raw` can be used without a positional `pdf_path`