### PR TITLE
Minimize raw dump output to base64-only payload

### DIFF
--- a/graph_pdf/README.md
+++ b/graph_pdf/README.md
@@ -45,7 +45,7 @@ python3 extractor/__main__.py sample.pdf \
 - `--debug-watermark`: 회전 문자 디버그 JSON 생성
 - `--profile-fonts`: body text 기준 `font_size + font_color` 조합 프로파일 JSON/CSV 생성
 - `--add-heading <path>`: 외부 JSON의 `font_size -> h1~h6` 규칙으로 body markdown heading 추가
-- `--raw <path>`: 선택 페이지 기준 원본 PDF raw dump 파일 생성
+- `--raw <path>`: 선택 페이지 기준 문서 PDF base64만 저장하는 최소 raw dump 생성
 - `--from-raw <path>`: raw dump 파일을 입력으로 읽어 기존 추출 파이프라인 실행
 
 ### 직접 실행 예시
@@ -87,7 +87,7 @@ python3 -m extractor sample.pdf \
   --raw artifacts/manual/raw/sample.raw.dump
 ```
 
-raw dump에는 문서 PDF 자체의 base64와 함께 페이지별 `content stream`, `resources`, `embedded images`, `chars`, `lines`, `rects`, `curves`, `images`, `horizontal_edges`, `vertical_edges`, `words`가 포함됩니다.
+raw dump에는 문서 PDF 바이트를 `document_pdf_base64`로 저장한 최소 payload(`schema_version`, `document_pdf_base64`)만 포함됩니다.
 
 PDF 대신 raw dump를 입력으로 재실행하려면 `--from-raw`를 사용합니다. 이 경우 positional `pdf_path` 없이 실행할 수 있습니다.
 

--- a/graph_pdf/extractor/raw.py
+++ b/graph_pdf/extractor/raw.py
@@ -6,121 +6,12 @@ import tempfile
 from contextlib import contextmanager
 from io import BytesIO
 from pathlib import Path
-from typing import Iterator, Optional, Sequence
+from typing import Iterator, Sequence
 
-import pdfplumber
 from pypdf import PdfReader, PdfWriter
-from pypdf.generic import ArrayObject, BooleanObject, ByteStringObject, DictionaryObject, FloatObject, IndirectObject, NameObject, NullObject, NumberObject, StreamObject, TextStringObject
 
 
-def _object_to_json_safe(value: object) -> object:
-    if value is None or isinstance(value, (bool, int, float, str)):
-        return value
-    if isinstance(value, bytes):
-        return {"type": "bytes", "base64": base64.b64encode(value).decode("ascii")}
-    if isinstance(value, tuple):
-        return [_object_to_json_safe(item) for item in value]
-    if isinstance(value, list):
-        return [_object_to_json_safe(item) for item in value]
-    if isinstance(value, dict):
-        return {str(key): _object_to_json_safe(item) for key, item in value.items()}
-    return str(value)
-
-
-def _serialize_pdf_object(
-    value: object,
-    *,
-    seen: set[tuple[int, int]] | None = None,
-    depth: int = 0,
-    max_depth: int = 16,
-) -> object:
-    seen = seen or set()
-    if depth > max_depth:
-        return {"type": "max_depth"}
-    if isinstance(value, BooleanObject):
-        return bool(value)
-    if value is None or isinstance(value, (bool, int, float, str, BooleanObject, FloatObject, NumberObject, NameObject, TextStringObject)):
-        if isinstance(value, (FloatObject, NumberObject)):
-            return float(value)
-        return str(value) if isinstance(value, NameObject) else value
-    if isinstance(value, NullObject):
-        return None
-    if isinstance(value, ByteStringObject):
-        return {"type": "bytes", "base64": base64.b64encode(bytes(value)).decode("ascii")}
-    if isinstance(value, IndirectObject):
-        ref = (int(value.idnum), int(value.generation))
-        if ref in seen:
-            return {"type": "indirect_ref", "idnum": ref[0], "generation": ref[1]}
-        seen.add(ref)
-        return {
-            "type": "indirect",
-            "idnum": ref[0],
-            "generation": ref[1],
-            "value": _serialize_pdf_object(value.get_object(), seen=seen, depth=depth + 1, max_depth=max_depth),
-        }
-    if isinstance(value, StreamObject):
-        return {
-            "type": "stream",
-            "dict": {
-                str(key): _serialize_pdf_object(item, seen=seen, depth=depth + 1, max_depth=max_depth)
-                for key, item in value.items()
-            },
-            "data_base64": base64.b64encode(value.get_data()).decode("ascii"),
-        }
-    if isinstance(value, DictionaryObject):
-        return {
-            str(key): _serialize_pdf_object(item, seen=seen, depth=depth + 1, max_depth=max_depth)
-            for key, item in value.items()
-        }
-    if isinstance(value, ArrayObject):
-        return [_serialize_pdf_object(item, seen=seen, depth=depth + 1, max_depth=max_depth) for item in value]
-    if isinstance(value, (list, tuple)):
-        return [_serialize_pdf_object(item, seen=seen, depth=depth + 1, max_depth=max_depth) for item in value]
-    if isinstance(value, bytes):
-        return {"type": "bytes", "base64": base64.b64encode(value).decode("ascii")}
-    return str(value)
-
-
-def _page_content_stream_base64(reader_page) -> str:
-    contents = reader_page.get_contents()
-    if contents is None:
-        return ""
-    if hasattr(contents, "get_data"):
-        return base64.b64encode(contents.get_data()).decode("ascii")
-    return ""
-
-
-def _page_embedded_images(reader_page) -> list[dict]:
-    payload: list[dict] = []
-    for image_file in getattr(reader_page, "images", []):
-        payload.append(
-            {
-                "name": str(getattr(image_file, "name", "") or ""),
-                "data_base64": base64.b64encode(bytes(getattr(image_file, "data", b""))).decode("ascii"),
-            }
-        )
-    return payload
-
-
-def _page_object_dump(plumber_page: "pdfplumber.page.Page") -> dict:
-    return {
-        "chars": _object_to_json_safe(list(getattr(plumber_page, "chars", []) or [])),
-        "lines": _object_to_json_safe(list(getattr(plumber_page, "lines", []) or [])),
-        "rects": _object_to_json_safe(list(getattr(plumber_page, "rects", []) or [])),
-        "curves": _object_to_json_safe(list(getattr(plumber_page, "curves", []) or [])),
-        "images": _object_to_json_safe(list(getattr(plumber_page, "images", []) or [])),
-        "horizontal_edges": _object_to_json_safe(list(getattr(plumber_page, "horizontal_edges", []) or [])),
-        "vertical_edges": _object_to_json_safe(list(getattr(plumber_page, "vertical_edges", []) or [])),
-        "words": _object_to_json_safe(
-            plumber_page.extract_words(
-                x_tolerance=1.5,
-                y_tolerance=2.0,
-                keep_blank_chars=False,
-                extra_attrs=["size", "fontname"],
-            )
-            or []
-        ),
-    }
+RAW_SCHEMA_VERSION = "1.1"
 
 
 def _subset_pdf_bytes(pdf_path: Path, page_numbers: Sequence[int]) -> bytes:
@@ -133,50 +24,28 @@ def _subset_pdf_bytes(pdf_path: Path, page_numbers: Sequence[int]) -> bytes:
     return buffer.getvalue()
 
 
+def _normalize_selected_pages(total_pages: int, pages: Sequence[int] | None) -> list[int]:
+    selected_pages = [int(page_no) for page_no in (pages or [])]
+    if not selected_pages:
+        return list(range(1, total_pages + 1))
+    return selected_pages
+
+
 def dump_pdf_to_raw_file(
     pdf_path: Path,
     raw_path: Path,
-    pages: Optional[Sequence[int]] = None,
+    pages: Sequence[int] | None = None,
 ) -> Path:
-    selected_pages = [int(page_no) for page_no in (pages or [])]
-    with pdfplumber.open(str(pdf_path)) as plumber_pdf:
-        total_pages = len(plumber_pdf.pages)
-        if not selected_pages:
-            selected_pages = list(range(1, total_pages + 1))
-
+    reader = PdfReader(str(pdf_path))
+    selected_pages = _normalize_selected_pages(len(reader.pages), pages)
     subset_pdf = _subset_pdf_bytes(pdf_path, selected_pages)
-    reader = PdfReader(BytesIO(subset_pdf))
-    page_payloads: list[dict] = []
-    with pdfplumber.open(BytesIO(subset_pdf)) as plumber_pdf:
-        for raw_index, (reader_page, plumber_page) in enumerate(zip(reader.pages, plumber_pdf.pages), start=1):
-            original_page_no = selected_pages[raw_index - 1]
-            page_payloads.append(
-                {
-                    "raw_page_number": raw_index,
-                    "source_page_number": original_page_no,
-                    "width": float(plumber_page.width),
-                    "height": float(plumber_page.height),
-                    "rotation": int(reader_page.get("/Rotate", 0) or 0),
-                    "mediabox": [float(value) for value in reader_page.mediabox],
-                    "cropbox": [float(value) for value in reader_page.cropbox],
-                    "content_stream_base64": _page_content_stream_base64(reader_page),
-                    "resources": _serialize_pdf_object(reader_page.get("/Resources")),
-                    "embedded_images": _page_embedded_images(reader_page),
-                    "objects": _page_object_dump(plumber_page),
-                }
-            )
 
     payload = {
-        "schema_version": "1.0",
-        "source_pdf": str(pdf_path),
-        "source_name": pdf_path.name,
-        "selected_pages": selected_pages,
-        "page_count": len(page_payloads),
+        "schema_version": RAW_SCHEMA_VERSION,
         "document_pdf_base64": base64.b64encode(subset_pdf).decode("ascii"),
-        "pages": page_payloads,
     }
     raw_path.parent.mkdir(parents=True, exist_ok=True)
-    raw_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    raw_path.write_text(json.dumps(payload, ensure_ascii=False, separators=(",", ":")), encoding="utf-8")
     return raw_path
 
 
@@ -187,7 +56,11 @@ def load_raw_payload(raw_path: Path) -> dict:
 @contextmanager
 def materialize_raw_dump(raw_path: Path) -> Iterator[tuple[Path, dict]]:
     payload = load_raw_payload(raw_path)
-    pdf_bytes = base64.b64decode(str(payload.get("document_pdf_base64") or ""))
+    raw_base64 = payload.get("document_pdf_base64")
+    if not isinstance(raw_base64, str) or not raw_base64:
+        raise ValueError("raw dump is missing required document_pdf_base64")
+
+    pdf_bytes = base64.b64decode(raw_base64)
     with tempfile.TemporaryDirectory() as tmpdir:
         pdf_name = Path(str(payload.get("source_name") or "raw_document.pdf")).with_suffix(".pdf").name
         materialized_path = Path(tmpdir) / pdf_name

--- a/graph_pdf/tests/test_raw.py
+++ b/graph_pdf/tests/test_raw.py
@@ -7,8 +7,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from pypdf.generic import BooleanObject
-
 from extractor.__main__ import main as cli_main
 from extractor.pipeline import extract_pdf_to_outputs
 from sample_generator import create_demo_pdf
@@ -23,7 +21,7 @@ class RawDumpTests(unittest.TestCase):
         create_demo_pdf(pdf_path)
         return root, pdf_path
 
-    def test_dump_pdf_to_raw_file_writes_document_base64_and_page_payloads(self) -> None:
+    def test_dump_pdf_to_raw_file_writes_minimal_payload(self) -> None:
         from extractor.raw import dump_pdf_to_raw_file
 
         root, pdf_path = self._build_pdf()
@@ -32,27 +30,9 @@ class RawDumpTests(unittest.TestCase):
         dump_pdf_to_raw_file(pdf_path=pdf_path, raw_path=raw_path, pages=[1, 2])
 
         payload = json.loads(raw_path.read_text(encoding="utf-8"))
-        self.assertEqual("1.0", payload["schema_version"])
-        self.assertEqual(str(pdf_path), payload["source_pdf"])
-        self.assertEqual([1, 2], payload["selected_pages"])
+        self.assertEqual("1.1", payload["schema_version"])
         self.assertTrue(payload["document_pdf_base64"])
-        self.assertEqual(2, len(payload["pages"]))
-        self.assertIn("chars", payload["pages"][0]["objects"])
-        self.assertIn("lines", payload["pages"][0]["objects"])
-        self.assertIn("rects", payload["pages"][0]["objects"])
-        self.assertIn("curves", payload["pages"][0]["objects"])
-        self.assertIn("images", payload["pages"][0]["objects"])
-        self.assertIn("content_stream_base64", payload["pages"][0])
-        self.assertIn("resources", payload["pages"][0])
-
-    def test_serialize_pdf_object_converts_boolean_object_to_plain_bool(self) -> None:
-        from extractor.raw import _serialize_pdf_object
-
-        payload = {"flag": _serialize_pdf_object(BooleanObject(True))}
-
-        encoded = json.dumps(payload)
-
-        self.assertEqual('{"flag": true}', encoded)
+        self.assertEqual(2, len(payload))
 
     def test_extract_pdf_to_outputs_from_raw_matches_pdf_text_outputs(self) -> None:
         from extractor.raw import dump_pdf_to_raw_file


### PR DESCRIPTION
## Summary
- Simplify raw dump output schema to include only base64 document payload.
- Keep `--from-raw` compatibility by materializing PDF only from `document_pdf_base64`.
- Update tests and README to match minimal raw format.

## Files changed
- extractor/raw.py
- tests/test_raw.py
- README.md