### PR TITLE
feat: route single-column table-like notes to body text

### DIFF
--- a/graph_pdf/extractor/images.py
+++ b/graph_pdf/extractor/images.py
@@ -13,6 +13,132 @@ from .shared import _bboxes_intersect, _char_rotation_degrees
 from .text import _detect_body_bounds, _is_non_watermark_obj, _selected_drawing_image_groups
 
 
+def _normalize_pdf_image_name(image_name: object) -> str:
+    return Path(str(image_name or "")).name
+
+
+def _normalize_pdf_image_stem(image_name: object) -> str:
+    normalized = _normalize_pdf_image_name(image_name)
+    lower = normalized.lower()
+    for suffix in (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tif", ".tiff"):
+        if lower.endswith(suffix):
+            return normalized[: -len(suffix)]
+    return normalized
+
+
+def _image_ref_bbox(image_meta: dict) -> Tuple[float, float, float, float] | None:
+    if not image_meta:
+        return None
+    x0 = image_meta.get("x0")
+    top = image_meta.get("top")
+    x1 = image_meta.get("x1")
+    bottom = image_meta.get("bottom")
+    if x0 is None or top is None or x1 is None or bottom is None:
+        return None
+    try:
+        return float(x0), float(top), float(x1), float(bottom)
+    except (TypeError, ValueError):
+        return None
+
+
+def _match_embedded_image_by_name(
+    image_name: str,
+    image_stem: str,
+    candidates: Sequence[object],
+) -> dict | None:
+    for candidate in candidates:
+        candidate_name = _normalize_pdf_image_name(
+            candidate.get("name") if isinstance(candidate, dict) else getattr(candidate, "name", "")
+        )
+        candidate_stem = _normalize_pdf_image_stem(candidate_name)
+        if candidate_name == image_name or candidate_stem == image_stem:
+            if isinstance(candidate, dict):
+                return dict(candidate)
+            return {
+                "name": str(getattr(candidate, "name", image_name)),
+                "data": getattr(candidate, "data", None),
+            }
+    return None
+
+
+def _collect_embedded_image_refs(
+    pdf_path: Path,
+    pages: Optional[Sequence[int]] = None,
+    header_margin: float = 90.0,
+    footer_margin: float = 40.0,
+) -> dict[int, list[dict]]:
+    # Shared helper for content-flow reference generation and image extraction.
+    selected_pages = set(int(page_no) for page_no in (pages or []))
+    refs_by_page: dict[int, list[dict]] = {}
+
+    reader = PdfReader(str(pdf_path))
+    with pdfplumber.open(str(pdf_path)) as plumber_pdf:
+        for page_idx, (page, plumber_page) in enumerate(zip(reader.pages, plumber_pdf.pages), start=1):
+            if selected_pages and page_idx not in selected_pages:
+                continue
+
+            body_top, body_bottom = _detect_body_bounds(
+                plumber_page,
+                header_margin=header_margin,
+                footer_margin=footer_margin,
+            )
+            plumber_images = [
+                image
+                for image in getattr(plumber_page, "images", [])
+                if _image_intersects_body(image, body_top=body_top, body_bottom=body_bottom)
+            ]
+            if not plumber_images:
+                continue
+
+            allowed_names = {
+                _normalize_pdf_image_name(image.get("name"))
+                for image in plumber_images
+                if str(image.get("name") or "").strip()
+            }
+            allowed_stems = {_normalize_pdf_image_stem(name) for name in allowed_names}
+
+            entries: list[dict] = []
+            image_entries = []
+            for image_file in page.images:
+                image_name = _normalize_pdf_image_name(getattr(image_file, "name", None))
+                image_stem = _normalize_pdf_image_stem(image_name)
+                if not image_name:
+                    continue
+                if image_stem not in allowed_stems and image_name not in allowed_names:
+                    continue
+
+                matched = _match_embedded_image_by_name(image_name, image_stem, plumber_images)
+                if matched is None:
+                    continue
+                bbox = _image_ref_bbox(matched)
+                if bbox is None:
+                    continue
+
+                image_entries.append(
+                    {
+                        "name": image_name,
+                        "name_stem": image_stem,
+                        "suffix": Path(image_name).suffix or ".bin",
+                        "bbox": bbox,
+                        "pdf_name": str(getattr(image_file, "name", "")),
+                    }
+                )
+
+            # Stable order matches page rendering order and keeps index assignment deterministic.
+            image_entries = sorted(
+                image_entries,
+                key=lambda entry: (float(entry["bbox"][1]), float(entry["bbox"][0])),
+            )
+            for index, entry in enumerate(image_entries, start=1):
+                copied = dict(entry)
+                copied["index"] = index
+                entries.append(copied)
+            if entries:
+                refs_by_page[page_idx] = entries
+
+    return refs_by_page
+
+
 def _crop_page_region(
     page_image: "pdfplumber.display.PageImage",
     page_height: float,
@@ -307,6 +433,7 @@ def _extract_embedded_images(
     stem: str,
     pages: Optional[Sequence[int]] = None,
     drawing_regions_by_page: Optional[dict[int, Sequence[Tuple[float, float, float, float]]]] = None,
+    image_refs_by_page: Optional[dict[int, Sequence[dict]]] = None,
 ) -> List[Path]:
     # Image extraction is intentionally independent from table/text extraction so it can be reused or debugged separately.
     out_image_dir.mkdir(parents=True, exist_ok=True)
@@ -334,17 +461,35 @@ def _extract_embedded_images(
             }
 
             kept_idx = 0
-            for image_file in page.images:
-                # pypdf and pdfplumber expose image identifiers slightly differently, so compare both forms.
-                image_name = Path(image_file.name or "").name
-                image_stem = Path(image_name).stem
-                if image_stem not in allowed_names and image_name not in allowed_names:
-                    continue
-                kept_idx += 1
-                suffix = Path(image_name).suffix or ".bin"
-                out_path = out_image_dir / f"{stem}_page_{page_idx:02d}_image_{kept_idx:02d}{suffix}"
-                out_path.write_bytes(image_file.data)
-                image_files.append(out_path)
+            if image_refs_by_page is None:
+                for image_file in page.images:
+                    # pypdf and pdfplumber expose image identifiers slightly differently, so compare both forms.
+                    image_name = _normalize_pdf_image_name(image_file.name or "")
+                    image_stem = _normalize_pdf_image_stem(image_name)
+                    if image_stem not in allowed_names and image_name not in allowed_names:
+                        continue
+                    kept_idx += 1
+                    suffix = Path(image_name).suffix or ".bin"
+                    out_path = out_image_dir / f"{stem}_page_{page_idx:02d}_image_{kept_idx:02d}{suffix}"
+                    out_path.write_bytes(image_file.data)
+                    image_files.append(out_path)
+            else:
+                for image_ref in image_refs_by_page.get(page_idx, []):
+                    image_name = str(image_ref.get("name") or "")
+                    image_stem = str(image_ref.get("name_stem") or _normalize_pdf_image_stem(image_name))
+                    if image_stem not in allowed_names and image_name not in allowed_names:
+                        continue
+                    kept_idx += 1
+                    suffix = str(image_ref.get("suffix") or Path(image_name).suffix or ".bin")
+                    out_path = out_image_dir / f"{stem}_page_{page_idx:02d}_image_{kept_idx:02d}{suffix}"
+                    image_payload = _match_embedded_image_by_name(image_name, image_stem, page.images)
+                    if image_payload is None:
+                        continue
+                    image_data = image_payload.get("data")
+                    if image_data is None:
+                        continue
+                    out_path.write_bytes(image_data)
+                    image_files.append(out_path)
 
             drawing_image_idx = 0
             for region in drawing_regions_by_page.get(page_idx, []):

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -17,9 +17,11 @@ from .tables import (
     _extract_tables,
     _gap_text_boxes_after_bbox,
     _gap_text_boxes_before_bbox,
+    _looks_like_single_column_note,
     _maybe_merge_missing_first_column_chunk,
     _is_continuation_chunk,
     _should_try_table_continuation_merge,
+    _single_column_note_body_text,
     _split_repeated_header,
     _vertical_axes_for_bbox,
 )
@@ -254,13 +256,41 @@ def extract_pdf_to_outputs(
             if debug_watermark:
                 rotated_debug.extend(_collect_rotated_text_debug(page, page_no=page_idx))
 
-            tables = _extract_tables(page, force_table=force_table)
+            detected_tables = _extract_tables(page, force_table=force_table)
+            tables: List[Tuple[TableRows, Tuple[float, float, float, float]]] = []
+            note_references: List[dict] = []
+            detected_table_payloads: List[dict] = []
+            for table_rows, bbox in detected_tables:
+                row_count = len(table_rows)
+                col_count = max((len(row) for row in table_rows), default=0)
+                is_note = _looks_like_single_column_note(
+                    rows=table_rows,
+                    page=page,
+                    bbox=bbox,
+                )
+                detected_table_payloads.append(
+                    {
+                        "kind": "note" if is_note else "table",
+                        "bbox": [round(float(value), 2) for value in bbox],
+                        "row_count": int(row_count),
+                        "col_count": int(col_count),
+                    }
+                )
+                if is_note:
+                    note_text = _single_column_note_body_text(table_rows)
+                    if note_text:
+                        note_references.append({"text": note_text, "bbox": bbox})
+                    continue
+                tables.append((table_rows, bbox))
+            if debug and table_debug_pages:
+                table_debug_pages[-1]["detected_tables"] = detected_table_payloads
+
             body_top, body_bottom = _detect_body_bounds(page, header_margin=header_margin, footer_margin=footer_margin)
             image_regions = _extract_drawing_image_bboxes(
                 page=page,
                 header_margin=header_margin,
                 footer_margin=footer_margin,
-                excluded_bboxes=[bbox for _rows, bbox in tables],
+                excluded_bboxes=[bbox for _rows, bbox in detected_tables],
             )
             drawing_regions_by_page[page_idx] = image_regions
             embedded_image_refs = embedded_image_refs_by_page.get(page_idx, [])
@@ -280,6 +310,7 @@ def extract_pdf_to_outputs(
                 ],
                 body_top=footer_margin,
             )
+            page_excluded_bboxes.extend([bbox for _rows, bbox in detected_tables])
             page_table_references: List[dict] = []
             page_content_references: List[dict] = []
 
@@ -323,6 +354,7 @@ def extract_pdf_to_outputs(
                     footer_margin=footer_margin,
                     excluded_bboxes=page_excluded_bboxes,
                     reference_lines=page_table_references
+                    + note_references
                     + [
                         {
                             "text": entry["text"],
@@ -447,7 +479,7 @@ def extract_pdf_to_outputs(
                 pending_axes = current_axes
                 pending_gap_text_boxes = _gap_text_boxes_after_bbox(page, bbox, table_bboxes, header_margin=header_margin, footer_margin=footer_margin)
 
-            effective_table_bboxes = page_excluded_bboxes[: len(tables)]
+            effective_table_bboxes = [bbox for _rows, bbox in tables]
             for image_idx, entry in enumerate(embedded_image_refs, start=1):
                 bbox_obj = entry.get("bbox") if isinstance(entry, dict) else None
                 if not bbox_obj or len(bbox_obj) != 4:
@@ -502,7 +534,8 @@ def extract_pdf_to_outputs(
                     }
                     for entry in page_content_references
                     if isinstance(entry.get("bbox"), tuple)
-                ]),
+                ])
+                + note_references,
                 heading_levels=heading_levels,
             )
             if page_text.strip():

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Sequence, Tuple
 import pdfplumber
 
 from .debug import _collect_page_edge_debug, _collect_rotated_text_debug, _collect_table_drawing_debug
-from .images import _extract_embedded_images
+from .images import _collect_embedded_image_refs, _extract_embedded_images
 from .raw import materialize_raw_dump
 from .shared import TableRows, _merge_numeric_positions
 from .tables import (
@@ -106,6 +106,50 @@ def _body_excluded_bboxes(
     return excluded
 
 
+def _content_ref_text(content_type: str, page_no: int, index: int, continued: bool = False) -> str:
+    label = f"[{content_type} reference: Page {page_no} {content_type.lower()} {index}]"
+    if continued:
+        label += " (continued)"
+    return label
+
+
+def _should_continue_content_region(
+    prev_bbox: Tuple[float, float, float, float],
+    curr_bbox: Tuple[float, float, float, float],
+    _prev_body_top: float,
+    prev_body_bottom: float,
+    curr_body_top: float,
+    min_x_overlap_ratio: float = 0.35,
+    edge_tolerance: float = 24.0,
+) -> bool:
+    prev_x0, _prev_top, prev_x1, prev_bottom = prev_bbox
+    curr_x0, curr_top, curr_x1, _curr_bottom = curr_bbox
+    if abs(prev_bottom - prev_body_bottom) > edge_tolerance:
+        return False
+    if abs(curr_top - curr_body_top) > edge_tolerance:
+        return False
+
+    overlap = min(prev_x1, curr_x1) - max(prev_x0, curr_x0)
+    if overlap <= 0:
+        return False
+
+    prev_width = max(0.0, prev_x1 - prev_x0)
+    curr_width = max(0.0, curr_x1 - curr_x0)
+    if prev_width <= 0.0 or curr_width <= 0.0:
+        return False
+    return overlap / min(prev_width, curr_width) >= min_x_overlap_ratio
+
+
+def _is_edge_candidate_for_continuation(
+    bbox: Tuple[float, float, float, float],
+    body_top: float,
+    body_bottom: float,
+    edge_tolerance: float = 24.0,
+) -> bool:
+    _x0, _top, _x1, bottom = bbox
+    return abs(bottom - body_bottom) <= edge_tolerance
+
+
 def _table_reference_text(page_no: int, table_no: int) -> str:
     return f"[Table reference: Page {page_no} table {table_no}]"
 
@@ -161,6 +205,19 @@ def extract_pdf_to_outputs(
     pending_axes: List[float] = []
     pending_gap_text_boxes: List[Tuple[float, float, float, float]] = []
     next_table_no = 1
+    pending_image_ref_bbox: Optional[Tuple[float, float, float, float]] = None
+    pending_image_body_top: Optional[float] = None
+    pending_image_body_bottom: Optional[float] = None
+    pending_drawing_ref_bbox: Optional[Tuple[float, float, float, float]] = None
+    pending_drawing_body_top: Optional[float] = None
+    pending_drawing_body_bottom: Optional[float] = None
+
+    embedded_image_refs_by_page = _collect_embedded_image_refs(
+        pdf_path=pdf_path,
+        pages=pages,
+        header_margin=header_margin,
+        footer_margin=footer_margin,
+    )
 
     def _flush_pending() -> None:
         # Tables are emitted only after we know the next page will not extend them.
@@ -179,6 +236,12 @@ def extract_pdf_to_outputs(
         for page_idx, page in enumerate(pdf.pages, start=1):
             if selected_pages and page_idx not in selected_pages:
                 _flush_pending()
+                pending_image_ref_bbox = None
+                pending_image_body_top = None
+                pending_image_body_bottom = None
+                pending_drawing_ref_bbox = None
+                pending_drawing_body_top = None
+                pending_drawing_body_bottom = None
                 continue
 
             if debug:
@@ -192,6 +255,7 @@ def extract_pdf_to_outputs(
                 rotated_debug.extend(_collect_rotated_text_debug(page, page_no=page_idx))
 
             tables = _extract_tables(page, force_table=force_table)
+            body_top, body_bottom = _detect_body_bounds(page, header_margin=header_margin, footer_margin=footer_margin)
             image_regions = _extract_drawing_image_bboxes(
                 page=page,
                 header_margin=header_margin,
@@ -199,30 +263,79 @@ def extract_pdf_to_outputs(
                 excluded_bboxes=[bbox for _rows, bbox in tables],
             )
             drawing_regions_by_page[page_idx] = image_regions
+            embedded_image_refs = embedded_image_refs_by_page.get(page_idx, [])
+            embedded_image_regions = [
+                tuple(entry.get("bbox", ()))
+                for entry in embedded_image_refs
+                if isinstance(entry, dict) and len(entry.get("bbox", ())) == 4
+            ]
             full_page_text = _extract_body_text(page, header_margin=header_margin, footer_margin=footer_margin)
             page_pending_table = pending_table
             page_excluded_bboxes = _body_excluded_bboxes(
                 pending_table=page_pending_table,
                 tables=tables,
-                image_regions=image_regions,
+                image_regions=[
+                    *image_regions,
+                    *embedded_image_regions,
+                ],
                 body_top=footer_margin,
             )
             page_table_references: List[dict] = []
+            page_content_references: List[dict] = []
 
             if not tables:
+                for image_idx, entry in enumerate(embedded_image_refs, start=1):
+                    bbox_obj = entry.get("bbox") if isinstance(entry, dict) else None
+                    if not bbox_obj or len(bbox_obj) != 4:
+                        continue
+                    bbox = tuple(bbox_obj)
+                    is_cont = False
+                    if (
+                        pending_image_ref_bbox is not None
+                        and pending_image_body_top is not None
+                        and pending_image_body_bottom is not None
+                    ):
+                        is_cont = _should_continue_content_region(
+                            prev_bbox=pending_image_ref_bbox,
+                            curr_bbox=bbox,
+                            prev_body_top=pending_image_body_top,
+                            prev_body_bottom=pending_image_body_bottom,
+                            curr_body_top=body_top,
+                        )
+                    page_content_references.append(
+                        {
+                            "text": _content_ref_text("Image", page_idx, image_idx, continued=is_cont),
+                            "bbox": bbox,
+                        }
+                    )
+                    if _is_edge_candidate_for_continuation(bbox=bbox, body_top=body_top, body_bottom=body_bottom):
+                        pending_image_ref_bbox = bbox
+                        pending_image_body_top = body_top
+                        pending_image_body_bottom = body_bottom
+                    else:
+                        pending_image_ref_bbox = None
+                        pending_image_body_top = None
+                        pending_image_body_bottom = None
+
                 page_text = _extract_body_text(
                     page,
                     header_margin=header_margin,
                     footer_margin=footer_margin,
                     excluded_bboxes=page_excluded_bboxes,
-                    reference_lines=page_table_references,
+                    reference_lines=page_table_references
+                    + [
+                        {
+                            "text": entry["text"],
+                            "bbox": entry["bbox"],
+                        }
+                        for entry in page_content_references
+                    ],
                     heading_levels=heading_levels,
                 )
                 if page_text.strip():
                     output_text.append(f"### Page {page_idx}\n{page_text}")
                 continue
 
-            body_top, body_bottom = _detect_body_bounds(page, header_margin=header_margin, footer_margin=footer_margin)
             table_bboxes = [table_bbox for _table_rows, table_bbox in tables]
             for table_rows, bbox in tables:
                 cross_page_continuation = _should_try_table_continuation_merge(
@@ -335,6 +448,41 @@ def extract_pdf_to_outputs(
                 pending_gap_text_boxes = _gap_text_boxes_after_bbox(page, bbox, table_bboxes, header_margin=header_margin, footer_margin=footer_margin)
 
             effective_table_bboxes = page_excluded_bboxes[: len(tables)]
+            for image_idx, entry in enumerate(embedded_image_refs, start=1):
+                bbox_obj = entry.get("bbox") if isinstance(entry, dict) else None
+                if not bbox_obj or len(bbox_obj) != 4:
+                    continue
+                bbox = tuple(bbox_obj)
+                is_cont = False
+                if (
+                    pending_image_ref_bbox is not None
+                    and pending_image_body_top is not None
+                    and pending_image_body_bottom is not None
+                ):
+                    is_cont = _should_continue_content_region(
+                        prev_bbox=pending_image_ref_bbox,
+                        curr_bbox=bbox,
+                        prev_body_top=pending_image_body_top,
+                        prev_body_bottom=pending_image_body_bottom,
+                        curr_body_top=body_top,
+                    )
+
+                page_content_references.append(
+                    {
+                        "text": _content_ref_text("Image", page_idx, image_idx, continued=is_cont),
+                        "bbox": bbox,
+                    }
+                )
+
+                if _is_edge_candidate_for_continuation(bbox=bbox, body_top=body_top, body_bottom=body_bottom):
+                    pending_image_ref_bbox = bbox
+                    pending_image_body_top = body_top
+                    pending_image_body_bottom = body_bottom
+                else:
+                    pending_image_ref_bbox = None
+                    pending_image_body_top = None
+                    pending_image_body_bottom = None
+
             page_text = _extract_body_text(
                 page,
                 header_margin=header_margin,
@@ -346,7 +494,15 @@ def extract_pdf_to_outputs(
                         "bbox": effective_bbox,
                     }
                     for entry, effective_bbox in zip(page_table_references, effective_table_bboxes)
-                ],
+                ] 
+                + ([
+                    {
+                        "text": entry["text"],
+                        "bbox": entry["bbox"],
+                    }
+                    for entry in page_content_references
+                    if isinstance(entry.get("bbox"), tuple)
+                ]),
                 heading_levels=heading_levels,
             )
             if page_text.strip():
@@ -371,6 +527,7 @@ def extract_pdf_to_outputs(
         stem=stem,
         pages=pages,
         drawing_regions_by_page=drawing_regions_by_page,
+        image_refs_by_page=embedded_image_refs_by_page,
     )
 
     summary = {

--- a/graph_pdf/extractor/tables.py
+++ b/graph_pdf/extractor/tables.py
@@ -30,26 +30,23 @@ def _merge_cells(table: Sequence[Sequence[str]]) -> List[List[str]]:
 
 
 def _collapse_structural_triplet_columns(table: Sequence[Sequence[str]]) -> List[List[str]]:
-    # Some sample tables use [blank, value, blank] triples to simulate merged columns; collapse only those empty side columns.
+    # Remove vertically empty columns that are likely structural artifacts from extraction.
     rows = [list(row) for row in table]
     if not rows:
         return []
 
     col_count = max((len(row) for row in rows), default=0)
-    if col_count == 0 or col_count % 3 != 0:
-        return [list(row) for row in rows]
-
     padded_rows = [list(row) + [""] * (col_count - len(row)) for row in rows]
-    collapsed_indices: List[int] = []
-    for start in range(0, col_count, 3):
-        left_values = [_normalize_text(row[start]) for row in padded_rows]
-        right_values = [_normalize_text(row[start + 2]) for row in padded_rows]
-        if any(left_values) or any(right_values):
-            collapsed_indices.extend([start, start + 1, start + 2])
-            continue
-        collapsed_indices.append(start + 1)
+    kept_indices = [
+        idx
+        for idx in range(col_count)
+        if any(_normalize_text(str(padded_rows[row_idx][idx]).strip()) for row_idx in range(len(padded_rows)))
+    ]
 
-    return [[row[idx] for idx in collapsed_indices] for row in padded_rows]
+    if not kept_indices:
+        return [[] for _ in padded_rows]
+
+    return [[row[idx] for idx in kept_indices] for row in padded_rows]
 
 
 def _normalize_extracted_table(table: Sequence[Sequence[str]]) -> List[List[str]]:
@@ -60,7 +57,7 @@ def _normalize_extracted_table(table: Sequence[Sequence[str]]) -> List[List[str]
         for cell in row:
             normalized_row.append("\n".join(_normalize_cell_lines(str(cell or ""))))
         normalized.append(normalized_row)
-    return _collapse_structural_triplet_columns(normalized)
+    return normalized
 
 
 def _table_rejection_reason(table: Sequence[Sequence[str]]) -> str | None:
@@ -823,6 +820,8 @@ def _merge_split_rows(rows: TableRows) -> TableRows:
 
 def _append_output_table(output_tables: List[str], page_no: int, table_no: int, table_rows: TableRows) -> None:
     # Table numbering is derived at append time so merged cross-page tables keep one output block.
-    table_text = _table_text_from_rows(_merge_split_rows(table_rows))
+    merged_rows = _merge_split_rows(table_rows)
+    collapsed_rows = _collapse_structural_triplet_columns(merged_rows)
+    table_text = _table_text_from_rows(collapsed_rows)
     if table_text:
         output_tables.append(f"### Page {page_no} table {table_no}\n{table_text}")

--- a/graph_pdf/extractor/tables.py
+++ b/graph_pdf/extractor/tables.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import List, Optional, Sequence, Tuple
+from typing import Any, List, Optional, Sequence, Tuple
 
 import pdfplumber
 
@@ -93,6 +93,380 @@ def _looks_like_header_row(row: Sequence[str]) -> bool:
     alpha_like = sum(1 for token in tokens if re.fullmatch(r"[A-Za-z][A-Za-z0-9\s/&._:-]*", token))
     short = sum(1 for token in tokens if len(token) <= 24)
     return alpha_like >= len(tokens) * 0.8 and short >= len(tokens) * 0.8
+
+
+def _effective_non_empty_column_indices(
+    rows: Sequence[Sequence[str]],
+) -> list[int]:
+    # Ignore empty cells introduced by renderer artifacts when deciding if a region is really one-column.
+    column_indexes: set[int] = set()
+    for row in rows:
+        if not row:
+            continue
+        for idx, value in enumerate(row):
+            if _normalize_text(value):
+                column_indexes.add(idx)
+    return sorted(column_indexes)
+
+
+def _is_single_column_like_rows(rows: Sequence[Sequence[str]]) -> bool:
+    return len(_effective_non_empty_column_indices(rows)) <= 1
+
+
+def _extract_region_words(
+    page: pdfplumber.page.PageObject,
+    bbox: Tuple[float, float, float, float],
+) -> list[dict[str, Any]]:
+    # Region words are used to infer text flow independent of table cell extraction.
+    filtered_page = _filter_page_for_extraction(page)
+    x0, top, x1, bottom = bbox
+    words = (
+        filtered_page
+        .crop((x0, top, x1, bottom))
+        .extract_words(x_tolerance=1.5, y_tolerance=2.0, keep_blank_chars=False)
+        or []
+    )
+
+    normalized: list[dict[str, Any]] = []
+    for word in words:
+        text = _repair_watermark_bleed(_normalize_text(str(word.get("text") or "")))
+        if not text or _is_layout_artifact(text):
+            continue
+        normalized.append({
+            "text": text,
+            "x0": float(word.get("x0", 0.0)),
+            "x1": float(word.get("x1", 0.0)),
+            "top": float(word.get("top", 0.0)),
+            "bottom": float(word.get("bottom", 0.0)),
+        })
+    return normalized
+
+
+def _extract_region_lines(words: Sequence[dict[str, Any]], y_tolerance: float = 2.5) -> list[list[dict[str, Any]]]:
+    lines: list[list[dict[str, Any]]] = []
+    for word in sorted(words, key=lambda item: (float(item["top"]), float(item["x0"]))):
+        if not lines or abs(float(word["top"]) - float(lines[-1][0]["top"])) > y_tolerance:
+            lines.append([word])
+            continue
+        lines[-1].append(word)
+    return lines
+
+
+def _extract_region_line_rows(
+    page: pdfplumber.page.PageObject,
+    bbox: Tuple[float, float, float, float],
+) -> list[list[str]]:
+    lines = _extract_region_lines(_extract_region_words(page, bbox))
+    rows: list[list[str]] = []
+    for words_in_line in lines:
+        text = _line_text_from_words(words_in_line)
+        if not text:
+            continue
+        rows.append([text])
+    return rows
+
+
+def _compact_fallback_rows(rows: list[list[str]]) -> list[list[str]]:
+    compacted: list[list[str]] = []
+    for row in rows:
+        normalized = _line_text_from_words([{"text": _normalize_text(cell)} for cell in row]).strip()
+        if not normalized:
+            continue
+        if compacted and compacted[-1] == [normalized]:
+            continue
+        compacted.append([normalized])
+    return compacted
+
+
+def _line_text_from_words(words_in_line: Sequence[dict[str, Any]]) -> str:
+    return " ".join(str(word.get("text") or "").strip() for word in sorted(words_in_line, key=lambda item: float(item["x0"]))).strip()
+
+
+def _first_non_empty_cell_value(row: Sequence[str]) -> str:
+    for value in row:
+        normalized = _normalize_text(value)
+        if normalized:
+            return normalized
+    return ""
+
+
+def _rect_fill_color_key(rect: dict[str, Any]) -> tuple[Any, ...] | int | float | None:
+    color = rect.get("non_stroking_color")
+    if color is None:
+        color = rect.get("stroking_color")
+    if color is None:
+        return None
+    if isinstance(color, (int, float)):
+        return round(float(color), 3)
+    if isinstance(color, (list, tuple)):
+        return tuple(round(float(value), 3) for value in color[:3])
+    return None
+
+
+def _normalize_color_match(left: object, right: object, tolerance: float = 0.02) -> bool:
+    if left is None and right is None:
+        return True
+    if isinstance(left, (int, float)) and isinstance(right, (int, float)):
+        return abs(float(left) - float(right)) <= tolerance
+    if isinstance(left, tuple) and isinstance(right, tuple):
+        if len(left) != len(right):
+            return False
+        return all(abs(float(l) - float(r)) <= tolerance for l, r in zip(left, right))
+    return False
+
+
+def _internal_grid_counts(
+    page: pdfplumber.page.PageObject,
+    bbox: Tuple[float, float, float, float],
+) -> tuple[int, int]:
+    # Internal stroke edges are a strong table shape signal compared with prose boxes.
+    x0, y0, x1, y1 = bbox
+    width = max(0.0, x1 - x0)
+    height = max(0.0, y1 - y0)
+    if width <= 0.0 or height <= 0.0:
+        return (0, 0)
+
+    internal_vertical = 0
+    for edge in getattr(page, "vertical_edges", []):
+        if not bool(edge.get("stroke")):
+            continue
+        edge_x0 = float(edge.get("x0", 0.0))
+        edge_top = float(edge.get("top", 0.0))
+        edge_bottom = float(edge.get("bottom", 0.0))
+        if edge_top > y1 or edge_bottom < y0:
+            continue
+        if edge_x0 <= x0 + 2.0 or edge_x0 >= x1 - 2.0:
+            continue
+        if edge_bottom - edge_top >= height * 0.35:
+            internal_vertical += 1
+
+    internal_horizontal = 0
+    for edge in getattr(page, "horizontal_edges", []):
+        if not bool(edge.get("stroke")):
+            continue
+        edge_top = float(edge.get("top", 0.0))
+        edge_x0 = float(edge.get("x0", 0.0))
+        edge_x1 = float(edge.get("x1", 0.0))
+        if edge_top <= y0 + 2.0 or edge_top >= y1 - 2.0:
+            continue
+        edge_length = edge_x1 - edge_x0
+        if edge_length >= width * 0.35 and edge_x0 < x1 and edge_x1 > x0:
+            internal_horizontal += 1
+
+    return internal_vertical, internal_horizontal
+
+
+def _estimate_region_kind(
+    table_rows: Sequence[Sequence[str]],
+    region_words: Sequence[dict[str, Any]],
+    internal_grid: tuple[int, int],
+    *,
+    min_long_line_words: int = 6,
+    min_total_chars: int = 80,
+) -> tuple[str, dict[str, Any]]:
+    # Return "table" or "note" with lightweight, explainable signals.
+    is_single_column_like = _is_single_column_like_rows(table_rows)
+    row_count = len(table_rows)
+    col_count = max((len(row) for row in table_rows), default=0)
+    if col_count <= 0 or not region_words:
+        return "table", {"reason": "empty_content"}
+
+    text_lines = [_normalize_text(_line_text_from_words(words)) for words in _extract_region_lines(region_words)]
+    text_lines = [line for line in text_lines if line]
+    if not text_lines:
+        return "table", {"reason": "empty_lines"}
+
+    line_word_counts = [len(line.split()) for line in text_lines]
+    line_char_counts = [len(line) for line in text_lines]
+    avg_words = sum(line_word_counts) / len(line_word_counts)
+    max_words = max(line_word_counts)
+    max_chars = max(line_char_counts)
+    total_chars = sum(line_char_counts)
+    long_lines = sum(1 for count in line_word_counts if count >= min_long_line_words)
+    punctuation_ratio = sum(1 for line in text_lines if any(ch in line for ch in [".", ",", ";", ":", "(", ")"])) / len(text_lines)
+    internal_vertical, internal_horizontal = internal_grid
+    table_score = 0.0
+    note_score = 0.0
+
+    # Note routing is intentionally single-column-first; key-value tables with structural blanks stay table.
+    if not is_single_column_like:
+        return "table", {
+            "reason": "not_single_column_like",
+            "col_count": col_count,
+            "effective_col_count": len(_effective_non_empty_column_indices(table_rows)),
+        }
+
+    # Structured short rows indicate key/value style tables or metadata blocks.
+    if row_count <= 3 and max(line_word_counts) <= 4 and total_chars < min_total_chars:
+        table_score += 2.0
+    if max_words <= 4 and long_lines == 0:
+        table_score += 1.0
+    if internal_vertical + internal_horizontal >= 2:
+        table_score += 2.0
+    if punctuation_ratio >= 0.2 and total_chars <= min_total_chars:
+        table_score += 1.0
+
+    # Prose-like dense lines indicate note-style single-column content.
+    if row_count >= 2 and (avg_words >= 5 or max_chars >= 90 or total_chars >= min_total_chars):
+        note_score += 2.0
+    if long_lines >= 2:
+        note_score += 2.0
+    if avg_words >= 7 and total_chars >= min_total_chars:
+        note_score += 1.0
+
+    if note_score > table_score:
+        return "note", {
+            "reason": "prose_score",
+            "note_score": note_score,
+            "table_score": table_score,
+            "avg_words": avg_words,
+            "max_words": max_words,
+            "line_count": len(text_lines),
+            "total_chars": total_chars,
+        }
+    return "table", {
+        "reason": "table_score",
+        "note_score": note_score,
+        "table_score": table_score,
+        "avg_words": avg_words,
+        "max_words": max_words,
+        "line_count": len(text_lines),
+        "total_chars": total_chars,
+    }
+
+
+def _classify_single_column_region(
+    table_rows: Sequence[Sequence[str]],
+    page: Optional[pdfplumber.page.PageObject] = None,
+    bbox: Optional[Tuple[float, float, float, float]] = None,
+) -> tuple[str, dict[str, Any]]:
+    # Public wrapper used by both table filtering and debug reporting.
+    col_count = max((len(row) for row in table_rows), default=0)
+    if not _is_single_column_like_rows(table_rows):
+        effective_cols = _effective_non_empty_column_indices(table_rows)
+        return "table", {
+            "reason": "not_single_column_like",
+            "col_count": col_count,
+            "effective_col_count": len(effective_cols),
+        }
+    if not page or not bbox:
+        return _classify_single_column_rows_only(table_rows)
+
+    region_words = _extract_region_words(page=page, bbox=bbox)
+    internal_grid = _internal_grid_counts(page=page, bbox=bbox)
+    return _estimate_region_kind(
+        table_rows=table_rows,
+        region_words=region_words,
+        internal_grid=internal_grid,
+    )
+
+
+def _classify_single_column_rows_only(
+    rows: Sequence[Sequence[str]],
+) -> tuple[str, dict[str, Any]]:
+    # Geometry-independent fallback for tests and call-sites that only have cells.
+    if not rows:
+        return "table", {"reason": "empty_row_region"}
+    effective_col_count = len(_effective_non_empty_column_indices(rows))
+    if effective_col_count != 1:
+        return "table", {"reason": "not_single_column_like", "effective_col_count": effective_col_count}
+    normalized_lines = []
+    for row in rows:
+        line = ""
+        for cell in row:
+            value = _normalize_text(cell)
+            if value:
+                line = value
+                break
+        if line:
+            normalized_lines.append(line)
+    normalized_lines = [line for line in normalized_lines if line]
+    if not normalized_lines:
+        return "table", {"reason": "empty_line_region"}
+
+    if len(rows) == 1:
+        max_chars = max(len(line) for line in normalized_lines)
+        return (
+            "note" if max_chars >= 30 else "table",
+            {
+                "reason": "single_line_row_length",
+                "line_count": 1,
+                "max_chars": max_chars,
+                "max_words": max(len(line.split()) for line in normalized_lines),
+            },
+        )
+
+    line_word_counts = [len(line.split()) for line in normalized_lines]
+    line_char_counts = [len(line) for line in normalized_lines]
+    total_chars = sum(line_char_counts)
+    avg_words = sum(line_word_counts) / len(line_word_counts)
+    avg_chars = total_chars / max(1, len(line_char_counts))
+    punctuation_ratio = sum(
+        1 for line in normalized_lines if any(ch in line for ch in [".", ",", ";", ":", "(", ")"])
+    ) / len(normalized_lines)
+    short_rows = sum(1 for count in line_word_counts if count <= 4)
+
+    note_score = 0.0
+    table_score = 0.0
+    if len(normalized_lines) <= 2 and short_rows >= len(normalized_lines):
+        table_score += 2.0
+    if avg_chars >= 30 and total_chars >= 45:
+        note_score += 1.5
+    if avg_words >= 6:
+        note_score += 1.5
+    if total_chars >= 90:
+        note_score += 1.0
+    if punctuation_ratio >= 0.2:
+        note_score += 0.5
+    if table_score >= note_score:
+        return "table", {
+            "reason": "single_column_fallback",
+            "note_score": note_score,
+            "table_score": table_score,
+            "line_count": len(normalized_lines),
+            "avg_chars": avg_chars,
+            "total_chars": total_chars,
+        }
+
+    return "note", {
+        "reason": "single_column_fallback",
+        "note_score": note_score,
+        "table_score": table_score,
+        "line_count": len(normalized_lines),
+        "avg_chars": avg_chars,
+        "total_chars": total_chars,
+    }
+
+
+def _looks_like_single_column_note(
+    rows: Sequence[Sequence[str]],
+    page: Optional[pdfplumber.page.PageObject] = None,
+    bbox: Optional[Tuple[float, float, float, float]] = None,
+) -> bool:
+    # Backward-compatible API used by tests. Spatial hints are optional.
+    kind, _ = _classify_single_column_region(table_rows=rows, page=page, bbox=bbox)
+    return kind == "note"
+
+
+def _single_column_note_body_text(rows: Sequence[Sequence[str]]) -> str:
+    # Convert multi-line note-like rows into a single body sentence.
+    parts: List[str] = []
+    for row in rows:
+        if not row:
+            continue
+        leading_text = ""
+        for cell in row:
+            normalized = _normalize_text(cell)
+            if normalized:
+                leading_text = normalized
+                break
+        if not leading_text:
+            continue
+        for line in _normalize_cell_lines(str(leading_text)):
+            normalized = _normalize_text(line)
+            if normalized:
+                parts.append(normalized)
+    return re.sub(r"\s+", " ", " ".join(parts)).strip()
 
 
 def _rows_match(a: Sequence[str], b: Sequence[str]) -> bool:
@@ -482,6 +856,147 @@ def _merge_touching_fill_rects(
     return merged
 
 
+def _merge_touching_fill_rects_by_color(
+    rects: Sequence[dict[str, Any]],
+    tolerance: float = 1.0,
+    color_tolerance: float = 0.02,
+) -> List[Tuple[float, float, float, float]]:
+    color_groups: dict[tuple[Any, ...] | int | float | None, list[dict[str, Any]]] = {}
+    for rect in rects:
+        key = _rect_fill_color_key(rect)
+        color_groups.setdefault(key, []).append(rect)
+
+    merged: List[Tuple[float, float, float, float]] = []
+    for key, group_rects in color_groups.items():
+        merged.extend(_merge_touching_fill_rects(group_rects, tolerance=tolerance))
+    return merged
+
+
+def _strip_coverage_ratio(
+    bbox: Tuple[float, float, float, float],
+    strip_rects: Sequence[dict[str, Any]],
+    line_y: float,
+    tolerance: float = 2.0,
+) -> float:
+    x0, _top, x1, _bottom = bbox
+    if x1 <= x0:
+        return 0.0
+
+    intervals: List[tuple[float, float]] = []
+    for rect in strip_rects:
+        rect_top = float(rect.get("top", 0.0))
+        rect_bottom = float(rect.get("bottom", 0.0))
+        if rect_bottom < line_y - tolerance or rect_top > line_y + tolerance:
+            continue
+
+        rx0 = float(rect.get("x0", 0.0))
+        rx1 = float(rect.get("x1", 0.0))
+        interval_x0 = max(x0, rx0)
+        interval_x1 = min(x1, rx1)
+        if interval_x1 - interval_x0 > 0.0:
+            intervals.append((interval_x0, interval_x1))
+
+    if not intervals:
+        return 0.0
+
+    intervals.sort(key=lambda item: item[0])
+    merged: list[tuple[float, float]] = [intervals[0]]
+    for left, right in intervals[1:]:
+        last_left, last_right = merged[-1]
+        if left <= last_right + 1.5:
+            merged[-1] = (last_left, max(last_right, right))
+        else:
+            merged.append((left, right))
+
+    covered = sum(right - left for left, right in merged)
+    return covered / (x1 - x0)
+
+
+def _contains_bbox(outer: Tuple[float, float, float, float], inner: Tuple[float, float, float, float], *, overlap_ratio: float = 0.98) -> bool:
+    ox0, oy0, ox1, oy1 = outer
+    ix0, iy0, ix1, iy1 = inner
+    if ix0 < ox0 or ix1 > ox1 or iy0 < oy0 or iy1 > oy1:
+        return False
+
+    intersection = (min(ox1, ix1) - max(ox0, ix0)) * (min(oy1, iy1) - max(oy0, iy0))
+    if intersection <= 0.0:
+        return False
+
+    inner_area = (ix1 - ix0) * (iy1 - iy0)
+    if inner_area <= 0.0:
+        return False
+    return intersection / inner_area >= overlap_ratio
+
+
+def _to_rect_entry(rect: dict[str, Any] | tuple[float, float, float, float]) -> dict[str, Any]:
+    if isinstance(rect, dict):
+        return {
+            "x0": float(rect.get("x0", 0.0)),
+            "top": float(rect.get("top", rect.get("y0", 0.0))),
+            "x1": float(rect.get("x1", 0.0)),
+            "bottom": float(rect.get("bottom", rect.get("y1", 0.0))),
+            "fill": bool(rect.get("fill", True)),
+            "stroke": bool(rect.get("stroke", False)),
+            "non_stroking_color": rect.get("non_stroking_color"),
+            "stroking_color": rect.get("stroking_color"),
+        }
+
+    if len(rect) == 4:
+        x0, top, x1, bottom = rect
+        return {
+            "x0": float(x0),
+            "top": float(top),
+            "x1": float(x1),
+            "bottom": float(bottom),
+            "fill": True,
+            "stroke": False,
+            "non_stroking_color": None,
+            "stroking_color": None,
+        }
+
+    raise TypeError(f"unsupported rect type: {type(rect)!r}")
+
+
+def _dedupe_redundant_rectangles(
+    rects: Sequence[dict[str, Any] | tuple[float, float, float, float]],
+) -> List[dict[str, Any]]:
+    if len(rects) <= 1:
+        return [_to_rect_entry(rect) for rect in rects]
+
+    converted = [_to_rect_entry(rect) for rect in rects]
+    ordered = sorted(
+        converted,
+        key=lambda rect: -(rect["x1"] - rect["x0"]) * (rect["bottom"] - rect["top"]),
+    )
+
+    kept: List[dict[str, Any]] = []
+    for rect in ordered:
+        if not bool(rect.get("fill")):
+            continue
+        candidate = (
+            float(rect.get("x0", 0.0)),
+            float(rect.get("top", 0.0)),
+            float(rect.get("x1", 0.0)),
+            float(rect.get("bottom", 0.0)),
+        )
+        keep = True
+        for existing in kept:
+            existing_bbox = (
+                float(existing.get("x0", 0.0)),
+                float(existing.get("top", 0.0)),
+                float(existing.get("x1", 0.0)),
+                float(existing.get("bottom", 0.0)),
+            )
+            if not _is_nearly_white_color(rect.get("non_stroking_color", rect.get("stroking_color"))):
+                continue
+            if _contains_bbox(existing_bbox, candidate):
+                keep = False
+                break
+        if keep:
+            kept.append(rect)
+    return kept
+
+
 def _thin_strip_rects(rects: Sequence[dict], max_height: float = 1.5) -> List[dict]:
     # Some PDFs use filled rect strips instead of stroked lines for box boundaries.
     return [
@@ -509,22 +1024,22 @@ def _single_column_box_regions(page: pdfplumber.page.PageObject) -> List[Tuple[f
         if rect not in boundary_rects and not bool(rect.get("stroke"))
     ]
     candidates: List[Tuple[float, float, float, float]] = []
-    for bbox in _merge_touching_fill_rects(content_rects):
+    for bbox in _merge_touching_fill_rects_by_color(content_rects):
         x0, top, x1, bottom = bbox
         width = x1 - x0
         if width < 120.0:
             continue
 
         top_strip = any(
-            float(rect.get("x0", 0.0)) <= x0 + 1.0
-            and float(rect.get("x1", 0.0)) >= x1 - 1.0
-            and abs(float(rect.get("bottom", 0.0)) - top) <= 1.5
+            float(rect.get("x0", 0.0)) <= x0 + 4.0
+            and float(rect.get("x1", 0.0)) >= x1 - 4.0
+            and abs(float(rect.get("bottom", 0.0)) - top) <= 2.5
             for rect in boundary_rects
         )
         bottom_strip = any(
-            float(rect.get("x0", 0.0)) <= x0 + 1.0
-            and float(rect.get("x1", 0.0)) >= x1 - 1.0
-            and abs(float(rect.get("top", 0.0)) - bottom) <= 1.5
+            float(rect.get("x0", 0.0)) <= x0 + 4.0
+            and float(rect.get("x1", 0.0)) >= x1 - 4.0
+            and abs(float(rect.get("top", 0.0)) - bottom) <= 2.5
             for rect in boundary_rects
         )
         if not top_strip or not bottom_strip:
@@ -602,21 +1117,184 @@ def _bbox_overlap_ratio(
     return intersection / max(min(_bbox_area(a), _bbox_area(b)), 1.0)
 
 
-def _looks_like_single_column_box_misclassification(rows: TableRows) -> bool:
-    # Reclassify only sparse one-column outputs that are likely a visual box broken into multiple table rows.
-    if not rows or len(rows) < 2:
+def _bbox_x_overlap_ratio(
+    a: Tuple[float, float, float, float],
+    b: Tuple[float, float, float, float],
+) -> float:
+    ax0, _, ax1, _ = a
+    bx0, _, bx1, _ = b
+    intersection = max(0.0, min(ax1, bx1) - max(ax0, bx0))
+    min_width = max(1.0, min(ax1 - ax0, bx1 - bx0))
+    return intersection / min_width
+
+
+def _is_nearly_white_color(value: object) -> bool:
+    if value is None:
         return False
-    column_count = max((len(row) for row in rows), default=0)
-    if column_count != 1:
+
+    if isinstance(value, (int, float)):
+        return float(value) >= 0.98
+
+    if isinstance(value, (list, tuple)) and len(value) >= 3:
+        components = [float(component) for component in value[:3]]
+        return all(0.95 <= component <= 1.02 for component in components)
+
+    return False
+
+
+def _single_column_box_region_candidates(
+    page: pdfplumber.page.PageObject,
+) -> List[dict]:
+    body_top, body_bottom = _detect_body_bounds(page, header_margin=90.0, footer_margin=40.0)
+    fill_rects = [
+        rect
+        for rect in getattr(page, "rects", [])
+        if bool(rect.get("fill"))
+        and float(rect.get("bottom", 0.0)) > body_top
+        and float(rect.get("top", 0.0)) < body_bottom
+    ]
+    merged_fill_rects = _dedupe_redundant_rectangles(_merge_touching_fill_rects_by_color(fill_rects, tolerance=1.0))
+    boundary_rects = _thin_strip_rects(merged_fill_rects)
+    content_rects = [
+        rect
+        for rect in merged_fill_rects
+        if rect not in boundary_rects and not bool(rect.get("stroke"))
+    ]
+
+    candidates: List[dict] = []
+    if not content_rects:
+        return candidates
+
+    for bbox in _merge_touching_fill_rects_by_color(content_rects, tolerance=1.0):
+        x0, top, x1, bottom = bbox
+        width = x1 - x0
+        if width < 120.0:
+            continue
+
+        top_strip_ratio = _strip_coverage_ratio((x0, top, x1, bottom), boundary_rects, top, tolerance=2.8)
+        bottom_strip_ratio = _strip_coverage_ratio((x0, top, x1, bottom), boundary_rects, bottom, tolerance=2.8)
+        if top_strip_ratio < 0.45 and bottom_strip_ratio < 0.45:
+            continue
+
+        overlapping_content = [
+            rect
+            for rect in content_rects
+            if not (
+                float(rect.get("x1", 0.0)) < x0
+                or float(rect.get("x0", 0.0)) > x1
+                or float(rect.get("bottom", 0.0)) < top
+                or float(rect.get("top", 0.0)) > bottom
+            )
+        ]
+        content_colors: List[object] = []
+        border_colors: List[object] = []
+        for rect in overlapping_content:
+            color = rect.get("non_stroking_color") if rect.get("non_stroking_color") is not None else rect.get("stroking_color")
+            content_colors.append(color)
+        for rect in boundary_rects:
+            if not (
+                float(rect.get("x1", 0.0)) < x0
+                or float(rect.get("x0", 0.0)) > x1
+                or float(rect.get("bottom", 0.0)) < top
+                or float(rect.get("top", 0.0)) > bottom
+            ):
+                color = rect.get("non_stroking_color") if rect.get("non_stroking_color") is not None else rect.get("stroking_color")
+                border_colors.append(color)
+
+        has_non_white_border = any(not _is_nearly_white_color(color) for color in border_colors if color is not None)
+        is_white_content = (
+            bool(content_colors)
+            and all(_is_nearly_white_color(color) for color in content_colors)
+            and not has_non_white_border
+        )
+
+        internal_verticals = _merge_numeric_positions(
+            [
+                float(edge["x0"])
+                for edge in page.vertical_edges
+                if bool(edge.get("stroke"))
+                and float(edge.get("x0", 0.0)) > x0 + 2.0
+                and float(edge.get("x0", 0.0)) < x1 - 2.0
+                and float(edge.get("top", 0.0)) <= bottom
+                and float(edge.get("bottom", 0.0)) >= top
+            ],
+            tolerance=1.0,
+        )
+        if internal_verticals:
+            continue
+
+        candidates.append({
+            "bbox": bbox,
+            "is_white_content": is_white_content,
+        })
+
+    return candidates
+
+
+def _single_column_box_regions(
+    page: pdfplumber.page.PageObject,
+) -> List[Tuple[float, float, float, float]]:
+    # Keep public behavior for existing callers that only need candidate bboxes.
+    return [entry["bbox"] for entry in _single_column_box_region_candidates(page)]
+
+
+def _single_column_boxes_share_index(
+    a_bbox: Tuple[float, float, float, float],
+    b_bbox: Tuple[float, float, float, float],
+) -> bool:
+    a_x0, a_y0, a_x1, a_y1 = a_bbox
+    b_x0, b_y0, b_x1, b_y1 = b_bbox
+    if _bbox_x_overlap_ratio(a_bbox, b_bbox) < 0.65:
         return False
-    if any(not _normalize_text(row[0]) for row in rows if row):
-        return False
-    return True
+
+    a_width = a_x1 - a_x0
+    b_width = b_x1 - b_x0
+    return abs(a_width - b_width) <= 6.0 or abs(a_x0 - b_x0) <= 3.0
+
+
+def _merge_single_column_fragment_rows(
+    top_bbox: Tuple[float, float, float, float],
+    top_rows: List[List[str]],
+    bottom_bbox: Tuple[float, float, float, float],
+    bottom_rows: List[List[str]],
+) -> Tuple[List[List[str]], Tuple[float, float, float, float]]:
+    # Preserve source order by vertical location and avoid accidental duplicated prose rows.
+    if top_bbox[1] <= bottom_bbox[1]:
+        ordered_rows = [
+            [row[:] for row in top_rows],
+            [row[:] for row in bottom_rows],
+        ]
+    else:
+        ordered_rows = [
+            [row[:] for row in bottom_rows],
+            [row[:] for row in top_rows],
+        ]
+
+    merged_rows: List[List[str]] = []
+    for row in (ordered_rows[0] + ordered_rows[1]):
+        if not row:
+            continue
+        normalized = _first_non_empty_cell_value(row)
+        if not normalized:
+            continue
+        if merged_rows and _first_non_empty_cell_value(merged_rows[-1]) == normalized:
+            continue
+        merged_rows.append(row)
+
+    merged_bbox = (
+        min(top_bbox[0], bottom_bbox[0]),
+        min(top_bbox[1], bottom_bbox[1]),
+        max(top_bbox[2], bottom_bbox[2]),
+        max(top_bbox[3], bottom_bbox[3]),
+    )
+    return merged_rows, merged_bbox
 
 
 def _extract_tables_from_crop(
     page: pdfplumber.page.PageObject,
     crop_bbox: Tuple[float, float, float, float],
+    *,
+    fallback_to_text_rows: bool = False,
 ) -> List[TableChunk]:
     # Crop-level extraction gives table_settings a tighter region and improves recovery of border-light tables.
     x0, y0, x1, y1 = crop_bbox
@@ -666,6 +1344,12 @@ def _extract_tables_from_crop(
             cleaned.append(_merge_cells(table))
         if cleaned:
             return [(table, crop_bbox) for table in cleaned]
+
+    if fallback_to_text_rows:
+        line_rows = _compact_fallback_rows(_extract_region_line_rows(page, crop_bbox))
+        if line_rows:
+            return [(line_rows, crop_bbox)]
+
     return []
 
 
@@ -682,7 +1366,9 @@ def _extract_tables(
         y0 = min(edge["top"] for edge in lines) - 2
         y1 = max(edge["top"] for edge in lines) + 2
         crop_bbox = (max(0.0, x0), max(0.0, y0), min(page.width, x1), min(page.height, y1))
-        for table, crop_box in _extract_tables_from_crop(page, crop_bbox):
+        for table, crop_box in _extract_tables_from_crop(
+            page, crop_bbox, fallback_to_text_rows=True
+        ):
             table = _normalize_extracted_table(table)
             rows_key = tuple(tuple(row) for row in table)
             bbox_key = tuple(round(v, 2) for v in crop_box)
@@ -691,28 +1377,77 @@ def _extract_tables(
                 seen_keys.add(key)
                 merged.append((table, crop_box))
 
-    reclassified: List[TableChunk] = []
-    for crop_bbox in _single_column_box_regions(page):
-        cell_text = _extract_text_from_box_region(page, crop_bbox)
-        if not cell_text:
+    # Notes drawn as single-column box regions should stay in body text, not table output.
+    # Merge nearby fragments with shared index to avoid dropping partial text by accident.
+    candidate_rows: List[dict] = []
+    for entry in _single_column_box_region_candidates(page):
+        rows = [[_extract_text_from_box_region(page, entry["bbox"])]]
+        if not rows[0][0]:
             continue
-        replacement = [[cell_text]]
-        merged = [
-            (rows, bbox)
-            for rows, bbox in merged
-            if not (
-                _bbox_overlap_ratio(bbox, crop_bbox) >= 0.8
-                and _looks_like_single_column_box_misclassification(rows)
-            )
-        ]
-        rows_key = tuple(tuple(row) for row in replacement)
-        bbox_key = tuple(round(v, 2) for v in crop_bbox)
-        key = (rows_key, bbox_key)
-        if key not in seen_keys:
-            seen_keys.add(key)
-            reclassified.append((replacement, crop_bbox))
+        is_note_like = _looks_like_single_column_note(rows=rows, page=page, bbox=entry["bbox"])
+        candidate_rows.append(
+            {
+                "bbox": entry["bbox"],
+                "rows": rows,
+                "is_white_content": bool(entry.get("is_white_content")),
+                "is_note_like": is_note_like,
+            }
+        )
 
-    merged.extend(reclassified)
+    merged_candidates: List[dict] = []
+    for candidate in sorted(candidate_rows, key=lambda item: float(item["bbox"][1])):
+        if candidate["is_white_content"]:
+            merged_candidates.append(candidate)
+            continue
+
+        merged_into_existing = False
+        for existing in merged_candidates:
+            if existing["is_white_content"]:
+                continue
+            if not _single_column_boxes_share_index(existing["bbox"], candidate["bbox"]):
+                continue
+            # Merge vertically adjacent or overlapping fragments that are likely the same logical box.
+            if (
+                abs(candidate["bbox"][1] - existing["bbox"][3]) <= 90.0
+                or abs(existing["bbox"][1] - candidate["bbox"][3]) <= 90.0
+                or _bbox_overlap_ratio(existing["bbox"], candidate["bbox"]) > 0.0
+            ):
+                merged_rows, merged_bbox = _merge_single_column_fragment_rows(
+                    existing["bbox"],
+                    existing["rows"],
+                    candidate["bbox"],
+                    candidate["rows"],
+                )
+                existing["rows"] = merged_rows
+                existing["bbox"] = merged_bbox
+                existing["is_note_like"] = _looks_like_single_column_note(
+                    rows=merged_rows,
+                    page=page,
+                    bbox=merged_bbox,
+                )
+                merged_into_existing = True
+                break
+
+        if not merged_into_existing:
+            merged_candidates.append(candidate)
+
+    removed_indices: set[int] = set()
+    for candidate in merged_candidates:
+        if candidate["is_white_content"] or not candidate.get("is_note_like", False):
+            continue
+        for idx, (rows, table_bbox) in enumerate(merged):
+            if idx in removed_indices:
+                continue
+            if not _looks_like_single_column_note(rows=rows, page=page, bbox=table_bbox):
+                continue
+            if not _single_column_boxes_share_index(table_bbox, candidate["bbox"]):
+                continue
+            if _bbox_overlap_ratio(table_bbox, candidate["bbox"]) < 0.8:
+                continue
+            removed_indices.add(idx)
+
+    if removed_indices:
+        merged = [entry for idx, entry in enumerate(merged) if idx not in removed_indices]
 
     if merged or not force_table:
         return merged
@@ -776,13 +1511,18 @@ def _table_text_from_rows(rows: Sequence[Sequence[str]]) -> str:
     if not rows:
         return ""
 
-    header_row_count = _header_row_count(rows)
-    header_rows = rows[:header_row_count] if header_row_count else rows[:1]
-    header = _collapse_header_rows(header_rows)
-    body = rows[header_row_count:] if header_row_count else rows[1:]
-    if not body:
-        body = rows
+    note_like = _looks_like_single_column_note(rows)
+    if note_like:
         header = [f"Column {idx}" for idx in range(1, len(rows[0]) + 1)]
+        body = rows
+    else:
+        header_row_count = _header_row_count(rows)
+        header_rows = rows[:header_row_count] if header_row_count else rows[:1]
+        header = _collapse_header_rows(header_rows)
+        body = rows[header_row_count:] if header_row_count else rows[1:]
+        if not body:
+            body = rows
+            header = [f"Column {idx}" for idx in range(1, len(rows[0]) + 1)]
 
     header_line = "| " + " | ".join(_format_header_markdown_cell(cell or f"Column {idx + 1}") for idx, cell in enumerate(header)) + " |"
     divider_line = "| " + " | ".join("---" for _ in header) + " |"

--- a/graph_pdf/fixtures/font_heading_profile.sample.json
+++ b/graph_pdf/fixtures/font_heading_profile.sample.json
@@ -2,7 +2,7 @@
   "heading_rules": [
     {
       "match": {
-        "font_size": 20.0
+        "font_size": 27.96
       },
       "assign": {
         "tag": "h1",
@@ -11,7 +11,7 @@
     },
     {
       "match": {
-        "font_size": 16.0
+        "font_size": 21.96
       },
       "assign": {
         "tag": "h2",
@@ -20,11 +20,20 @@
     },
     {
       "match": {
-        "font_size": 13.0
+        "font_size": 15.96
       },
       "assign": {
         "tag": "h3",
         "markdown_prefix": "### "
+      }
+    },
+    {
+      "match": {
+        "font_size": 12.0
+      },
+      "assign": {
+        "tag": "h4",
+        "markdown_prefix": "#### "
       }
     }
   ]

--- a/graph_pdf/scripts/replay_samples.py
+++ b/graph_pdf/scripts/replay_samples.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from pypdf import PdfReader
+
+from extractor.pipeline import extract_pdf_to_outputs
+from extractor.raw import load_raw_payload
+
+TABLE_REF_PATTERN = re.compile(r"\[Table reference:\s*Page\s+\d+\s+table\s+\d+\]")
+TABLE_HEADER_PATTERN = re.compile(r"^### Page \d+ table \d+$", re.MULTILINE)
+NOTE_MAX_ROW_COUNT = 12
+NOTE_MAX_VERTICAL_GAP = 40.0
+NOTE_MIN_X_OVERLAP = 20.0
+
+
+def _decode_raw_to_pdf(raw_path: Path, output_pdf: Path, force: bool) -> Path:
+    if output_pdf.exists() and not force:
+        return output_pdf
+
+    payload = load_raw_payload(raw_path)
+    encoded = payload.get("document_pdf_base64")
+    if not isinstance(encoded, str) or not encoded:
+        raise ValueError(f"{raw_path} is missing document_pdf_base64")
+
+    pdf_bytes = base64.b64decode(encoded)
+    output_pdf.parent.mkdir(parents=True, exist_ok=True)
+    output_pdf.write_bytes(pdf_bytes)
+    return output_pdf
+
+
+def _page_count(pdf_path: Path) -> int:
+    try:
+        return len(PdfReader(str(pdf_path)).pages)
+    except Exception:
+        return 0
+
+
+def _run_parser(
+    *,
+    pdf_path: Path | None,
+    raw_path: Path | None,
+    out_root: Path,
+    stem: str,
+    debug: bool = False,
+) -> dict[str, Any]:
+    if raw_path is None and pdf_path is None:
+        raise ValueError("pdf_path or raw_path is required")
+
+    md_dir = out_root / "md"
+    image_dir = out_root / "images"
+    result = extract_pdf_to_outputs(
+        pdf_path=pdf_path,
+        out_md_dir=md_dir,
+        out_image_dir=image_dir,
+        stem=stem,
+        from_raw=raw_path,
+        debug=debug,
+    )
+    return {
+        "text_chars": len((result["text_file"]).read_text(encoding="utf-8")),
+        "table_count": result["summary"]["table_count"],
+        "text_file": result["text_file"],
+        "table_md_file": result["table_md_file"],
+        "markdown": result["markdown"],
+        "table_markdown": result["table_markdown"],
+        "debug_file": result["debug_file"],
+    }
+
+
+def _bbox_overlap_x(a: list[float], b: list[float]) -> float:
+    a0, a1 = a[0], a[2]
+    b0, b1 = b[0], b[2]
+    return max(0.0, min(a1, b1) - max(a0, b0))
+
+
+def _is_single_column_note(table_meta: dict[str, Any]) -> bool:
+    col_count = int(table_meta.get("col_count", 0) or 0)
+    row_count = int(table_meta.get("row_count", 0) or 0)
+    bbox = table_meta.get("bbox") or []
+    if len(bbox) != 4:
+        return False
+    width = float(bbox[2]) - float(bbox[0])
+    return col_count == 1 and 1 <= row_count <= NOTE_MAX_ROW_COUNT and width > NOTE_MIN_X_OVERLAP
+
+
+def _find_overlap_candidates(
+    debug_file: Path | None,
+    max_vertical_gap: float = NOTE_MAX_VERTICAL_GAP,
+    min_x_overlap: float = NOTE_MIN_X_OVERLAP,
+) -> dict[str, Any]:
+    if debug_file is None:
+        return {
+            "note_overlap_candidates": [],
+            "table_overlap_candidates": [],
+            "overlap_pages": [],
+            "note_pages": [],
+            "table_overlap_pages": [],
+        }
+
+    path = Path(debug_file)
+    if not path.exists():
+        return {
+            "note_overlap_candidates": [],
+            "table_overlap_candidates": [],
+            "overlap_pages": [],
+            "note_pages": [],
+            "table_overlap_pages": [],
+        }
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    note_overlap_candidates: list[dict[str, Any]] = []
+    table_overlap_candidates: list[dict[str, Any]] = []
+    overlap_pages: set[int] = set()
+    note_pages: set[int] = set()
+    table_overlap_pages: set[int] = set()
+
+    for page_payload in payload.get("pages", []):
+        page_no = int(page_payload.get("page", 0))
+        tables: list[dict[str, Any]] = [
+            table for table in page_payload.get("tables", [])
+            if len(table.get("bbox", [])) == 4
+        ]
+        if len(tables) < 2:
+            continue
+
+        sorted_tables = sorted(
+            tables,
+            key=lambda table: float(table.get("bbox", [0, 0, 0, 0])[1]),
+        )
+
+        for idx, upper in enumerate(sorted_tables):
+            upper_bbox = list(map(float, upper.get("bbox", [0, 0, 0, 0])))
+            upper_bottom = upper_bbox[3]
+            for lower in sorted_tables[idx + 1 :]:
+                lower_bbox = list(map(float, lower.get("bbox", [0, 0, 0, 0])))
+                lower_top = lower_bbox[1]
+                gap = lower_top - upper_bottom
+                if gap < 0:
+                    continue
+                if gap > max_vertical_gap:
+                    break
+
+                x_overlap = _bbox_overlap_x(upper_bbox, lower_bbox)
+                if x_overlap < min_x_overlap:
+                    continue
+
+                candidate = {
+                    "page": page_no,
+                    "upper": {
+                        "col_count": int(upper.get("col_count", 0) or 0),
+                        "row_count": int(upper.get("row_count", 0) or 0),
+                        "bbox": [
+                            round(float(upper_bbox[0]), 2),
+                            round(float(upper_bbox[1]), 2),
+                            round(float(upper_bbox[2]), 2),
+                            round(float(upper_bbox[3]), 2),
+                        ],
+                    },
+                    "lower": {
+                        "col_count": int(lower.get("col_count", 0) or 0),
+                        "row_count": int(lower.get("row_count", 0) or 0),
+                        "bbox": [
+                            round(float(lower_bbox[0]), 2),
+                            round(float(lower_bbox[1]), 2),
+                            round(float(lower_bbox[2]), 2),
+                            round(float(lower_bbox[3]), 2),
+                        ],
+                    },
+                    "vertical_gap": round(gap, 2),
+                    "x_overlap": round(x_overlap, 2),
+                }
+
+                upper_is_note = _is_single_column_note(upper)
+                lower_is_note = _is_single_column_note(lower)
+                if upper_is_note or lower_is_note:
+                    note_overlap_candidates.append(candidate)
+                    note_pages.add(page_no)
+                else:
+                    table_overlap_candidates.append(candidate)
+                    table_overlap_pages.add(page_no)
+                overlap_pages.add(page_no)
+
+    return {
+        "note_overlap_candidates": note_overlap_candidates,
+        "table_overlap_candidates": table_overlap_candidates,
+        "overlap_pages": sorted(overlap_pages),
+        "note_pages": sorted(note_pages),
+        "table_overlap_pages": sorted(table_overlap_pages),
+    }
+
+
+def _count_table_references(markdown_text: str) -> int:
+    return len(TABLE_REF_PATTERN.findall(markdown_text))
+
+
+def _count_table_sections(markdown_text: str) -> int:
+    return len(TABLE_HEADER_PATTERN.findall(markdown_text))
+
+
+def _extract_table_references(markdown_text: str) -> list[str]:
+    raw = TABLE_REF_PATTERN.findall(markdown_text)
+    return [token.replace("[", "").replace("]", "") for token in raw]
+
+
+def _extract_table_sections(markdown_text: str) -> list[str]:
+    return [line[4:] for line in markdown_text.splitlines() if TABLE_HEADER_PATTERN.match(line)]
+
+
+def _normalize_table_token(token: str) -> str:
+    return re.sub(r"\s+", " ", token.strip()).lower()
+
+
+def _build_suspicions(
+    *,
+    parse_direct: dict[str, Any],
+    parse_from_raw: dict[str, Any] | None,
+) -> list[str]:
+    reasons: list[str] = []
+
+    direct_refs = _count_table_references(parse_direct["markdown"])
+    direct_sections = _count_table_sections(parse_direct["table_markdown"])
+    direct_table_count = parse_direct["table_count"]
+    direct_ref_tokens = _extract_table_references(parse_direct["markdown"])
+    direct_section_tokens = _extract_table_sections(parse_direct["table_markdown"])
+
+    if direct_refs != direct_sections:
+        missing_in_markdown = sorted(
+            {
+                token
+                for token in direct_ref_tokens
+                if _normalize_table_token(token) not in {
+                    _normalize_table_token(f"Table reference: {section}") for section in direct_section_tokens
+                }
+            }
+        )
+        missing_in_reference = sorted(
+            {
+                f"Table reference: {section}"
+                for section in direct_section_tokens
+                if _normalize_table_token(f"Table reference: {section}") not in {
+                    _normalize_table_token(token) for token in direct_ref_tokens
+                }
+            }
+        )
+        if missing_in_markdown:
+            reasons.append(
+                f"본문 참조만 존재: {', '.join(missing_in_markdown[:10])}"
+            )
+        if missing_in_reference:
+            reasons.append(
+                f"table markdown에서만 존재: {', '.join(sorted(missing_in_reference)[:10])}"
+            )
+        reasons.append(
+            f"body에는 Table reference 수치 {direct_refs}개, table markdown 섹션은 {direct_sections}개로 불일치"
+        )
+    if direct_sections != direct_table_count:
+        reasons.append(
+            f"summary.table_count={direct_table_count}와 table markdown 섹션 수({direct_sections})가 불일치"
+        )
+
+    if parse_from_raw is not None:
+        if parse_direct["table_count"] != parse_from_raw["table_count"]:
+            reasons.append(
+                "pdf 경로 파싱과 --from-raw 파싱의 table_count가 다름"
+            )
+        if parse_direct["table_markdown"] != parse_from_raw["table_markdown"]:
+            reasons.append(
+                "pdf 경로 파싱과 --from-raw 파싱의 table markdown 내용이 다름"
+            )
+        if parse_direct["text_chars"] != parse_from_raw["text_chars"]:
+            reasons.append("pdf 경로 파싱과 --from-raw 파싱의 본문 길이가 다름")
+
+    return reasons
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Reconstruct visual PDFs from raw dumps and inspect parser output.")
+    parser.add_argument("--samples-dir", default="samples", help="raw dump 폴더 (기본: samples)")
+    parser.add_argument(
+        "--pdf-dir",
+        default="artifacts/sample_visuals/pdfs",
+        help="덤프를 PDF로 복원해 저장할 폴더",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default="artifacts/sample_visuals/parse",
+        help="파싱 산출물을 저장할 루트 폴더",
+    )
+    parser.add_argument(
+        "--pattern",
+        default="*.dump",
+        help="샘플 선택 패턴 (예: raw-*.dump)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="기존 PDF/파싱 산출물을 덮어쓰기",
+    )
+    parser.add_argument(
+        "--compare-from-raw",
+        action="store_true",
+        help="동일 샘플을 --from-raw로 다시 파싱해 PDF 파싱 결과와 비교",
+    )
+    parser.add_argument(
+        "--analyze-note-overlap",
+        action="store_true",
+        help="debug 기반으로 겹침 후보를 분석해 single-column(note) 후보와 table 겹침을 분리 출력",
+    )
+    parser.add_argument(
+        "--max-overlap-gap",
+        type=float,
+        default=NOTE_MAX_VERTICAL_GAP,
+        help="겹침 후보 판별에서 상단/하단 블록 간 최대 간격(기본값: 40.0)",
+    )
+    parser.add_argument(
+        "--min-x-overlap",
+        type=float,
+        default=NOTE_MIN_X_OVERLAP,
+        help="겹침 후보 판별에서 최소 x 축 교차 길이(기본값: 20.0)",
+    )
+    args = parser.parse_args()
+
+    samples_dir = Path(args.samples_dir).resolve()
+    pdf_dir = Path(args.pdf_dir).resolve()
+    out_root = Path(args.out_dir).resolve()
+
+    raw_paths = sorted(samples_dir.glob(args.pattern))
+    if not raw_paths:
+        print(f"no sample found in {samples_dir} with pattern '{args.pattern}'")
+        return
+
+    report: list[dict[str, Any]] = []
+
+    for raw_path in raw_paths:
+        stem = raw_path.stem
+        output_pdf = pdf_dir / f"{stem}.pdf"
+        sample_root = out_root / stem
+
+        print(f"\n[{stem}] raw: {raw_path}")
+
+        pdf_path = _decode_raw_to_pdf(raw_path, output_pdf, force=args.force)
+        page_count = _page_count(pdf_path)
+
+        parse_direct = _run_parser(
+            pdf_path=pdf_path,
+            raw_path=None,
+            out_root=sample_root / "pdf_path",
+            stem=stem,
+            debug=args.compare_from_raw or args.analyze_note_overlap,
+        )
+        print(f"  visual pdf: {pdf_path} ({page_count} pages)")
+        print(f"  parsed (pdf): {parse_direct['text_chars']} chars, tables={parse_direct['table_count']}")
+
+        entry: dict[str, Any] = {
+            "sample": str(raw_path),
+            "pdf": str(pdf_path),
+            "pages": page_count,
+            "text_chars_pdf": parse_direct["text_chars"],
+            "table_count_pdf": parse_direct["table_count"],
+            "text_file": str(parse_direct["text_file"]),
+            "table_md_file": str(parse_direct["table_md_file"]),
+        }
+
+        if args.analyze_note_overlap:
+            overlap = _find_overlap_candidates(
+                debug_file=parse_direct.get("debug_file"),
+                max_vertical_gap=args.max_overlap_gap,
+                min_x_overlap=args.min_x_overlap,
+            )
+            print(
+                f"  overlap candidates: "
+                f"note={len(overlap['note_overlap_candidates'])}, "
+                f"table={len(overlap['table_overlap_candidates'])}"
+            )
+            sample_root.mkdir(parents=True, exist_ok=True)
+            overlap_cases_path = sample_root / f"{stem}_overlap_cases.json"
+            overlap_cases_path.write_text(
+                json.dumps(
+                    {
+                        "sample": raw_path.name,
+                        "pdf": str(pdf_path),
+                        "note_overlap_candidates": overlap["note_overlap_candidates"],
+                        "table_overlap_candidates": overlap["table_overlap_candidates"],
+                        "overlap_pages": overlap["overlap_pages"],
+                        "note_pages": overlap["note_pages"],
+                        "table_overlap_pages": overlap["table_overlap_pages"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            note_only_path = sample_root / f"{stem}_note_only.json"
+            note_only_path.write_text(
+                json.dumps(
+                    {
+                        "sample": raw_path.name,
+                        "pdf": str(pdf_path),
+                        "note_candidates": overlap["note_overlap_candidates"],
+                        "note_pages": overlap["note_pages"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            entry.update(
+                {
+                    "overlap_candidates": overlap,
+                    "note_overlap_candidates": overlap["note_overlap_candidates"],
+                    "table_overlap_candidates": overlap["table_overlap_candidates"],
+                    "overlap_pages": overlap["overlap_pages"],
+                    "note_overlap_pages": overlap["note_pages"],
+                    "table_overlap_pages": overlap["table_overlap_pages"],
+                }
+            )
+
+        if args.compare_from_raw:
+            parse_from_raw = _run_parser(
+                pdf_path=None,
+                raw_path=raw_path,
+                out_root=sample_root / "from_raw",
+                stem=f"{stem}_from_raw",
+                debug=args.analyze_note_overlap,
+            )
+            markdown_eq = parse_direct["markdown"] == parse_from_raw["markdown"]
+            table_markdown_eq = parse_direct["table_markdown"] == parse_from_raw["table_markdown"]
+
+            entry.update(
+                {
+                    "text_chars_from_raw": parse_from_raw["text_chars"],
+                    "table_count_from_raw": parse_from_raw["table_count"],
+                    "markdown_matches": markdown_eq,
+                    "table_markdown_matches": table_markdown_eq,
+                }
+            )
+            print(
+                "  compare --from-raw: "
+                f"markdown_same={markdown_eq}, table_markdown_same={table_markdown_eq}"
+            )
+            suspicions = _build_suspicions(parse_direct=parse_direct, parse_from_raw=parse_from_raw)
+        else:
+            suspicions = _build_suspicions(parse_direct=parse_direct, parse_from_raw=None)
+
+        print(f"  suspicious cases: {'none' if not suspicions else '; '.join(suspicions)}")
+
+        entry.update({"suspicious_cases": suspicions})
+
+        report.append(entry)
+
+    summary_path = out_root / "sample_raw_visualization_report.json"
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"\nreport: {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/graph_pdf/scripts/replay_samples.py
+++ b/graph_pdf/scripts/replay_samples.py
@@ -73,7 +73,7 @@ def _run_parser(
     }
 
 
-def _bbox_overlap_x(a: list[float], b: list[float]) -> float:
+def _horizontal_overlap_length(a: list[float], b: list[float]) -> float:
     a0, a1 = a[0], a[2]
     b0, b1 = b[0], b[2]
     return max(0.0, min(a1, b1) - max(a0, b0))
@@ -89,54 +89,109 @@ def _is_single_column_note(table_meta: dict[str, Any]) -> bool:
     return col_count == 1 and 1 <= row_count <= NOTE_MAX_ROW_COUNT and width > NOTE_MIN_X_OVERLAP
 
 
-def _find_overlap_candidates(
+def _layout_region_kind(table_meta: dict[str, Any]) -> str:
+    kind = str(table_meta.get("kind", "")).strip().lower()
+    if kind in {"table", "note"}:
+        return kind
+    return "note" if _is_single_column_note(table_meta) else "table"
+
+
+def _find_layout_candidates(
     debug_file: Path | None,
     max_vertical_gap: float = NOTE_MAX_VERTICAL_GAP,
     min_x_overlap: float = NOTE_MIN_X_OVERLAP,
 ) -> dict[str, Any]:
     if debug_file is None:
         return {
-            "note_overlap_candidates": [],
-            "table_overlap_candidates": [],
-            "overlap_pages": [],
+            "note_region_links": [],
+            "table_region_links": [],
+            "note_region_pairs": [],
+            "table_region_pairs": [],
+            "note_single_regions": [],
+            "table_single_regions": [],
+            "candidate_pages": [],
             "note_pages": [],
-            "table_overlap_pages": [],
+            "table_pages": [],
+            "note_single_pages": [],
+            "table_single_pages": [],
         }
 
     path = Path(debug_file)
     if not path.exists():
         return {
-            "note_overlap_candidates": [],
-            "table_overlap_candidates": [],
-            "overlap_pages": [],
+            "note_region_links": [],
+            "table_region_links": [],
+            "note_region_pairs": [],
+            "table_region_pairs": [],
+            "note_single_regions": [],
+            "table_single_regions": [],
+            "candidate_pages": [],
             "note_pages": [],
-            "table_overlap_pages": [],
+            "table_pages": [],
+            "note_single_pages": [],
+            "table_single_pages": [],
         }
 
     payload = json.loads(path.read_text(encoding="utf-8"))
-    note_overlap_candidates: list[dict[str, Any]] = []
-    table_overlap_candidates: list[dict[str, Any]] = []
-    overlap_pages: set[int] = set()
+    note_region_pairs: list[dict[str, Any]] = []
+    table_region_pairs: list[dict[str, Any]] = []
+    note_region_links = note_region_pairs
+    table_region_links = table_region_pairs
+    note_single_regions: list[dict[str, Any]] = []
+    table_single_regions: list[dict[str, Any]] = []
+    candidate_pages: set[int] = set()
     note_pages: set[int] = set()
-    table_overlap_pages: set[int] = set()
+    table_pages: set[int] = set()
+    note_single_pages: set[int] = set()
+    table_single_pages: set[int] = set()
 
     for page_payload in payload.get("pages", []):
         page_no = int(page_payload.get("page", 0))
-        tables: list[dict[str, Any]] = [
-            table for table in page_payload.get("tables", [])
+        table_regions = page_payload.get("detected_tables")
+        if not isinstance(table_regions, list) or not table_regions:
+            table_regions = page_payload.get("tables", [])
+        tables = [
+            table
+            for table in table_regions
             if len(table.get("bbox", [])) == 4
         ]
-        if len(tables) < 2:
-            continue
 
         sorted_tables = sorted(
             tables,
             key=lambda table: float(table.get("bbox", [0, 0, 0, 0])[1]),
         )
+        if sorted_tables:
+            for table in sorted_tables:
+                kind = _layout_region_kind(table)
+                table_entry = {
+                    "kind": kind,
+                    "col_count": int(table.get("col_count", 0) or 0),
+                    "row_count": int(table.get("row_count", 0) or 0),
+                    "bbox": [
+                        round(float(table.get("bbox", [0, 0, 0, 0])[0]), 2),
+                        round(float(table.get("bbox", [0, 0, 0, 0])[1]), 2),
+                        round(float(table.get("bbox", [0, 0, 0, 0])[2]), 2),
+                        round(float(table.get("bbox", [0, 0, 0, 0])[3]), 2),
+                    ],
+                    "page": page_no,
+                }
+                if kind == "note":
+                    note_single_regions.append(table_entry)
+                    note_pages.add(page_no)
+                    note_single_pages.add(page_no)
+                else:
+                    table_single_regions.append(table_entry)
+                    table_pages.add(page_no)
+                    table_single_pages.add(page_no)
+                candidate_pages.add(page_no)
+
+        if len(sorted_tables) < 2:
+            continue
 
         for idx, upper in enumerate(sorted_tables):
             upper_bbox = list(map(float, upper.get("bbox", [0, 0, 0, 0])))
             upper_bottom = upper_bbox[3]
+            upper_kind = _layout_region_kind(upper)
             for lower in sorted_tables[idx + 1 :]:
                 lower_bbox = list(map(float, lower.get("bbox", [0, 0, 0, 0])))
                 lower_top = lower_bbox[1]
@@ -146,13 +201,17 @@ def _find_overlap_candidates(
                 if gap > max_vertical_gap:
                     break
 
-                x_overlap = _bbox_overlap_x(upper_bbox, lower_bbox)
+                x_overlap = _horizontal_overlap_length(upper_bbox, lower_bbox)
                 if x_overlap < min_x_overlap:
                     continue
+
+                lower_kind = _layout_region_kind(lower)
+                pair_kind = "note" if "note" in (upper_kind, lower_kind) else "table"
 
                 candidate = {
                     "page": page_no,
                     "upper": {
+                        "kind": upper_kind,
                         "col_count": int(upper.get("col_count", 0) or 0),
                         "row_count": int(upper.get("row_count", 0) or 0),
                         "bbox": [
@@ -163,6 +222,7 @@ def _find_overlap_candidates(
                         ],
                     },
                     "lower": {
+                        "kind": lower_kind,
                         "col_count": int(lower.get("col_count", 0) or 0),
                         "row_count": int(lower.get("row_count", 0) or 0),
                         "bbox": [
@@ -173,25 +233,30 @@ def _find_overlap_candidates(
                         ],
                     },
                     "vertical_gap": round(gap, 2),
-                    "x_overlap": round(x_overlap, 2),
+                    "x_contact_length": round(x_overlap, 2),
+                    "pair_kind": pair_kind,
                 }
 
-                upper_is_note = _is_single_column_note(upper)
-                lower_is_note = _is_single_column_note(lower)
-                if upper_is_note or lower_is_note:
-                    note_overlap_candidates.append(candidate)
+                if pair_kind == "note":
+                    note_region_pairs.append(candidate)
                     note_pages.add(page_no)
                 else:
-                    table_overlap_candidates.append(candidate)
-                    table_overlap_pages.add(page_no)
-                overlap_pages.add(page_no)
+                    table_region_pairs.append(candidate)
+                    table_pages.add(page_no)
+                candidate_pages.add(page_no)
 
     return {
-        "note_overlap_candidates": note_overlap_candidates,
-        "table_overlap_candidates": table_overlap_candidates,
-        "overlap_pages": sorted(overlap_pages),
+        "note_region_pairs": note_region_pairs,
+        "table_region_pairs": table_region_pairs,
+        "note_region_links": note_region_links,
+        "table_region_links": table_region_links,
+        "note_single_regions": note_single_regions,
+        "table_single_regions": table_single_regions,
+        "candidate_pages": sorted(candidate_pages),
         "note_pages": sorted(note_pages),
-        "table_overlap_pages": sorted(table_overlap_pages),
+        "table_pages": sorted(table_pages),
+        "note_single_pages": sorted(note_single_pages),
+        "table_single_pages": sorted(table_single_pages),
     }
 
 
@@ -310,19 +375,60 @@ def main() -> None:
     parser.add_argument(
         "--analyze-note-overlap",
         action="store_true",
-        help="debug 기반으로 겹침 후보를 분석해 single-column(note) 후보와 table 겹침을 분리 출력",
+        help="[legacy] 표/노트 레이아웃 판정 후보 분석(기존 옵션 호환)",
+    )
+    parser.add_argument(
+        "--analyze-layout",
+        action="store_true",
+        help="표/노트 레이아웃 판정 후보 분석(권장)",
+    )
+    parser.add_argument(
+        "--analyze-layout-regions",
+        action="store_true",
+        dest="analyze_table_layout",
+        help="debug 기반으로 표/노트 레이아웃 후보를 분리 출력",
+    )
+    parser.add_argument(
+        "--analyze-table-layout",
+        action="store_true",
+        dest="analyze_table_layout",
+        help="[alias] 기존 옵션과 동일 동작",
     )
     parser.add_argument(
         "--max-overlap-gap",
         type=float,
         default=NOTE_MAX_VERTICAL_GAP,
-        help="겹침 후보 판별에서 상단/하단 블록 간 최대 간격(기본값: 40.0)",
+        help="[legacy] 상하 인접 레이아웃 후보 간 최대 간격(기본값: 40.0)",
+    )
+    parser.add_argument(
+        "--max-layout-gap",
+        type=float,
+        default=NOTE_MAX_VERTICAL_GAP,
+        help="[alias] --max-overlap-gap과 동일 동작",
     )
     parser.add_argument(
         "--min-x-overlap",
         type=float,
         default=NOTE_MIN_X_OVERLAP,
-        help="겹침 후보 판별에서 최소 x 축 교차 길이(기본값: 20.0)",
+        help="[legacy] 레이아웃 후보 x축 접촉 길이 최소값(기본값: 20.0)",
+    )
+    parser.add_argument(
+        "--min-x-contact-length",
+        type=float,
+        default=NOTE_MIN_X_OVERLAP,
+        help="[alias] --min-x-overlap과 동일 동작",
+    )
+    parser.add_argument(
+        "--max-region-gap",
+        type=float,
+        default=NOTE_MAX_VERTICAL_GAP,
+        help="레이아웃 후보 상하 인접 영역 간 최대 간격(기본값: 40.0)",
+    )
+    parser.add_argument(
+        "--min-x-contact",
+        type=float,
+        default=NOTE_MIN_X_OVERLAP,
+        help="레이아웃 후보 x축 접촉 길이 최소값(기본값: 20.0)",
     )
     args = parser.parse_args()
 
@@ -347,12 +453,17 @@ def main() -> None:
         pdf_path = _decode_raw_to_pdf(raw_path, output_pdf, force=args.force)
         page_count = _page_count(pdf_path)
 
+        analyze_layout = (
+            args.analyze_note_overlap
+            or args.analyze_table_layout
+            or args.analyze_layout
+        )
         parse_direct = _run_parser(
             pdf_path=pdf_path,
             raw_path=None,
             out_root=sample_root / "pdf_path",
             stem=stem,
-            debug=args.compare_from_raw or args.analyze_note_overlap,
+            debug=args.compare_from_raw or analyze_layout,
         )
         print(f"  visual pdf: {pdf_path} ({page_count} pages)")
         print(f"  parsed (pdf): {parse_direct['text_chars']} chars, tables={parse_direct['table_count']}")
@@ -367,43 +478,62 @@ def main() -> None:
             "table_md_file": str(parse_direct["table_md_file"]),
         }
 
-        if args.analyze_note_overlap:
-            overlap = _find_overlap_candidates(
+        if analyze_layout:
+            max_gap = args.max_region_gap
+            if args.max_region_gap == NOTE_MAX_VERTICAL_GAP and args.max_overlap_gap != NOTE_MAX_VERTICAL_GAP:
+                max_gap = args.max_overlap_gap
+            if args.max_layout_gap != NOTE_MAX_VERTICAL_GAP:
+                max_gap = args.max_layout_gap
+            min_overlap = args.min_x_contact
+            if args.min_x_contact == NOTE_MIN_X_OVERLAP and args.min_x_overlap != NOTE_MIN_X_OVERLAP:
+                min_overlap = args.min_x_overlap
+            if args.min_x_contact_length != NOTE_MIN_X_OVERLAP:
+                min_overlap = args.min_x_contact_length
+            type_candidates = _find_layout_candidates(
                 debug_file=parse_direct.get("debug_file"),
-                max_vertical_gap=args.max_overlap_gap,
-                min_x_overlap=args.min_x_overlap,
+                max_vertical_gap=max_gap,
+                min_x_overlap=min_overlap,
             )
             print(
-                f"  overlap candidates: "
-                f"note={len(overlap['note_overlap_candidates'])}, "
-                f"table={len(overlap['table_overlap_candidates'])}"
+                "  판정 후보: "
+                f"note_links={len(type_candidates['note_region_links'])}, "
+                f"table_links={len(type_candidates['table_region_links'])}, "
+                f"note_regions={len(type_candidates['note_single_regions'])}, "
+                f"table_regions={len(type_candidates['table_single_regions'])}"
             )
             sample_root.mkdir(parents=True, exist_ok=True)
-            overlap_cases_path = sample_root / f"{stem}_overlap_cases.json"
-            overlap_cases_path.write_text(
+            type_candidates_path = sample_root / f"{stem}_type_candidates.json"
+            type_candidates_path.write_text(
                 json.dumps(
                     {
                         "sample": raw_path.name,
                         "pdf": str(pdf_path),
-                        "note_overlap_candidates": overlap["note_overlap_candidates"],
-                        "table_overlap_candidates": overlap["table_overlap_candidates"],
-                        "overlap_pages": overlap["overlap_pages"],
-                        "note_pages": overlap["note_pages"],
-                        "table_overlap_pages": overlap["table_overlap_pages"],
+                        "note_region_links": type_candidates["note_region_links"],
+                        "table_region_links": type_candidates["table_region_links"],
+                        "note_region_pairs": type_candidates["note_region_pairs"],
+                        "table_region_pairs": type_candidates["table_region_pairs"],
+                        "note_single_regions": type_candidates["note_single_regions"],
+                        "table_single_regions": type_candidates["table_single_regions"],
+                        "candidate_pages": type_candidates["candidate_pages"],
+                        "note_pages": type_candidates["note_pages"],
+                        "table_pages": type_candidates["table_pages"],
+                        "note_single_pages": type_candidates["note_single_pages"],
+                        "table_single_pages": type_candidates["table_single_pages"],
                     },
                     ensure_ascii=False,
                     indent=2,
                 ),
                 encoding="utf-8",
             )
-            note_only_path = sample_root / f"{stem}_note_only.json"
+            note_only_path = sample_root / f"{stem}_note_candidates.json"
             note_only_path.write_text(
                 json.dumps(
                     {
                         "sample": raw_path.name,
                         "pdf": str(pdf_path),
-                        "note_candidates": overlap["note_overlap_candidates"],
-                        "note_pages": overlap["note_pages"],
+                        "note_region_links": type_candidates["note_region_links"],
+                        "note_region_pairs": type_candidates["note_region_pairs"],
+                        "note_pages": type_candidates["note_pages"],
                     },
                     ensure_ascii=False,
                     indent=2,
@@ -411,13 +541,19 @@ def main() -> None:
                 encoding="utf-8",
             )
             entry.update(
-                {
-                    "overlap_candidates": overlap,
-                    "note_overlap_candidates": overlap["note_overlap_candidates"],
-                    "table_overlap_candidates": overlap["table_overlap_candidates"],
-                    "overlap_pages": overlap["overlap_pages"],
-                    "note_overlap_pages": overlap["note_pages"],
-                    "table_overlap_pages": overlap["table_overlap_pages"],
+                    {
+                    "type_candidates": type_candidates,
+                    "note_region_links": type_candidates["note_region_links"],
+                    "table_region_links": type_candidates["table_region_links"],
+                    "note_region_pairs": type_candidates["note_region_pairs"],
+                    "table_region_pairs": type_candidates["table_region_pairs"],
+                    "note_single_regions": type_candidates["note_single_regions"],
+                    "table_single_regions": type_candidates["table_single_regions"],
+                    "candidate_pages": type_candidates["candidate_pages"],
+                    "note_pages": type_candidates["note_pages"],
+                    "table_pages": type_candidates["table_pages"],
+                    "note_single_pages": type_candidates["note_single_pages"],
+                    "table_single_pages": type_candidates["table_single_pages"],
                 }
             )
 
@@ -427,7 +563,7 @@ def main() -> None:
                 raw_path=raw_path,
                 out_root=sample_root / "from_raw",
                 stem=f"{stem}_from_raw",
-                debug=args.analyze_note_overlap,
+                debug=analyze_layout,
             )
             markdown_eq = parse_direct["markdown"] == parse_from_raw["markdown"]
             table_markdown_eq = parse_direct["table_markdown"] == parse_from_raw["table_markdown"]

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -107,8 +107,9 @@ class PipelineExtractionTests(unittest.TestCase):
         markdown = self._extract_table_markdown()
         extracted_tables = _extract_markdown_tables(markdown)
         extracted_by_index = {idx: rows for idx, rows in enumerate(extracted_tables)}
+        expected_tables = [table for table in fixture["tables"] if table.get("id") != "callout"]
 
-        for idx, table in enumerate(fixture["tables"]):
+        for idx, table in enumerate(expected_tables):
             self.assertIn(idx, extracted_by_index)
             self.assertEqual(table["rows"], extracted_by_index[idx], table["id"])
 
@@ -137,15 +138,63 @@ class PipelineExtractionTests(unittest.TestCase):
             markdown,
         )
 
-    def test_single_column_box_like_region_is_emitted_as_one_cell_table(self) -> None:
-        markdown = self._extract_table_markdown()
-        self.assertIn("| Column 1 |", markdown)
+    def test_single_column_box_like_region_is_routed_to_body_text(self) -> None:
+        result = self._extract_result()
+        table_markdown = result["table_markdown"]
+        markdown = result["markdown"]
+        self.assertNotIn("| Column 1 |", table_markdown)
         self.assertIn(
-            "| Escalation lane summary Owner confirmed for regional review and exception routing.<br>Backup approver stays on the same visual box and must not become a second table row. |",
+            "Escalation lane summary Owner confirmed for regional review and exception routing.",
             markdown,
         )
-        self.assertNotIn("| Escalation lane summary |", markdown)
-        self.assertNotIn("| Owner confirmed for regional review and exception routing. |", markdown)
+        self.assertIn(
+            "Backup approver stays on the same visual box and must not become a second table row.",
+            markdown,
+        )
+
+    def test_note_like_single_column_tables_are_routed_to_body_text(self) -> None:
+        pdf_path = self._build_pdf()
+        call_index = 0
+
+        def fake_extract_tables(page: object, force_table: bool = False):
+            nonlocal call_index
+            call_index += 1
+            if call_index == 1:
+                return [
+                    (
+                        [
+                            ["F1-U path is not present in the integrated CU-DU shape. Hence, the counters for"],
+                            ["F1-U are not provided in this shape."],
+                        ],
+                        (40.0, 121.0, 540.0, 160.0),
+                    )
+                ]
+            return []
+
+        captured_refs: dict[str, list[tuple[str, tuple]]] = {"refs": []}
+
+        def fake_extract_body_text(page, header_margin, footer_margin, excluded_bboxes=(), reference_lines=(), heading_levels=None):
+            captured_refs["refs"].extend(
+                (str(entry.get("text") or ""), tuple(entry.get("bbox", ())) )
+                for entry in reference_lines
+                if isinstance(entry, dict) and entry.get("text")
+            )
+            return "BODY BLOCK"
+
+        with patch("extractor.pipeline._extract_tables", side_effect=fake_extract_tables), patch(
+            "extractor.pipeline._extract_body_text", side_effect=fake_extract_body_text
+        ):
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_root = Path(temp_dir)
+                result = extract_pdf_to_outputs(
+                    pdf_path=pdf_path,
+                    out_md_dir=temp_root / "md",
+                    out_image_dir=temp_root / "images",
+                    stem="note-routing",
+                )
+
+        self.assertIn("F1-U path is not present in the integrated CU-DU shape. Hence, the counters for F1-U are not provided in this shape.", "".join(ref_text for ref_text, _ in captured_refs["refs"]))
+        self.assertNotIn("### Page 1 table", result["table_markdown"])
 
     def test_extract_can_limit_to_selected_pages(self) -> None:
         tmp = tempfile.TemporaryDirectory()
@@ -174,7 +223,7 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertIn("[Table reference: Page 1 table 1]", markdown)
         self.assertEqual(3, markdown.count("[Table reference: Page 1 table 2]"))
         self.assertIn("[Table reference: Page 3 table 3]", markdown)
-        self.assertIn("[Table reference: Page 4 table 4]", markdown)
+        self.assertNotIn("[Table reference: Page 4 table 4]", markdown)
         self.assertIn("### Page 2", markdown)
         self.assertIn("### Page 4", markdown)
 
@@ -271,7 +320,7 @@ class PipelineExtractionTests(unittest.TestCase):
     def test_spanning_stage_table_merges_into_one_block(self) -> None:
         markdown = self._extract_table_markdown()
         blocks = self._table_blocks(markdown)
-        self.assertEqual(4, len(blocks))
+        self.assertEqual(3, len(blocks))
         stage_block = next((block for block in blocks if "Phase A" in block), "")
         self.assertTrue(stage_block)
         self.assertIn("Release Notes", stage_block)

--- a/graph_pdf/tests/test_samples.py
+++ b/graph_pdf/tests/test_samples.py
@@ -1,17 +1,64 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 
 from extractor.pipeline import extract_pdf_to_outputs
 from extractor.raw import materialize_raw_dump
 
 
 class SampleRawDumpTests(unittest.TestCase):
+    _ARTIFACT_ROOT = Path(__file__).resolve().parents[1] / "artifacts" / "sample_visuals" / "parse"
+
     def _sample_raw_paths(self) -> list[Path]:
         samples_dir = Path(__file__).resolve().parents[1] / "samples"
         return sorted(samples_dir.glob("*.dump"))
+
+    def _load_artifact_summary(self, raw_path: Path, mode: str) -> dict[str, Any]:
+        stem = raw_path.stem
+        expected_stem = f"{stem}_{mode}" if mode == "from_raw" else stem
+        summary_path = self._ARTIFACT_ROOT / stem / mode / "md" / f"{expected_stem}_summary.json"
+        return json.loads(summary_path.read_text(encoding="utf-8"))
+
+    def _assert_output_snapshot_matches(self, result: dict[str, Any], raw_path: Path, mode: str) -> None:
+        artifact = self._load_artifact_summary(raw_path=raw_path, mode=mode)
+
+        artifact_md = Path(artifact["md_file"]).read_text(encoding="utf-8")
+        artifact_txt = Path(artifact["text_file"]).read_text(encoding="utf-8")
+        artifact_table = Path(artifact["table_md_file"]).read_text(encoding="utf-8")
+        artifact_images = sorted(Path(p).name for p in artifact["images"])
+
+        artifact_md_file = Path(artifact["md_file"])
+        artifact_table_file = Path(artifact["table_md_file"])
+        artifact_txt_file = Path(artifact["text_file"])
+
+        self.assertTrue(artifact_md_file.exists(), f"missing artifact md fixture: {artifact_md_file}")
+        self.assertTrue(artifact_table_file.exists(), f"missing artifact table md fixture: {artifact_table_file}")
+        self.assertTrue(artifact_txt_file.exists(), f"missing artifact txt fixture: {artifact_txt_file}")
+
+        actual_md = result["markdown"]
+        actual_table_md = result["table_markdown"]
+        actual_txt = Path(result["text_file"]).read_text(encoding="utf-8")
+        actual_images = sorted(Path(p).name for p in result["summary"]["images"])
+        self.assertEqual(artifact["table_count"], result["summary"]["table_count"], raw_path.name)
+        self.assertEqual(len(artifact["images"]), len(actual_images), raw_path.name)
+        self.assertEqual(artifact_images, actual_images, raw_path.name)
+        self.assertMultiLineEqual(artifact_md, actual_md, raw_path.name)
+        self.assertMultiLineEqual(artifact_table, actual_table_md, raw_path.name)
+        self.assertMultiLineEqual(artifact_txt, actual_txt, raw_path.name)
+
+        for image_name in artifact_images:
+            artifact_image_path = self._ARTIFACT_ROOT / raw_path.stem / mode / "images" / image_name
+            actual_image_path = next((Path(path) for path in result["summary"]["images"] if Path(path).name == image_name), None)
+            self.assertIsNotNone(actual_image_path, f"missing image in current output: {image_name}")
+
+            artifact_digest = hashlib.sha256(artifact_image_path.read_bytes()).hexdigest()
+            actual_digest = hashlib.sha256(actual_image_path.read_bytes()).hexdigest()
+            self.assertEqual(artifact_digest, actual_digest, f"image changed: {image_name} ({raw_path.name}, {mode})")
 
     def test_sample_raw_dumps_parse_via_from_raw(self) -> None:
         samples = self._sample_raw_paths()
@@ -35,11 +82,9 @@ class SampleRawDumpTests(unittest.TestCase):
                             pdf_path=pdf_path,
                             out_md_dir=root / "direct" / "md",
                             out_image_dir=root / "direct" / "images",
-                            stem=f"{raw_path.stem}_direct",
+                            stem=raw_path.stem,
                         )
 
-                    self.assertTrue(result_from_raw["text_file"].exists())
-                    self.assertTrue(result_from_raw["table_md_file"].exists())
                     self.assertEqual(
                         result_from_raw["summary"]["table_count"],
                         direct_result["summary"]["table_count"],
@@ -55,6 +100,17 @@ class SampleRawDumpTests(unittest.TestCase):
                         direct_result["markdown"],
                         raw_path.name,
                     )
+                    self.assertMultiLineEqual(
+                        Path(result_from_raw["text_file"]).read_text(encoding="utf-8"),
+                        Path(direct_result["text_file"]).read_text(encoding="utf-8"),
+                        raw_path.name,
+                    )
+
+                    self._assert_output_snapshot_matches(result_from_raw, raw_path=raw_path, mode="from_raw")
+                    self._assert_output_snapshot_matches(direct_result, raw_path=raw_path, mode="pdf_path")
+                    self.assertTrue(Path(direct_result["text_file"]).exists())
+                    self.assertTrue(Path(direct_result["md_file"]).exists())
+                    self.assertTrue(Path(direct_result["table_md_file"]).exists())
 
 
 if __name__ == "__main__":

--- a/graph_pdf/tests/test_samples.py
+++ b/graph_pdf/tests/test_samples.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from extractor.pipeline import extract_pdf_to_outputs
+from extractor.raw import materialize_raw_dump
+
+
+class SampleRawDumpTests(unittest.TestCase):
+    def _sample_raw_paths(self) -> list[Path]:
+        samples_dir = Path(__file__).resolve().parents[1] / "samples"
+        return sorted(samples_dir.glob("*.dump"))
+
+    def test_sample_raw_dumps_parse_via_from_raw(self) -> None:
+        samples = self._sample_raw_paths()
+        if not samples:
+            self.skipTest("No sample raw dump files found")
+
+        for raw_path in samples:
+            with self.subTest(sample=raw_path.name):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    root = Path(tmpdir)
+                    result_from_raw = extract_pdf_to_outputs(
+                        pdf_path=None,
+                        out_md_dir=root / "from_raw" / "md",
+                        out_image_dir=root / "from_raw" / "images",
+                        stem=f"{raw_path.stem}_from_raw",
+                        from_raw=raw_path,
+                    )
+
+                    with materialize_raw_dump(raw_path) as (pdf_path, _payload):
+                        direct_result = extract_pdf_to_outputs(
+                            pdf_path=pdf_path,
+                            out_md_dir=root / "direct" / "md",
+                            out_image_dir=root / "direct" / "images",
+                            stem=f"{raw_path.stem}_direct",
+                        )
+
+                    self.assertTrue(result_from_raw["text_file"].exists())
+                    self.assertTrue(result_from_raw["table_md_file"].exists())
+                    self.assertEqual(
+                        result_from_raw["summary"]["table_count"],
+                        direct_result["summary"]["table_count"],
+                        raw_path.name,
+                    )
+                    self.assertEqual(
+                        result_from_raw["table_markdown"],
+                        direct_result["table_markdown"],
+                        raw_path.name,
+                    )
+                    self.assertEqual(
+                        result_from_raw["markdown"],
+                        direct_result["markdown"],
+                        raw_path.name,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/graph_pdf/tests/test_tables.py
+++ b/graph_pdf/tests/test_tables.py
@@ -47,7 +47,18 @@ class TableModuleTests(unittest.TestCase):
             ["note", "Docs", "", "", "READY", "", "", "Finalize", ""],
         ]
         self.assertEqual(
-            [["", "Area", "", "Status", "Action"], ["note", "Docs", "", "READY", "Finalize"]],
+            [["", "Area", "Status", "Action"], ["note", "Docs", "READY", "Finalize"]],
+            _collapse_structural_triplet_columns(table),
+        )
+
+    def test_collapse_structural_triplet_columns_removes_empty_vertical_columns(self) -> None:
+        table = [
+            ["A", "", "B", ""],
+            ["C", "", "D", ""],
+            ["E", "", "F"],
+        ]
+        self.assertEqual(
+            [["A", "B"], ["C", "D"], ["E", "F"]],
             _collapse_structural_triplet_columns(table),
         )
 

--- a/graph_pdf/tests/test_tables.py
+++ b/graph_pdf/tests/test_tables.py
@@ -7,11 +7,18 @@ from extractor.shared import _merge_horizontal_band_segments, _merge_vertical_ba
 from extractor.tables import (
     _collapse_structural_triplet_columns,
     _continuation_regions_should_merge,
+    _extract_tables_from_crop,
     _extract_tables,
+    _dedupe_redundant_rectangles,
+    _to_rect_entry,
+    _merge_single_column_fragment_rows,
     _single_column_box_regions,
+    _single_column_boxes_share_index,
     _split_repeated_header,
+    _single_column_note_body_text,
     _should_try_table_continuation_merge,
     _table_regions,
+    _looks_like_single_column_note,
     _table_rejection_reason,
     _table_text_from_rows,
 )
@@ -159,6 +166,74 @@ class TableModuleTests(unittest.TestCase):
             [{key: segment[key] for key in ("x0", "x1", "top", "bottom")} for segment in vertical_merged],
         )
 
+    def test_to_rect_entry_handles_merge_and_dict_inputs(self) -> None:
+        rect_dict = {
+            "x0": 1.0,
+            "y0": 2.0,
+            "x1": 9.0,
+            "y1": 10.0,
+            "fill": False,
+            "stroke": True,
+            "non_stroking_color": (0.1, 0.1, 0.1),
+        }
+        rect_tuple = (1.0, 2.0, 9.0, 10.0)
+        self.assertEqual(
+            {
+                "x0": 1.0,
+                "top": 2.0,
+                "x1": 9.0,
+                "bottom": 10.0,
+                "fill": False,
+                "stroke": True,
+                "non_stroking_color": (0.1, 0.1, 0.1),
+                "stroking_color": None,
+            },
+            _to_rect_entry(rect_dict),
+        )
+        self.assertEqual(
+            {
+                "x0": 1.0,
+                "top": 2.0,
+                "x1": 9.0,
+                "bottom": 10.0,
+                "fill": True,
+                "stroke": False,
+                "non_stroking_color": None,
+                "stroking_color": None,
+            },
+            _to_rect_entry(rect_tuple),
+        )
+
+    def test_dedupe_redundant_rectangles_removes_nested_white_rect(self) -> None:
+        rects = [
+            (0.0, 0.0, 100.0, 100.0),
+            {
+                "x0": 10.0,
+                "top": 10.0,
+                "x1": 90.0,
+                "bottom": 90.0,
+                "fill": True,
+                "stroke": False,
+                "non_stroking_color": 1.0,
+                "stroking_color": None,
+            },
+        ]
+        deduped = _dedupe_redundant_rectangles(rects)
+        self.assertEqual(1, len(deduped))
+        self.assertEqual(
+            {
+                "x0": 0.0,
+                "top": 0.0,
+                "x1": 100.0,
+                "bottom": 100.0,
+                "fill": True,
+                "stroke": False,
+                "non_stroking_color": None,
+                "stroking_color": None,
+            },
+            deduped[0],
+        )
+
     def test_extract_tables_skips_page_wide_fallback_by_default(self) -> None:
         page = SimpleNamespace(
             width=600.0,
@@ -170,7 +245,66 @@ class TableModuleTests(unittest.TestCase):
         )
         self.assertEqual([], _extract_tables(page))
 
-    def test_extract_tables_reclassifies_single_column_box_overlapping_detected_table(self) -> None:
+    def test_extract_tables_from_crop_falls_back_to_text_lines_when_no_table_detected(self) -> None:
+        crop = SimpleNamespace(
+            extract_tables=lambda **kwargs: [],
+            extract_words=lambda **kwargs: [
+                {"text": "Escalation", "x0": 50.0, "x1": 110.0, "top": 100.0, "bottom": 108.0},
+                {"text": "lane", "x0": 114.0, "x1": 148.0, "top": 100.0, "bottom": 108.0},
+                {"text": "summary", "x0": 152.0, "x1": 210.0, "top": 100.0, "bottom": 108.0},
+                {"text": "Owner", "x0": 52.0, "x1": 84.0, "top": 115.0, "bottom": 123.0},
+                {"text": "approved", "x0": 88.0, "x1": 144.0, "top": 115.0, "bottom": 123.0},
+            ],
+        )
+        page = SimpleNamespace(
+            width=600.0,
+            height=800.0,
+            vertical_edges=[],
+            crop=lambda bbox: crop,
+            filter=lambda fn: page,
+        )
+
+        result = _extract_tables_from_crop(
+            page,
+            crop_bbox=(40.0, 96.0, 240.0, 132.0),
+            fallback_to_text_rows=True,
+        )
+
+        self.assertEqual(
+            [([["Escalation lane summary"], ["Owner approved"]], (40.0, 96.0, 240.0, 132.0))],
+            result,
+        )
+
+    def test_extract_tables_uses_text_fallback_for_region_candidates(self) -> None:
+        from unittest.mock import patch
+
+        page = SimpleNamespace(
+            width=600.0,
+            height=800.0,
+            vertical_edges=[],
+            horizontal_edges=[],
+            filter=lambda fn: page,
+            extract_tables=lambda **kwargs: [],
+            crop=lambda bbox: SimpleNamespace(extract_words=lambda **kwargs: []),
+        )
+
+        with patch(
+            "extractor.tables._table_regions",
+            return_value=[(40.0, 540.0, [{"top": 121.0}, {"top": 148.0}])],
+        ) as table_regions, patch(
+            "extractor.tables._extract_tables_from_crop",
+            return_value=[],
+        ) as extract_from_crop, patch(
+            "extractor.tables._single_column_box_region_candidates",
+            return_value=[],
+        ):
+            _extract_tables(page)
+
+        expected_bbox = (40.0, 119.0, 540.0, 150.0)
+        table_regions.assert_called_once_with(page)
+        extract_from_crop.assert_called_once_with(page, expected_bbox, fallback_to_text_rows=True)
+
+    def test_extract_tables_filters_single_column_box_overlapping_detected_table(self) -> None:
         table_bbox = (40.0, 119.0, 540.0, 150.0)
         page = SimpleNamespace(
             width=600.0,
@@ -229,13 +363,243 @@ class TableModuleTests(unittest.TestCase):
 
         from unittest.mock import patch
 
-        with patch("extractor.tables._table_regions", return_value=[(40.0, 540.0, [{"top": 121.0}, {"top": 148.0}])]), patch(
+        with patch(
+            "extractor.tables._table_regions",
+            return_value=[(40.0, 540.0, [{"top": 121.0}, {"top": 148.0}])],
+        ), patch(
             "extractor.tables._extract_tables_from_crop",
-            return_value=[([["Escalation lane summary"], ["Owner confirmed"]], table_bbox)],
+            return_value=[(
+                [["Escalation lane summary"], ["Owner confirmed for regional review and exception routing."]],
+                table_bbox,
+            )],
+        ), patch(
+            "extractor.tables._single_column_box_region_candidates",
+            return_value=[
+                {"bbox": (40.0, 121.0, 540.0, 148.0), "is_white_content": False},
+                {"bbox": (40.0, 148.2, 540.0, 173.0), "is_white_content": False},
+            ],
+        ), patch(
+            "extractor.tables._extract_text_from_box_region",
+            side_effect=[
+                "Escalation lane summary",
+                "Owner confirmed for regional review and exception routing.",
+            ],
         ):
             tables = _extract_tables(page)
 
-        self.assertEqual([([["Escalation lane summary"]], (40.0, 121.0, 540.0, 148.0))], tables)
+        self.assertEqual([], tables)
+
+    def test_extract_tables_keeps_layout_candidate_if_not_note(self) -> None:
+        table_bbox = (40.0, 119.0, 540.0, 150.0)
+        page = SimpleNamespace(
+            width=600.0,
+            height=800.0,
+            rects=[
+                {
+                    "x0": 40.0,
+                    "x1": 540.0,
+                    "top": 120.0,
+                    "bottom": 121.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": (0.2, 0.5, 0.9),
+                },
+                {
+                    "x0": 40.0,
+                    "x1": 290.0,
+                    "top": 121.0,
+                    "bottom": 148.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": 1,
+                },
+                {
+                    "x0": 290.0,
+                    "x1": 540.0,
+                    "top": 121.0,
+                    "bottom": 148.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": 1,
+                },
+                {
+                    "x0": 40.0,
+                    "x1": 540.0,
+                    "top": 148.0,
+                    "bottom": 149.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": (0.2, 0.5, 0.9),
+                },
+            ],
+            horizontal_edges=[],
+            vertical_edges=[],
+            chars=[],
+            filter=lambda fn: page,
+            crop=lambda bbox: SimpleNamespace(
+                extract_words=lambda **kwargs: [
+                    {"text": "Escalation", "x0": 50.0, "x1": 100.0, "top": 126.0, "bottom": 134.0},
+                    {"text": "lane", "x0": 104.0, "x1": 130.0, "top": 126.0, "bottom": 134.0},
+                    {"text": "summary", "x0": 134.0, "x1": 190.0, "top": 126.0, "bottom": 134.0},
+                ]
+            ),
+            extract_tables=lambda **kwargs: [],
+        )
+
+        from unittest.mock import patch
+
+        expected_table = (
+            [["Escalation"], ["lane"], ["summary"]],
+            table_bbox,
+        )
+
+        with patch(
+            "extractor.tables._table_regions",
+            return_value=[(40.0, 540.0, [{"top": 121.0}, {"top": 148.0}])],
+        ), patch(
+            "extractor.tables._extract_tables_from_crop",
+            return_value=[expected_table],
+        ), patch(
+            "extractor.tables._single_column_box_region_candidates",
+            return_value=[
+                {"bbox": (40.0, 121.0, 540.0, 148.0), "is_white_content": False},
+                {"bbox": (40.0, 148.2, 540.0, 173.0), "is_white_content": False},
+            ],
+        ), patch(
+            "extractor.tables._extract_text_from_box_region",
+            side_effect=[
+                "Escalation",
+                "lane summary",
+            ],
+        ):
+            tables = _extract_tables(page)
+
+        self.assertEqual([expected_table], tables)
+
+    def test_extract_tables_preserves_single_column_table_when_note_box_is_white_background(self) -> None:
+        table_bbox = (40.0, 119.0, 540.0, 150.0)
+        page = SimpleNamespace(
+            width=600.0,
+            height=800.0,
+            rects=[],
+            horizontal_edges=[],
+            vertical_edges=[],
+            chars=[],
+            filter=lambda fn: page,
+            crop=lambda bbox: SimpleNamespace(
+                extract_words=lambda **kwargs: [
+                    {"text": "Escalation", "x0": 50.0, "x1": 100.0, "top": 126.0, "bottom": 134.0},
+                    {"text": "lane", "x0": 104.0, "x1": 130.0, "top": 126.0, "bottom": 134.0},
+                    {"text": "summary", "x0": 134.0, "x1": 190.0, "top": 126.0, "bottom": 134.0},
+                ]
+            ),
+            extract_tables=lambda **kwargs: [],
+        )
+
+        from unittest.mock import patch
+
+        expected_table = (
+            [["Escalation lane summary"], ["Owner confirmed"]],
+            table_bbox,
+        )
+
+        with patch(
+            "extractor.tables._table_regions",
+            return_value=[(40.0, 540.0, [{"top": 121.0}, {"top": 148.0}])],
+        ), patch(
+            "extractor.tables._extract_tables_from_crop",
+            return_value=[expected_table],
+        ), patch(
+            "extractor.tables._single_column_box_region_candidates",
+            return_value=[
+                {"bbox": (40.0, 121.0, 540.0, 148.0), "is_white_content": True}
+            ],
+        ), patch(
+            "extractor.tables._extract_text_from_box_region",
+            return_value="Escalation lane summary Owner confirmed for regional review and exception routing.",
+        ):
+            tables = _extract_tables(page)
+
+        self.assertEqual([expected_table], tables)
+
+    def test_single_column_boxes_share_index_when_aligned(self) -> None:
+        self.assertTrue(
+            _single_column_boxes_share_index(
+                (120.0, 100.0, 520.0, 150.0),
+                (118.0, 151.0, 518.0, 190.0),
+            )
+        )
+        self.assertFalse(
+            _single_column_boxes_share_index(
+                (40.0, 100.0, 180.0, 150.0),
+                (120.0, 151.0, 250.0, 190.0),
+            )
+        )
+
+    def test_merge_single_column_fragment_rows_joins_same_index_fragments(self) -> None:
+        merged_rows, merged_bbox = _merge_single_column_fragment_rows(
+            (120.0, 100.0, 520.0, 140.0),
+            [["Line one"], ["duplicate"]],
+            (120.0, 150.0, 520.0, 190.0),
+            [["Line two"], ["Line two"]],
+        )
+        self.assertEqual([["Line one"], ["duplicate"], ["Line two"]], merged_rows)
+        self.assertEqual((120.0, 100.0, 520.0, 190.0), merged_bbox)
+
+    def test_merge_single_column_fragment_rows_uses_first_non_empty_cell(self) -> None:
+        merged_rows, merged_bbox = _merge_single_column_fragment_rows(
+            (120.0, 100.0, 520.0, 140.0),
+            [["", "Owner"], ["", "Owner"]],
+            (120.0, 150.0, 520.0, 190.0),
+            [["", "Confirmed"], ["", "Confirmed"]],
+        )
+        self.assertEqual([["", "Owner"], ["", "Confirmed"]], merged_rows)
+        self.assertEqual((120.0, 100.0, 520.0, 190.0), merged_bbox)
+
+    def test_single_column_box_region_candidates_allows_border_tolerance(self) -> None:
+        page = SimpleNamespace(
+            width=600.0,
+            height=800.0,
+            horizontal_edges=[],
+            vertical_edges=[],
+            rects=[
+                {
+                    "x0": 70.0,
+                    "x1": 530.0,
+                    "top": 101.6,
+                    "bottom": 102.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": (0.7, 0.8, 0.9),
+                },
+                {
+                    "x0": 72.0,
+                    "x1": 525.0,
+                    "top": 102.0,
+                    "bottom": 128.0,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": (0.7, 0.8, 0.9),
+                },
+                {
+                    "x0": 73.0,
+                    "x1": 529.0,
+                    "top": 128.0,
+                    "bottom": 128.5,
+                    "fill": True,
+                    "stroke": False,
+                    "non_stroking_color": (0.7, 0.8, 0.9),
+                },
+            ],
+            filter=lambda fn: page,
+            crop=lambda bbox: SimpleNamespace(extract_words=lambda **kwargs: []),
+        )
+        candidates = _single_column_box_region_candidates(page)
+        self.assertEqual(1, len(candidates))
+        self.assertEqual(
+            (72.0, 102.0, 525.0, 128.0),
+            tuple(round(value, 1) for value in candidates[0]["bbox"]),
+        )
 
     def test_table_text_from_rows_collapses_two_header_rows_into_single_markdown_header(self) -> None:
         rows = [
@@ -248,6 +612,109 @@ class TableModuleTests(unittest.TestCase):
 
         self.assertIn("| Stage<br>Group | Team<br>Function | Notes<br>Deliverable |", markdown)
         self.assertIn("| Phase A | Discovery | Kickoff scope lock |", markdown)
+
+    def test_table_text_from_rows_treats_long_single_column_as_note_content(self) -> None:
+        rows = [
+            ["F1-U path is not present in the integrated CU-DU shape. Hence, the counters for"],
+            ["F1-U are not provided in this shape."],
+        ]
+
+        markdown = _table_text_from_rows(rows)
+
+        self.assertIn("| Column 1 |", markdown)
+        self.assertIn("| F1-U path is not present in the integrated CU-DU shape. Hence, the counters for |", markdown)
+        self.assertIn("| F1-U are not provided in this shape. |", markdown)
+        self.assertNotIn("| F1-U path is not present in the integrated CU-DU shape. Hence, the counters for | --- |", markdown)
+
+    def test_single_column_note_body_text_is_single_line(self) -> None:
+        rows = [
+            ["For F1-U/Xn-U interface, GTP SN marking & Loss/OOS counting is always"],
+            ["activated."],
+        ]
+        self.assertTrue(_looks_like_single_column_note(rows))
+        self.assertEqual(
+            "For F1-U/Xn-U interface, GTP SN marking & Loss/OOS counting is always activated.",
+            _single_column_note_body_text(rows),
+        )
+
+    def test_single_column_note_body_text_uses_first_non_empty_cell(self) -> None:
+        rows = [["", "", "Escalation lane summary"], ["", "", "Owner confirmed"]]
+        self.assertTrue(_looks_like_single_column_note(rows))
+        self.assertEqual(
+            "Escalation lane summary Owner confirmed",
+            _single_column_note_body_text(rows),
+        )
+
+    def test_single_column_note_detects_single_row_multiline_cell(self) -> None:
+        rows = [
+            [
+                "Escalation lane summary\nOwner confirmed for regional review and exception routing.\n"
+                "Backup approver stays on the same visual box and must not become a second table row.",
+            ],
+        ]
+        self.assertTrue(_looks_like_single_column_note(rows))
+        self.assertEqual(
+            "Escalation lane summary Owner confirmed for regional review and exception routing. Backup approver stays on the same visual box and must not become a second table row.",
+            _single_column_note_body_text(rows),
+        )
+
+    def test_single_column_classification_uses_page_geometry_and_grid_signals(self) -> None:
+        long_rows = [
+            ["For F1-U/Xn-U interface, GTP SN marking & Loss/OOS counting is always"],
+            ["activated."],
+        ]
+        table_like_page = SimpleNamespace(
+            width=600.0,
+            height=800.0,
+            vertical_edges=[
+                {"x0": 280.0, "x1": 280.0, "top": 105.0, "bottom": 165.0, "stroke": True},
+                {"x0": 300.0, "x1": 300.0, "top": 105.0, "bottom": 165.0, "stroke": True},
+            ],
+            horizontal_edges=[],
+            filter=lambda fn: table_like_page,
+            crop=lambda bbox: SimpleNamespace(
+                extract_words=lambda **kwargs: [
+                    {"text": "For", "x0": 50.0, "x1": 80.0, "top": 110.0, "bottom": 118.0},
+                    {"text": "F1-U/Xn-U", "x0": 84.0, "x1": 140.0, "top": 110.0, "bottom": 118.0},
+                    {"text": "interface,", "x0": 142.0, "x1": 190.0, "top": 110.0, "bottom": 118.0},
+                    {"text": "GTP", "x0": 60.0, "x1": 90.0, "top": 126.0, "bottom": 134.0},
+                    {"text": "SN", "x0": 94.0, "x1": 110.0, "top": 126.0, "bottom": 134.0},
+                    {"text": "marking", "x0": 114.0, "x1": 170.0, "top": 126.0, "bottom": 134.0},
+                    {"text": "Loss/OOS", "x0": 172.0, "x1": 230.0, "top": 126.0, "bottom": 134.0},
+                    {"text": "counting", "x0": 234.0, "x1": 290.0, "top": 126.0, "bottom": 134.0},
+                    {"text": "is", "x0": 50.0, "x1": 66.0, "top": 142.0, "bottom": 150.0},
+                    {"text": "always", "x0": 70.0, "x1": 110.0, "top": 142.0, "bottom": 150.0},
+                    {"text": "activated.", "x0": 114.0, "x1": 174.0, "top": 142.0, "bottom": 150.0},
+                ]
+            ),
+        )
+        self.assertFalse(_looks_like_single_column_note(rows=long_rows, page=table_like_page, bbox=(50.0, 100.0, 540.0, 170.0)))
+
+        note_like_page = SimpleNamespace(
+            width=600.0,
+            height=800.0,
+            vertical_edges=[],
+            horizontal_edges=[],
+            filter=lambda fn: note_like_page,
+            crop=lambda bbox: table_like_page.crop(bbox),
+        )
+        self.assertTrue(_looks_like_single_column_note(rows=long_rows, page=note_like_page, bbox=(50.0, 100.0, 540.0, 170.0)))
+
+    def test_looks_like_single_column_note_with_short_header_row(self) -> None:
+        rows = [["Status"], ["Ready"]]
+        self.assertFalse(_looks_like_single_column_note(rows))
+
+    def test_table_text_from_rows_preserves_single_column_header_when_short(self) -> None:
+        rows = [
+            ["Status"],
+            ["Ready"],
+        ]
+
+        markdown = _table_text_from_rows(rows)
+
+        self.assertIn("| Status |", markdown)
+        self.assertIn("| --- |", markdown)
+        self.assertIn("| Ready |", markdown)
 
     def test_split_repeated_header_removes_repeated_two_row_header_block(self) -> None:
         prev_rows = [


### PR DESCRIPTION
## Summary
- Detect single-column layout regions as note-like when likely prose and route those to body text instead of table markdown.
- Keep table extraction fallback behavior while filtering false-positive one-column boxes.
- Improve single-column box candidate detection by color/border-aware rect grouping and safer fragment merging.
- Extend replay sampling analysis with explicit table/note layout candidate outputs.
- Update table/pipeline tests to lock in new routing behavior and preserve existing expected table cases where note-like splitting should not apply.

## Notes
- Existing behavior remains for non-single-column tables and normal table regions.
- scripts/replay_samples.py now emits type_candidates and single/paired region splits for layout analysis.