### PR TITLE
Add body markdown table references

### DIFF
--- a/graph_pdf/README.md
+++ b/graph_pdf/README.md
@@ -78,7 +78,7 @@ python3 -m extractor sample.pdf \
   --add-heading fixtures/font_heading_profile.sample.json
 ```
 
-샘플 heading JSON은 `fixtures/font_heading_profile.sample.json`에 있습니다. 현재는 `heading_rules[].match.font_size`와 `assign.tag` 또는 `assign.markdown_prefix`만 사용하며, 매칭되지 않는 font size는 일반 문단으로 유지됩니다.
+샘플 heading JSON은 `fixtures/font_heading_profile.sample.json`에 있습니다. 구조는 `heading_rules[].match.font_size`와 `heading_rules[].assign.tag`/`heading_rules[].assign.markdown_prefix`만 남긴 최소 형태이며, 매칭되지 않는 font size는 일반 문단으로 유지됩니다.
 
 문서 전체를 raw dump로 저장하려면 `--raw`를 사용합니다.
 
@@ -133,7 +133,7 @@ python3 -m extractor \
 - `sample_generator.py`: 본문, 표, 워터마크, 이미지가 포함된 테스트용 샘플 PDF 생성기
 - `sample_fixture.py`: 샘플 PDF 검증용 fixture 로더
 - `fixtures/demo_document.json`: 샘플 문서의 기대 본문/표 데이터 fixture
-- `fixtures/font_heading_profile.sample.json`: `--add-heading`용 font size 기반 heading 규칙 샘플
+- `fixtures/font_heading_profile.sample.json`: `--add-heading`용 최소 heading 규칙 샘플
 - `extractor/__init__.py`: 외부에서 사용하는 공개 진입점 export
 - `extractor/__main__.py`: CLI 실행용 entrypoint
 - `extractor/font_profile.py`: body text 기준 `font_size + font_color` 프로파일 생성과 JSON/CSV 기록
@@ -179,7 +179,7 @@ python3 -m extractor \
 5. `--from-raw`가 주어지면 raw dump의 문서 PDF base64를 임시 PDF로 복원한 뒤 같은 파이프라인을 재사용합니다.
 6. `extractor.tables._extract_tables(...)`가 현재 페이지의 표 후보를 찾고 행 데이터를 정규화합니다.
 7. `extractor.text._extract_body_text(...)`가 전체 body text를 구합니다.
-8. `--add-heading`이 있으면 외부 JSON의 `font_size -> heading level` 규칙으로 markdown heading prefix를 추가합니다.
+8. `--add-heading`이 있으면 외부 JSON의 `heading_rules[].match.font_size -> assign.tag/assign.markdown_prefix` 규칙으로 markdown heading prefix를 추가합니다.
 9. 표 bbox를 제외한 body text를 다시 계산해 최종 본문 markdown에 사용합니다.
 10. 표가 있으면 이전 페이지의 pending table과 이어붙일 수 있는지 검사합니다.
 11. 이어붙일 수 있으면 pending table을 확장하고, 아니면 이전 pending table을 flush한 뒤 현재 표를 새 pending 상태로 둡니다.

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -46,8 +46,6 @@ def _load_heading_levels(add_heading: Path | None) -> dict[float, int] | None:
     payload = json.loads(Path(add_heading).read_text(encoding="utf-8"))
     heading_levels: dict[float, int] = {}
     for rule in payload.get("heading_rules", []):
-        if not bool(rule.get("enabled", True)):
-            continue
         match = rule.get("match") or {}
         if "font_size" not in match:
             continue
@@ -108,6 +106,10 @@ def _body_excluded_bboxes(
     return excluded
 
 
+def _table_reference_text(page_no: int, table_no: int) -> str:
+    return f"[Table reference: Page {page_no} table {table_no}]"
+
+
 def extract_pdf_to_outputs(
     pdf_path: Path | None,
     out_md_dir: Path,
@@ -155,18 +157,21 @@ def extract_pdf_to_outputs(
     pending_page: Optional[int] = None
     pending_last_page: Optional[int] = None
     pending_bbox: Optional[Tuple[float, float, float, float]] = None
+    pending_table_no: Optional[int] = None
     pending_axes: List[float] = []
     pending_gap_text_boxes: List[Tuple[float, float, float, float]] = []
+    next_table_no = 1
 
     def _flush_pending() -> None:
         # Tables are emitted only after we know the next page will not extend them.
-        nonlocal pending_table, pending_page, pending_last_page, pending_bbox, pending_axes, pending_gap_text_boxes
-        if pending_table is not None and pending_page is not None:
-            _append_output_table(output_tables, pending_page, len(output_tables) + 1, pending_table)
+        nonlocal pending_table, pending_page, pending_last_page, pending_bbox, pending_table_no, pending_axes, pending_gap_text_boxes
+        if pending_table is not None and pending_page is not None and pending_table_no is not None:
+            _append_output_table(output_tables, pending_page, pending_table_no, pending_table)
         pending_table = None
         pending_page = None
         pending_last_page = None
         pending_bbox = None
+        pending_table_no = None
         pending_axes = []
         pending_gap_text_boxes = []
 
@@ -195,23 +200,26 @@ def extract_pdf_to_outputs(
             )
             drawing_regions_by_page[page_idx] = image_regions
             full_page_text = _extract_body_text(page, header_margin=header_margin, footer_margin=footer_margin)
-            # Body text for the final page output excludes table areas so prose does not duplicate table content.
-            page_text = _extract_body_text(
-                page,
-                header_margin=header_margin,
-                footer_margin=footer_margin,
-                excluded_bboxes=_body_excluded_bboxes(
-                    pending_table=pending_table,
-                    tables=tables,
-                    image_regions=image_regions,
-                    body_top=footer_margin,
-                ),
-                heading_levels=heading_levels,
+            page_pending_table = pending_table
+            page_excluded_bboxes = _body_excluded_bboxes(
+                pending_table=page_pending_table,
+                tables=tables,
+                image_regions=image_regions,
+                body_top=footer_margin,
             )
-            if page_text.strip():
-                output_text.append(f"### Page {page_idx}\n{page_text}")
+            page_table_references: List[dict] = []
 
             if not tables:
+                page_text = _extract_body_text(
+                    page,
+                    header_margin=header_margin,
+                    footer_margin=footer_margin,
+                    excluded_bboxes=page_excluded_bboxes,
+                    reference_lines=page_table_references,
+                    heading_levels=heading_levels,
+                )
+                if page_text.strip():
+                    output_text.append(f"### Page {page_idx}\n{page_text}")
                 continue
 
             body_top, body_bottom = _detect_body_bounds(page, header_margin=header_margin, footer_margin=footer_margin)
@@ -231,6 +239,13 @@ def extract_pdf_to_outputs(
                         full_page_text,
                     )
                 if merged_missing_first is not None:
+                    if pending_page is not None and pending_table_no is not None:
+                        page_table_references.append(
+                            {
+                                "text": _table_reference_text(pending_page, pending_table_no),
+                                "bbox": bbox,
+                            }
+                        )
                     pending_table = merged_missing_first
                     pending_last_page = page_idx
                     pending_bbox = bbox
@@ -243,6 +258,13 @@ def extract_pdf_to_outputs(
                     # Repeated headers should not be duplicated when the next page is clearly part of the same table.
                     continuation_rows = _split_repeated_header(pending_table or [], table_rows)
                     if pending_table is not None and _is_continuation_chunk(pending_table, continuation_rows):
+                        if pending_page is not None and pending_table_no is not None:
+                            page_table_references.append(
+                                {
+                                    "text": _table_reference_text(pending_page, pending_table_no),
+                                    "bbox": bbox,
+                                }
+                            )
                         pending_table.extend(continuation_rows)
                         pending_last_page = page_idx
                         if pending_bbox is not None:
@@ -275,6 +297,13 @@ def extract_pdf_to_outputs(
                         gap_text_boxes=[*pending_gap_text_boxes, *current_gap_text_boxes],
                     )
                 ):
+                    if pending_page is not None and pending_table_no is not None:
+                        page_table_references.append(
+                            {
+                                "text": _table_reference_text(pending_page, pending_table_no),
+                                "bbox": bbox,
+                            }
+                        )
                     pending_table.extend(continuation_rows)
                     pending_last_page = page_idx
                     pending_bbox = (
@@ -289,12 +318,39 @@ def extract_pdf_to_outputs(
 
                 # Once continuation checks fail, the previous pending table is finalized and a new table starts.
                 _flush_pending()
+                current_table_no = next_table_no
+                next_table_no += 1
+                page_table_references.append(
+                    {
+                        "text": _table_reference_text(page_idx, current_table_no),
+                        "bbox": bbox,
+                    }
+                )
                 pending_table = table_rows
                 pending_page = page_idx
                 pending_last_page = page_idx
                 pending_bbox = bbox
+                pending_table_no = current_table_no
                 pending_axes = current_axes
                 pending_gap_text_boxes = _gap_text_boxes_after_bbox(page, bbox, table_bboxes, header_margin=header_margin, footer_margin=footer_margin)
+
+            effective_table_bboxes = page_excluded_bboxes[: len(tables)]
+            page_text = _extract_body_text(
+                page,
+                header_margin=header_margin,
+                footer_margin=footer_margin,
+                excluded_bboxes=page_excluded_bboxes,
+                reference_lines=[
+                    {
+                        "text": entry["text"],
+                        "bbox": effective_bbox,
+                    }
+                    for entry, effective_bbox in zip(page_table_references, effective_table_bboxes)
+                ],
+                heading_levels=heading_levels,
+            )
+            if page_text.strip():
+                output_text.append(f"### Page {page_idx}\n{page_text}")
 
         _flush_pending()
 

--- a/graph_pdf/extractor/text.py
+++ b/graph_pdf/extractor/text.py
@@ -389,6 +389,7 @@ def _extract_body_text(
     header_margin: float,
     footer_margin: float,
     excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
+    reference_lines: Sequence[dict] = (),
     heading_levels: dict[float, int] | None = None,
 ) -> str:
     # Most callers want page text as joined logical lines rather than raw line payloads.
@@ -397,6 +398,7 @@ def _extract_body_text(
         header_margin=header_margin,
         footer_margin=footer_margin,
         excluded_bboxes=excluded_bboxes,
+        reference_lines=reference_lines,
         heading_levels=heading_levels,
     )
     return "\n".join(normalized_lines)
@@ -407,6 +409,7 @@ def _extract_body_text_lines(
     header_margin: float,
     footer_margin: float,
     excluded_bboxes: Sequence[Tuple[float, float, float, float]] = (),
+    reference_lines: Sequence[dict] = (),
     heading_levels: dict[float, int] | None = None,
 ) -> Tuple[List[str], List[str]]:
     # Return both the raw visual lines and the normalized logical lines for debug and downstream reuse.
@@ -416,12 +419,16 @@ def _extract_body_text_lines(
         footer_margin=footer_margin,
         excluded_bboxes=excluded_bboxes,
     )
-    raw_lines = [str(line["text"]) for line in line_payloads]
-    blocks = _build_body_blocks(line_payloads, heading_levels=heading_levels)
+    output_lines = _merge_reference_lines(line_payloads, reference_lines)
+    raw_lines = [str(line["text"]) for line in output_lines]
+    blocks = _build_body_blocks(output_lines, heading_levels=heading_levels)
 
     normalized_lines: List[str] = []
     for block in blocks:
         block_lines = [str(line["text"]) for line in block["lines"]]
+        if block["kind"] == "reference":
+            normalized_lines.extend(line for line in block_lines if line.strip())
+            continue
         if block["kind"] == "heading":
             if heading_levels is None:
                 normalized_lines.extend(block_lines)
@@ -494,6 +501,9 @@ def _line_heading_level(line: dict, heading_levels: dict[float, int] | None = No
 
 def _line_kind(line: dict, heading_levels: dict[float, int] | None = None) -> str:
     # The current body flow distinguishes only headings and paragraphs.
+    explicit_kind = str(line.get("line_kind") or "").strip().lower()
+    if explicit_kind in {"reference", "heading", "paragraph"}:
+        return explicit_kind
     if heading_levels is not None:
         return "heading" if _line_heading_level(line, heading_levels) is not None else "paragraph"
     if _is_body_heading_line(str(line.get("text") or "").strip()):
@@ -533,6 +543,49 @@ def _build_body_blocks(lines: Sequence[dict], heading_levels: dict[float, int] |
     if current_block is not None:
         blocks.append(current_block)
     return blocks
+
+
+def _reference_line_payload(entry: dict) -> dict | None:
+    text = str(entry.get("text") or "").strip()
+    bbox = entry.get("bbox")
+    if not text or not isinstance(bbox, (list, tuple)) or len(bbox) != 4:
+        return None
+
+    x0, top, x1, bottom = (float(value) for value in bbox)
+    return {
+        "text": text,
+        "x0": x0,
+        "x1": x1,
+        "top": top,
+        "bottom": bottom,
+        "size": 0.0,
+        "fontname": "",
+        "fontnames": [],
+        "dominant_font_size": 0.0,
+        "font_size_candidates": [],
+        "color": None,
+        "is_bold": False,
+        "is_italic": False,
+        "marker_candidate": False,
+        "text_start_x": x0,
+        "first_word_width": 0.0,
+        "body_right": x1,
+        "word_count": 1,
+        "has_mixed_styles": False,
+        "first_word_style_signature": None,
+        "is_shape_text": False,
+        "line_kind": "reference",
+    }
+
+
+def _merge_reference_lines(lines: Sequence[dict], reference_lines: Sequence[dict]) -> List[dict]:
+    merged = list(lines)
+    for entry in reference_lines:
+        payload = _reference_line_payload(entry)
+        if payload is not None:
+            merged.append(payload)
+    merged.sort(key=lambda line: (float(line.get("top", 0.0)), float(line.get("x0", 0.0)), float(line.get("bottom", 0.0))))
+    return merged
 
 
 def _extract_body_word_lines(

--- a/graph_pdf/fixtures/font_heading_profile.sample.json
+++ b/graph_pdf/fixtures/font_heading_profile.sample.json
@@ -1,174 +1,31 @@
 {
-  "schema_version": "1.0",
-  "description": "Sample dynamic mapping from font profile styles to markdown heading tags.",
-  "profile_source": {
-    "pdf": "sample.pdf",
-    "font_profile_json": "artifacts/manual/md/sample_font_profile.json",
-    "grouping_key": [
-      "font_size"
-    ],
-    "generated_at": "2026-03-24T00:00:00+09:00"
-  },
-  "defaults": {
-    "body_tag": null,
-    "emit_unmapped_as_paragraph": true,
-    "unknown_profile_action": "keep_text"
-  },
   "heading_rules": [
     {
-      "rule_id": "title-black-20",
-      "enabled": true,
-      "priority": 100,
       "match": {
         "font_size": 20.0
       },
       "assign": {
         "tag": "h1",
-        "markdown_prefix": "# ",
-        "semantic_role": "document_title"
-      },
-      "notes": "Main chapter title style."
+        "markdown_prefix": "# "
+      }
     },
     {
-      "rule_id": "section-black-16",
-      "enabled": true,
-      "priority": 90,
       "match": {
         "font_size": 16.0
       },
       "assign": {
         "tag": "h2",
-        "markdown_prefix": "## ",
-        "semantic_role": "section_heading"
-      },
-      "notes": "Section heading style."
+        "markdown_prefix": "## "
+      }
     },
     {
-      "rule_id": "subsection-black-13",
-      "enabled": true,
-      "priority": 80,
       "match": {
         "font_size": 13.0
       },
       "assign": {
         "tag": "h3",
-        "markdown_prefix": "### ",
-        "semantic_role": "subsection_heading"
-      },
-      "notes": "Subsection heading style."
-    }
-  ],
-  "fallback_rules": [
-    {
-      "rule_id": "fallback-h1",
-      "enabled": true,
-      "priority": 50,
-      "match": {
-        "min_font_size": 18.0
-      },
-      "assign": {
-        "tag": "h1",
-        "markdown_prefix": "# ",
-        "semantic_role": "large_heading"
+        "markdown_prefix": "### "
       }
-    },
-    {
-      "rule_id": "fallback-h2",
-      "enabled": true,
-      "priority": 40,
-      "match": {
-        "min_font_size": 15.0,
-        "max_font_size": 17.99
-      },
-      "assign": {
-        "tag": "h2",
-        "markdown_prefix": "## ",
-        "semantic_role": "medium_heading"
-      }
-    },
-    {
-      "rule_id": "fallback-h3",
-      "enabled": true,
-      "priority": 30,
-      "match": {
-        "min_font_size": 12.0,
-        "max_font_size": 14.99
-      },
-      "assign": {
-        "tag": "h3",
-        "markdown_prefix": "### ",
-        "semantic_role": "small_heading"
-      }
-    }
-  ],
-  "profiles": [
-    {
-      "profile_id": "20.00",
-      "font_size": 20.0,
-      "line_count": 1,
-      "page_count": 1,
-      "sample_page": 1,
-      "sample_texts": [
-        "Chapter 1: Deep Structure Verification"
-      ],
-      "assigned_tag": "h1",
-      "assignment_source": "exact_rule",
-      "matched_rule_id": "title-black-20"
-    },
-    {
-      "profile_id": "16.00",
-      "font_size": 16.0,
-      "line_count": 4,
-      "page_count": 2,
-      "sample_page": 1,
-      "sample_texts": [
-        "Overview",
-        "Data Sources"
-      ],
-      "assigned_tag": "h2",
-      "assignment_source": "exact_rule",
-      "matched_rule_id": "section-black-16"
-    },
-    {
-      "profile_id": "13.00",
-      "font_size": 13.0,
-      "line_count": 7,
-      "page_count": 3,
-      "sample_page": 2,
-      "sample_texts": [
-        "Normalization Notes",
-        "Fallback Logic"
-      ],
-      "assigned_tag": "h3",
-      "assignment_source": "exact_rule",
-      "matched_rule_id": "subsection-black-13"
-    },
-    {
-      "profile_id": "11.00",
-      "font_size": 11.0,
-      "line_count": 128,
-      "page_count": 5,
-      "sample_page": 1,
-      "sample_texts": [
-        "This paragraph remains body text.",
-        "The extractor keeps this as normal prose."
-      ],
-      "assigned_tag": null,
-      "assignment_source": "default_body",
-      "matched_rule_id": null
-    },
-    {
-      "profile_id": "11.00-accent",
-      "font_size": 11.0,
-      "line_count": 9,
-      "page_count": 2,
-      "sample_page": 1,
-      "sample_texts": [
-        "Blue accent line marks a separate style bucket for font profile review."
-      ],
-      "assigned_tag": null,
-      "assignment_source": "default_body",
-      "matched_rule_id": null
     }
   ]
 }

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -168,6 +168,16 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertEqual(2, result["summary"]["table_count"])
         self.assertEqual(1, len(result["image_files"]))
 
+    def test_markdown_includes_table_references_for_detected_tables(self) -> None:
+        markdown = self._extract_result()["markdown"]
+
+        self.assertIn("[Table reference: Page 1 table 1]", markdown)
+        self.assertEqual(3, markdown.count("[Table reference: Page 1 table 2]"))
+        self.assertIn("[Table reference: Page 3 table 3]", markdown)
+        self.assertIn("[Table reference: Page 4 table 4]", markdown)
+        self.assertIn("### Page 2", markdown)
+        self.assertIn("### Page 4", markdown)
+
     def test_extract_embedded_images_respects_selected_pages(self) -> None:
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)


### PR DESCRIPTION
## Summary
- add in-flow table reference lines to body markdown so table positions remain visible even when table text is excluded
- keep spanning tables mapped to the same reference id across continuation pages
- simplify the sample `--add-heading` JSON/README examples to the minimal `font_size -> heading` rule shape

## Validation
- python3 -m unittest discover -s tests -p 'test_*.py'

## Notes
- previous PR #236 is already merged, so this branch was rebased to contain only the new work on top of current `main`
- the markdown reference format is `[Table reference: Page N table M]`