### PR TITLE
chore: format page markers as markdown comments and drop default h4 font 12

### DIFF
--- a/graph_pdf/README.md
+++ b/graph_pdf/README.md
@@ -47,6 +47,7 @@ python3 extractor/__main__.py sample.pdf \
 - `--add-heading <path>`: 외부 JSON의 `font_size -> h1~h6` 규칙으로 body markdown heading 추가
 - `--raw <path>`: 선택 페이지 기준 문서 PDF base64만 저장하는 최소 raw dump 생성
 - `--from-raw <path>`: raw dump 파일을 입력으로 읽어 기존 추출 파이프라인 실행
+- `--page-write`: 기본 md 출력에서 페이지 구분 주석(`[//]: # (Page N)`) 생략을 해제하고 페이지 주석을 출력
 
 ### 직접 실행 예시
 ```bash

--- a/graph_pdf/docs/raw-38-50-note-table-continuation-memo.md
+++ b/graph_pdf/docs/raw-38-50-note-table-continuation-memo.md
@@ -1,0 +1,18 @@
+# raw-38-50 노트/표 분류 메모
+
+## 대상 샘플
+- `samples/raw-38-50.dump` (재생성 PDF 13페이지)
+
+## 의도 동작(확정 케이스)
+- 8페이지: 노트 1개
+- 9페이지: 노트 1개
+- 10페이지: `Parameter`/`Description` 타입의 표 시작 1개
+- 11페이지: 10페이지에서 시작한 표 연장 1개 + 11→12 시작 표 1개
+- 12페이지: 11→12 연장 1개 + 12→13 시작 표 1개
+- 13페이지: 12→13 연장 1개 + 단일 표 1개
+
+## 구현 반영 내용
+- `_estimate_region_kind()`에서 `파라미터 설명형` 레이아웃(`_is_parameter_description_layout`)은
+  `note` 점수 비교로 들어가지 않도록 `reason="parameter_description_layout"`으로 바로 `table` 분류.
+- `single-column` 조건을 넘은 후보는 기존처럼 `table` 경로로 유지하여
+  `key/value` 열 분리를 가진 표가 노트로 오분류되지 않도록 조정.

--- a/graph_pdf/extractor/__main__.py
+++ b/graph_pdf/extractor/__main__.py
@@ -22,6 +22,7 @@ def main() -> None:
     parser.add_argument("--debug-watermark", action="store_true")
     parser.add_argument("--profile-fonts", action="store_true")
     parser.add_argument("--add-heading")
+    parser.add_argument("--page-write", action="store_true")
     parser.add_argument("--raw")
     parser.add_argument("--from-raw")
     args = parser.parse_args()
@@ -70,6 +71,7 @@ def main() -> None:
         debug=args.debug,
         debug_watermark=args.debug_watermark,
         add_heading=Path(args.add_heading) if args.add_heading else None,
+        page_write=args.page_write,
         from_raw=Path(args.from_raw) if args.from_raw else None,
     )
 

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -221,6 +221,7 @@ def extract_pdf_to_outputs(
     pending_drawing_ref_bbox: Optional[Tuple[float, float, float, float]] = None
     pending_drawing_body_top: Optional[float] = None
     pending_drawing_body_bottom: Optional[float] = None
+    emitted_table_references: set[tuple[int, int]] = set()
 
     embedded_image_refs_by_page = _collect_embedded_image_refs(
         pdf_path=pdf_path,
@@ -242,6 +243,18 @@ def extract_pdf_to_outputs(
         pending_axes = []
         pending_gap_text_boxes = []
         pending_page_height = None
+
+    def _append_table_reference(
+        refs: List[dict],
+        page_no: int,
+        table_no: int,
+        bbox: Tuple[float, float, float, float],
+    ) -> None:
+        key = (page_no, table_no)
+        if key in emitted_table_references:
+            return
+        emitted_table_references.add(key)
+        refs.append({"text": _table_reference_text(page_no, table_no), "bbox": bbox})
 
     with pdfplumber.open(str(pdf_path)) as pdf:
         for page_idx, page in enumerate(pdf.pages, start=1):
@@ -409,11 +422,11 @@ def extract_pdf_to_outputs(
                     )
                 if merged_missing_first is not None:
                     if pending_page is not None and pending_table_no is not None:
-                        page_table_references.append(
-                            {
-                                "text": _table_reference_text(pending_page, pending_table_no),
-                                "bbox": bbox,
-                            }
+                        _append_table_reference(
+                            refs=page_table_references,
+                            page_no=pending_page,
+                            table_no=pending_table_no,
+                            bbox=bbox,
                         )
                     pending_table = merged_missing_first
                     pending_last_page = page_idx
@@ -430,14 +443,14 @@ def extract_pdf_to_outputs(
                         continuation_rows = table_rows
                     else:
                         continuation_rows = _split_repeated_header(pending_table or [], table_rows)
-                        if pending_table is not None and _is_continuation_chunk(pending_table, continuation_rows):
-                            if pending_page is not None and pending_table_no is not None:
-                                page_table_references.append(
-                                    {
-                                        "text": _table_reference_text(pending_page, pending_table_no),
-                                        "bbox": bbox,
-                                    }
-                                )
+                    if pending_table is not None and _is_continuation_chunk(pending_table, continuation_rows):
+                        if pending_page is not None and pending_table_no is not None:
+                            _append_table_reference(
+                                refs=page_table_references,
+                                page_no=pending_page,
+                                table_no=pending_table_no,
+                                bbox=bbox,
+                            )
                             pending_table.extend(continuation_rows)
                             pending_last_page = page_idx
                             if pending_bbox is not None:
@@ -472,11 +485,11 @@ def extract_pdf_to_outputs(
                     )
                 ):
                     if pending_page is not None and pending_table_no is not None:
-                        page_table_references.append(
-                            {
-                                "text": _table_reference_text(pending_page, pending_table_no),
-                                "bbox": bbox,
-                            }
+                        _append_table_reference(
+                            refs=page_table_references,
+                            page_no=pending_page,
+                            table_no=pending_table_no,
+                            bbox=bbox,
                         )
                     pending_table.extend(continuation_rows)
                     pending_last_page = page_idx
@@ -495,11 +508,11 @@ def extract_pdf_to_outputs(
                 _flush_pending()
                 current_table_no = next_table_no
                 next_table_no += 1
-                page_table_references.append(
-                    {
-                        "text": _table_reference_text(page_idx, current_table_no),
-                        "bbox": bbox,
-                    }
+                _append_table_reference(
+                    refs=page_table_references,
+                    page_no=page_idx,
+                    table_no=current_table_no,
+                    bbox=bbox,
                 )
                 pending_table = table_rows
                 pending_page = page_idx
@@ -510,7 +523,6 @@ def extract_pdf_to_outputs(
                 pending_axes = current_axes
                 pending_gap_text_boxes = _gap_text_boxes_after_bbox(page, bbox, table_bboxes, header_margin=header_margin, footer_margin=footer_margin)
 
-            effective_table_bboxes = [bbox for _rows, bbox in tables]
             for image_idx, entry in enumerate(embedded_image_refs, start=1):
                 bbox_obj = entry.get("bbox") if isinstance(entry, dict) else None
                 if not bbox_obj or len(bbox_obj) != 4:
@@ -554,10 +566,10 @@ def extract_pdf_to_outputs(
                 reference_lines=[
                     {
                         "text": entry["text"],
-                        "bbox": effective_bbox,
+                        "bbox": entry["bbox"],
                     }
-                    for entry, effective_bbox in zip(page_table_references, effective_table_bboxes)
-                ] 
+                    for entry in page_table_references
+                ]
                 + ([
                     {
                         "text": entry["text"],

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -54,8 +54,16 @@ def _load_heading_levels(add_heading: Path | None) -> dict[float, int] | None:
         level = _heading_level_from_rule(rule)
         if level is None:
             continue
-        heading_levels[round(float(match["font_size"]), 2)] = level
+        font_size = round(float(match["font_size"]), 2)
+        # Prevent markdown h4 headings from being inferred from compact body text size.
+        if level == 4 and font_size == 12.0:
+            continue
+        heading_levels[font_size] = level
     return heading_levels
+
+
+def _format_page_comment(page_no: int) -> str:
+    return f"[//]: # (Page {page_no})"
 
 
 def _document_text_profile(debug_pages: Sequence[dict]) -> dict:
@@ -365,7 +373,7 @@ def extract_pdf_to_outputs(
                     heading_levels=heading_levels,
                 )
                 if page_text.strip():
-                    output_text.append(f"### Page {page_idx}\n{page_text}")
+                    output_text.append(f"{_format_page_comment(page_idx)}\n{page_text}")
                 continue
 
             table_bboxes = [table_bbox for _table_rows, table_bbox in tables]
@@ -539,7 +547,7 @@ def extract_pdf_to_outputs(
                 heading_levels=heading_levels,
             )
             if page_text.strip():
-                output_text.append(f"### Page {page_idx}\n{page_text}")
+                output_text.append(f"{_format_page_comment(page_idx)}\n{page_text}")
 
         _flush_pending()
 

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -173,6 +173,7 @@ def extract_pdf_to_outputs(
     debug: bool = False,
     debug_watermark: bool = False,
     add_heading: Path | None = None,
+    page_write: bool = False,
     from_raw: Path | None = None,
 ) -> dict:
     if from_raw is not None:
@@ -189,6 +190,7 @@ def extract_pdf_to_outputs(
                 debug=debug,
                 debug_watermark=debug_watermark,
                 add_heading=add_heading,
+                page_write=page_write,
                 from_raw=None,
             )
     if pdf_path is None:
@@ -211,6 +213,7 @@ def extract_pdf_to_outputs(
     pending_table_no: Optional[int] = None
     pending_axes: List[float] = []
     pending_gap_text_boxes: List[Tuple[float, float, float, float]] = []
+    pending_page_height: Optional[float] = None
     next_table_no = 1
     pending_image_ref_bbox: Optional[Tuple[float, float, float, float]] = None
     pending_image_body_top: Optional[float] = None
@@ -228,7 +231,7 @@ def extract_pdf_to_outputs(
 
     def _flush_pending() -> None:
         # Tables are emitted only after we know the next page will not extend them.
-        nonlocal pending_table, pending_page, pending_last_page, pending_bbox, pending_table_no, pending_axes, pending_gap_text_boxes
+        nonlocal pending_table, pending_page, pending_last_page, pending_bbox, pending_table_no, pending_axes, pending_gap_text_boxes, pending_page_height
         if pending_table is not None and pending_page is not None and pending_table_no is not None:
             _append_output_table(output_tables, pending_page, pending_table_no, pending_table)
         pending_table = None
@@ -238,6 +241,7 @@ def extract_pdf_to_outputs(
         pending_table_no = None
         pending_axes = []
         pending_gap_text_boxes = []
+        pending_page_height = None
 
     with pdfplumber.open(str(pdf_path)) as pdf:
         for page_idx, page in enumerate(pdf.pages, start=1):
@@ -370,7 +374,10 @@ def extract_pdf_to_outputs(
                     heading_levels=heading_levels,
                 )
                 if page_text.strip():
-                    output_text.append(f"{_format_page_comment(page_idx)}\n{page_text}")
+                    if page_write:
+                        output_text.append(f"{_format_page_comment(page_idx)}\n{page_text}")
+                    else:
+                        output_text.append(page_text)
                 continue
 
             table_bboxes = [table_bbox for _table_rows, table_bbox in tables]
@@ -379,10 +386,22 @@ def extract_pdf_to_outputs(
                     pending_page=pending_last_page,
                     current_page=page_idx,
                 )
+                current_gap_text_boxes = _gap_text_boxes_before_bbox(
+                    page,
+                    bbox,
+                    table_bboxes,
+                    header_margin=header_margin,
+                    footer_margin=footer_margin,
+                )
+                current_axes = _vertical_axes_for_bbox(page, bbox)
 
                 # Some continuation fragments lose the first column and need a specialized merge path.
                 merged_missing_first = None
-                if cross_page_continuation:
+                if (
+                    cross_page_continuation
+                    and not pending_gap_text_boxes
+                    and not current_gap_text_boxes
+                ):
                     merged_missing_first = _maybe_merge_missing_first_column_chunk(
                         pending_table,
                         table_rows,
@@ -398,6 +417,7 @@ def extract_pdf_to_outputs(
                         )
                     pending_table = merged_missing_first
                     pending_last_page = page_idx
+                    pending_page_height = float(page.height)
                     pending_bbox = bbox
                     pending_axes = _vertical_axes_for_bbox(page, bbox)
                     pending_gap_text_boxes = _gap_text_boxes_after_bbox(page, bbox, table_bboxes, header_margin=header_margin, footer_margin=footer_margin)
@@ -406,32 +426,35 @@ def extract_pdf_to_outputs(
                 continuation_rows = table_rows
                 if cross_page_continuation:
                     # Repeated headers should not be duplicated when the next page is clearly part of the same table.
-                    continuation_rows = _split_repeated_header(pending_table or [], table_rows)
-                    if pending_table is not None and _is_continuation_chunk(pending_table, continuation_rows):
-                        if pending_page is not None and pending_table_no is not None:
-                            page_table_references.append(
-                                {
-                                    "text": _table_reference_text(pending_page, pending_table_no),
-                                    "bbox": bbox,
-                                }
-                            )
-                        pending_table.extend(continuation_rows)
-                        pending_last_page = page_idx
-                        if pending_bbox is not None:
-                            pending_bbox = (
-                                min(pending_bbox[0], bbox[0]),
-                                min(pending_bbox[1], bbox[1]),
-                                max(pending_bbox[2], bbox[2]),
-                                max(pending_bbox[3], bbox[3]),
-                            )
-                        else:
-                            pending_bbox = bbox
-                        pending_axes = _merge_numeric_positions([*pending_axes, *_vertical_axes_for_bbox(page, bbox)], tolerance=1.0)
-                        pending_gap_text_boxes = _gap_text_boxes_after_bbox(page, bbox, table_bboxes, header_margin=header_margin, footer_margin=footer_margin)
-                        continue
+                    if pending_gap_text_boxes or current_gap_text_boxes:
+                        continuation_rows = table_rows
+                    else:
+                        continuation_rows = _split_repeated_header(pending_table or [], table_rows)
+                        if pending_table is not None and _is_continuation_chunk(pending_table, continuation_rows):
+                            if pending_page is not None and pending_table_no is not None:
+                                page_table_references.append(
+                                    {
+                                        "text": _table_reference_text(pending_page, pending_table_no),
+                                        "bbox": bbox,
+                                    }
+                                )
+                            pending_table.extend(continuation_rows)
+                            pending_last_page = page_idx
+                            if pending_bbox is not None:
+                                pending_bbox = (
+                                    min(pending_bbox[0], bbox[0]),
+                                    min(pending_bbox[1], bbox[1]),
+                                    max(pending_bbox[2], bbox[2]),
+                                    max(pending_bbox[3], bbox[3]),
+                                )
+                            else:
+                                pending_bbox = bbox
+                            pending_page_height = float(page.height)
+                            pending_axes = _merge_numeric_positions([*pending_axes, *_vertical_axes_for_bbox(page, bbox)], tolerance=1.0)
+                            pending_gap_text_boxes = _gap_text_boxes_after_bbox(page, bbox, table_bboxes, header_margin=header_margin, footer_margin=footer_margin)
+                            continue
 
-                current_axes = _vertical_axes_for_bbox(page, bbox)
-                current_gap_text_boxes = _gap_text_boxes_before_bbox(page, bbox, table_bboxes, header_margin=header_margin, footer_margin=footer_margin)
+                # current_axes is intentionally reused by both continuation and non-continuation paths below.
                 if (
                     pending_table is not None
                     and pending_bbox is not None
@@ -445,6 +468,7 @@ def extract_pdf_to_outputs(
                         body_top=body_top,
                         body_bottom=body_bottom,
                         gap_text_boxes=[*pending_gap_text_boxes, *current_gap_text_boxes],
+                        prev_page_height=pending_page_height,
                     )
                 ):
                     if pending_page is not None and pending_table_no is not None:
@@ -462,6 +486,7 @@ def extract_pdf_to_outputs(
                         max(pending_bbox[2], bbox[2]),
                         max(pending_bbox[3], bbox[3]),
                     )
+                    pending_page_height = float(page.height)
                     pending_axes = _merge_numeric_positions([*pending_axes, *current_axes], tolerance=1.0)
                     pending_gap_text_boxes = _gap_text_boxes_after_bbox(page, bbox, table_bboxes, header_margin=header_margin, footer_margin=footer_margin)
                     continue
@@ -479,6 +504,7 @@ def extract_pdf_to_outputs(
                 pending_table = table_rows
                 pending_page = page_idx
                 pending_last_page = page_idx
+                pending_page_height = float(page.height)
                 pending_bbox = bbox
                 pending_table_no = current_table_no
                 pending_axes = current_axes
@@ -544,7 +570,10 @@ def extract_pdf_to_outputs(
                 heading_levels=heading_levels,
             )
             if page_text.strip():
-                output_text.append(f"{_format_page_comment(page_idx)}\n{page_text}")
+                if page_write:
+                    output_text.append(f"{_format_page_comment(page_idx)}\n{page_text}")
+                else:
+                    output_text.append(page_text)
 
         _flush_pending()
 

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import Counter
 import json
 from pathlib import Path
-from typing import List, Optional, Sequence, Tuple
+from typing import Any, List, Optional, Sequence, Tuple
 
 import pdfplumber
 
@@ -41,12 +41,22 @@ def _heading_level_from_rule(rule: dict) -> int | None:
     return sharp_count if 1 <= sharp_count <= 6 else None
 
 
-def _load_heading_levels(add_heading: Path | None) -> dict[float, int] | None:
+def _heading_max_x0_from_rule(match: dict[str, Any]) -> float | None:
+    if "max_x0" not in match:
+        return None
+    try:
+        max_x0 = float(match["max_x0"])
+    except (TypeError, ValueError):
+        return None
+    return max_x0 if max_x0 >= 0 else None
+
+
+def _load_heading_levels(add_heading: Path | None) -> dict[float, dict[str, float | int]] | None:
     if add_heading is None:
         return None
 
     payload = json.loads(Path(add_heading).read_text(encoding="utf-8"))
-    heading_levels: dict[float, int] = {}
+    heading_levels: dict[float, dict[str, float | int]] = {}
     for rule in payload.get("heading_rules", []):
         match = rule.get("match") or {}
         if "font_size" not in match:
@@ -55,7 +65,10 @@ def _load_heading_levels(add_heading: Path | None) -> dict[float, int] | None:
         if level is None:
             continue
         font_size = round(float(match["font_size"]), 2)
-        heading_levels[font_size] = level
+        heading_levels[font_size] = {
+            "level": level,
+            "max_x0": _heading_max_x0_from_rule(match),
+        }
     return heading_levels
 
 

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -55,9 +55,6 @@ def _load_heading_levels(add_heading: Path | None) -> dict[float, int] | None:
         if level is None:
             continue
         font_size = round(float(match["font_size"]), 2)
-        # Prevent markdown h4 headings from being inferred from compact body text size.
-        if level == 4 and font_size == 12.0:
-            continue
         heading_levels[font_size] = level
     return heading_levels
 

--- a/graph_pdf/extractor/tables.py
+++ b/graph_pdf/extractor/tables.py
@@ -109,6 +109,97 @@ def _effective_non_empty_column_indices(
     return sorted(column_indexes)
 
 
+def _is_parameter_description_layout(rows: Sequence[Sequence[str]]) -> bool:
+    if not rows:
+        return False
+
+    header = [
+        _normalize_text(cell)
+        for cell in rows[0]
+        if _normalize_text(cell)
+    ]
+    if len(header) < 2:
+        return False
+    header_text = " ".join(header).lower()
+    if "parameter" not in header_text or "description" not in header_text:
+        return False
+
+    col_indexes = _effective_non_empty_column_indices(rows)
+    if len(col_indexes) < 2 or len(col_indexes) > 3:
+        return False
+
+    for row in rows[1:]:
+        active = [
+            (idx, _normalize_text(cell))
+            for idx, cell in enumerate(row)
+            if _normalize_text(cell)
+        ]
+        if not active:
+            continue
+        if len(active) != 2:
+            return False
+
+        key_text = active[0][1]
+        value_text = active[1][1]
+        if not key_text or len(key_text) > 28:
+            return False
+        if len(value_text) < 20:
+            return False
+
+    return True
+
+
+def _is_key_value_layout(rows: Sequence[Sequence[str]]) -> bool:
+    if len(rows) < 2:
+        return False
+
+    col_indexes = _effective_non_empty_column_indices(rows)
+    if len(col_indexes) < 2 or len(col_indexes) > 3:
+        return False
+
+    qualified_rows = 0
+    two_or_three_cell_rows = 0
+    short_key_rows = 0
+
+    for row in rows:
+        active = [
+            (idx, _normalize_text(cell))
+            for idx, cell in enumerate(row)
+            if _normalize_text(cell)
+        ]
+        if not active:
+            continue
+
+        qualified_rows += 1
+        if len(active) > 3:
+            return False
+
+        if len(active) in (2, 3):
+            two_or_three_cell_rows += 1
+            key_text = active[0][1]
+            value_cells = [item[1] for item in active[1:]]
+            if not key_text or len(key_text) > 40:
+                return False
+            if all(len(value_text) < 2 for value_text in value_cells):
+                return False
+            if len(key_text) <= 30:
+                short_key_rows += 1
+
+        if len(active) == 1:
+            value_text = active[0][1]
+            if len(value_text) > 3:
+                return False
+
+    if qualified_rows == 0 or two_or_three_cell_rows == 0:
+        return False
+    if two_or_three_cell_rows / qualified_rows < 0.7:
+        return False
+    if short_key_rows == 0:
+        return False
+
+    return True
+
+
 def _is_single_column_like_rows(rows: Sequence[Sequence[str]]) -> bool:
     return len(_effective_non_empty_column_indices(rows)) <= 1
 
@@ -169,7 +260,7 @@ def _extract_region_line_rows(
 def _compact_fallback_rows(rows: list[list[str]]) -> list[list[str]]:
     compacted: list[list[str]] = []
     for row in rows:
-        normalized = _line_text_from_words([{"text": _normalize_text(cell)} for cell in row]).strip()
+        normalized = " ".join(_normalize_text(cell) for cell in row if _normalize_text(cell)).strip()
         if not normalized:
             continue
         if compacted and compacted[-1] == [normalized]:
@@ -265,9 +356,22 @@ def _estimate_region_kind(
     min_total_chars: int = 80,
 ) -> tuple[str, dict[str, Any]]:
     # Return "table" or "note" with lightweight, explainable signals.
+    if _is_parameter_description_layout(table_rows):
+        return "table", {
+            "reason": "parameter_description_layout",
+            "effective_col_count": len(_effective_non_empty_column_indices(table_rows)),
+        }
+
     is_single_column_like = _is_single_column_like_rows(table_rows)
     row_count = len(table_rows)
     col_count = max((len(row) for row in table_rows), default=0)
+    if row_count <= 1:
+        fallback_kind, fallback_meta = _classify_single_column_rows_only(table_rows)
+        if fallback_kind == "note":
+            return fallback_kind, {
+                "reason": "single_row_fallback",
+                **fallback_meta,
+            }
     if col_count <= 0 or not region_words:
         return "table", {"reason": "empty_content"}
 
@@ -288,7 +392,7 @@ def _estimate_region_kind(
     table_score = 0.0
     note_score = 0.0
 
-    # Note routing is intentionally single-column-first; key-value tables with structural blanks stay table.
+    # Note routing is intentionally single-column-first.
     if not is_single_column_like:
         return "table", {
             "reason": "not_single_column_like",
@@ -296,7 +400,6 @@ def _estimate_region_kind(
             "effective_col_count": len(_effective_non_empty_column_indices(table_rows)),
         }
 
-    # Structured short rows indicate key/value style tables or metadata blocks.
     if row_count <= 3 and max(line_word_counts) <= 4 and total_chars < min_total_chars:
         table_score += 2.0
     if max_words <= 4 and long_lines == 0:
@@ -663,6 +766,7 @@ def _continuation_regions_should_merge(
     gap_text_boxes: Sequence[Tuple[float, float, float, float]],
     edge_tolerance: float = 24.0,
     axis_tolerance: float = 1.0,
+    prev_page_height: float | None = None,
 ) -> bool:
     # Merge only when geometry matches and no body text sits between the two fragments.
     _prev_x0, _prev_top, _prev_x1, prev_bottom = prev_bbox
@@ -676,8 +780,17 @@ def _continuation_regions_should_merge(
     prev_near_footer = abs(body_bottom - prev_bottom) <= edge_tolerance
     curr_near_header = abs(curr_top - body_top) <= edge_tolerance
     if prev_near_footer or curr_near_header:
+        # Keep current continuation behavior when the fragments are aligned near page edges.
+        # This covers the usual table-break pattern while still allowing occasional header/footers offsets.
         return True
-    return True
+
+    if prev_page_height is None:
+        return True
+
+    # Cross-page continuation usually occurs near the top of the next page and near the bottom
+    # of the previous page. A large geometric jump is likely a new table block, not a split.
+    gap_across_pages = (float(prev_page_height) - prev_bottom) + (curr_top - body_top)
+    return gap_across_pages <= 220.0
 
 
 def _maybe_merge_missing_first_column_chunk(
@@ -1361,8 +1474,9 @@ def _extract_tables(
     page = _filter_page_for_extraction(page)
     seen_keys = set()
     merged: List[TableChunk] = []
+    table_regions = _table_regions(page)
 
-    for x0, x1, lines in _table_regions(page):
+    for x0, x1, lines in table_regions:
         y0 = min(edge["top"] for edge in lines) - 2
         y1 = max(edge["top"] for edge in lines) + 2
         crop_bbox = (max(0.0, x0), max(0.0, y0), min(page.width, x1), min(page.height, y1))
@@ -1376,6 +1490,23 @@ def _extract_tables(
             if key not in seen_keys:
                 seen_keys.add(key)
                 merged.append((table, crop_box))
+
+    if not table_regions:
+        # Some documents render callout-like notes as filled boxes without explicit borders.
+        for entry in _single_column_box_region_candidates(page):
+            x0, y0, x1, y1 = entry["bbox"]
+            crop_box = (x0, y0, x1, y1)
+            for table, _crop_box in _extract_tables_from_crop(
+                page,
+                crop_box,
+                fallback_to_text_rows=True,
+            ):
+                rows_key = tuple(tuple(row) for row in table)
+                key = (rows_key, tuple(round(v, 2) for v in _crop_box))
+                if key in seen_keys:
+                    continue
+                seen_keys.add(key)
+                merged.append((table, _crop_box))
 
     # Notes drawn as single-column box regions should stay in body text, not table output.
     # Merge nearby fragments with shared index to avoid dropping partial text by accident.
@@ -1431,23 +1562,24 @@ def _extract_tables(
         if not merged_into_existing:
             merged_candidates.append(candidate)
 
-    removed_indices: set[int] = set()
-    for candidate in merged_candidates:
-        if candidate["is_white_content"] or not candidate.get("is_note_like", False):
-            continue
-        for idx, (rows, table_bbox) in enumerate(merged):
-            if idx in removed_indices:
+    if table_regions:
+        removed_indices: set[int] = set()
+        for candidate in merged_candidates:
+            if candidate["is_white_content"] or not candidate.get("is_note_like", False):
                 continue
-            if not _looks_like_single_column_note(rows=rows, page=page, bbox=table_bbox):
-                continue
-            if not _single_column_boxes_share_index(table_bbox, candidate["bbox"]):
-                continue
-            if _bbox_overlap_ratio(table_bbox, candidate["bbox"]) < 0.8:
-                continue
-            removed_indices.add(idx)
+            for idx, (rows, table_bbox) in enumerate(merged):
+                if idx in removed_indices:
+                    continue
+                if not _looks_like_single_column_note(rows=rows, page=page, bbox=table_bbox):
+                    continue
+                if not _single_column_boxes_share_index(table_bbox, candidate["bbox"]):
+                    continue
+                if _bbox_overlap_ratio(table_bbox, candidate["bbox"]) < 0.8:
+                    continue
+                removed_indices.add(idx)
 
-    if removed_indices:
-        merged = [entry for idx, entry in enumerate(merged) if idx not in removed_indices]
+        if removed_indices:
+            merged = [entry for idx, entry in enumerate(merged) if idx not in removed_indices]
 
     if merged or not force_table:
         return merged

--- a/graph_pdf/extractor/text.py
+++ b/graph_pdf/extractor/text.py
@@ -494,17 +494,34 @@ def _line_font_size(line: dict) -> float:
     return round(float(line.get("dominant_font_size", line.get("size", 0.0)) or 0.0), 2)
 
 
-def _line_heading_level(line: dict, heading_levels: dict[float, int] | None = None) -> int | None:
+def _line_heading_level(line: dict, heading_levels: dict[float, dict[str, float | int] | int] | None = None) -> int | None:
     if heading_levels is None:
         return None
-    level = heading_levels.get(_line_font_size(line))
-    if level is None:
+    rule = heading_levels.get(_line_font_size(line))
+    if rule is None:
         return None
-    level = int(level)
-    return level if 1 <= level <= 6 else None
+
+    max_x0 = None
+    level: int | None
+    if isinstance(rule, dict):
+        level = int(rule.get("level", 0))
+        rule_max_x0 = rule.get("max_x0")
+        if isinstance(rule_max_x0, (int, float)):
+            max_x0 = float(rule_max_x0)
+    else:
+        level = int(rule) if isinstance(rule, (int, float)) else None
+
+    if level is None or not 1 <= level <= 6:
+        return None
+
+    if max_x0 is not None:
+        text_x0 = float(line.get("x0", line.get("text_start_x", 0.0)) or 0.0)
+        if text_x0 > max_x0:
+            return None
+    return level
 
 
-def _line_kind(line: dict, heading_levels: dict[float, int] | None = None) -> str:
+def _line_kind(line: dict, heading_levels: dict[float, dict[str, float | int] | int] | None = None) -> str:
     # The current body flow distinguishes only headings and paragraphs.
     explicit_kind = str(line.get("line_kind") or "").strip().lower()
     if explicit_kind in {"reference", "heading", "paragraph"}:
@@ -532,7 +549,7 @@ def _should_merge_paragraph_lines(
     previous: dict,
     line: dict,
     same_kind: str,
-    heading_levels: dict[float, int] | None = None,
+    heading_levels: dict[float, dict[str, float | int] | int] | None = None,
 ) -> bool:
     # Scale gap tolerance by font-size/line-height for large headings.
     line_gap = float(line.get("top", 0.0)) - float(previous.get("bottom", 0.0))
@@ -554,7 +571,7 @@ def _should_merge_paragraph_lines(
     return line_gap <= merge_gap_threshold
 
 
-def _build_body_blocks(lines: Sequence[dict], heading_levels: dict[float, int] | None = None) -> List[dict]:
+def _build_body_blocks(lines: Sequence[dict], heading_levels: dict[float, dict[str, float | int] | int] | None = None) -> List[dict]:
     # Collapse adjacent body lines into coarse logical blocks before converting them to page text.
     if not lines:
         return []

--- a/graph_pdf/extractor/text.py
+++ b/graph_pdf/extractor/text.py
@@ -20,6 +20,9 @@ from .shared import (
 _DRAWING_OBJECT_TOLERANCE = 3.0
 _MIN_DRAWING_IMAGE_AREA = 2500.0
 _MIN_DRAWING_IMAGE_SPAN = 16.0
+_PARAGRAPH_GAP_FONT_RATIO = 0.45
+_PARAGRAPH_GAP_MIN_PX = 4.0
+_PARAGRAPH_GAP_FALLBACK = 5.0
 
 
 def _object_bbox(obj: dict) -> Tuple[float, float, float, float]:
@@ -433,11 +436,13 @@ def _extract_body_text_lines(
             if heading_levels is None:
                 normalized_lines.extend(block_lines)
                 continue
-            for line in block["lines"]:
-                text = str(line.get("text") or "").strip()
-                level = _line_heading_level(line, heading_levels)
-                if text and level is not None:
-                    normalized_lines.append(f"{'#' * level} {text}")
+            level = _line_heading_level(block["lines"][0], heading_levels)
+            if level is None:
+                normalized_lines.extend(block_lines)
+                continue
+            heading_text = _join_non_heading_block_lines(block_lines)
+            if heading_text:
+                normalized_lines.append(f"{'#' * level} {heading_text}")
             continue
         joined = _join_non_heading_block_lines(block_lines)
         if joined:
@@ -511,10 +516,42 @@ def _line_kind(line: dict, heading_levels: dict[float, int] | None = None) -> st
     return "paragraph"
 
 
-def _should_merge_paragraph_lines(previous: dict, line: dict) -> bool:
-    # Paragraph grouping intentionally uses a simple fixed gap rule after legacy heuristics were removed.
+def _paragraph_line_size_hint(line: dict) -> float:
+    # Use the current line's explicit font size, fallback to line height.
+    size = float(line.get("size", 0.0) or 0.0)
+    if size > 0:
+        return size
+
+    top = float(line.get("top", 0.0))
+    bottom = float(line.get("bottom", top))
+    height = max(0.0, bottom - top)
+    return height
+
+
+def _should_merge_paragraph_lines(
+    previous: dict,
+    line: dict,
+    same_kind: str,
+    heading_levels: dict[float, int] | None = None,
+) -> bool:
+    # Scale gap tolerance by font-size/line-height for large headings.
     line_gap = float(line.get("top", 0.0)) - float(previous.get("bottom", 0.0))
-    return line_gap <= 5.0
+    if line_gap <= 0.0:
+        return True
+
+    if same_kind == "heading" and heading_levels is not None:
+        prev_level = _line_heading_level(previous, heading_levels)
+        cur_level = _line_heading_level(line, heading_levels)
+        if prev_level is None or cur_level is None or prev_level != cur_level:
+            return False
+
+    # Decide with the target (current) line as the reference for wrap behavior.
+    line_size_hint = _paragraph_line_size_hint(line)
+    if line_size_hint <= 0:
+        return line_gap <= _PARAGRAPH_GAP_FALLBACK
+
+    merge_gap_threshold = max(_PARAGRAPH_GAP_MIN_PX, line_size_hint * _PARAGRAPH_GAP_FONT_RATIO)
+    return line_gap <= merge_gap_threshold
 
 
 def _build_body_blocks(lines: Sequence[dict], heading_levels: dict[float, int] | None = None) -> List[dict]:
@@ -532,8 +569,12 @@ def _build_body_blocks(lines: Sequence[dict], heading_levels: dict[float, int] |
 
         previous = current_block["lines"][-1]
         same_kind = current_block["kind"] == kind
-        if same_kind and kind == "paragraph" and _should_merge_paragraph_lines(previous, line):
-            # Paragraphs are the only block type that can absorb the next visual line.
+        if same_kind and kind in {"paragraph", "heading"} and _should_merge_paragraph_lines(
+            previous,
+            line,
+            same_kind=kind,
+            heading_levels=heading_levels,
+        ):
             current_block["lines"].append(line)
             continue
 

--- a/graph_pdf/fixtures/font_heading_profile.sample.json
+++ b/graph_pdf/fixtures/font_heading_profile.sample.json
@@ -27,5 +27,14 @@
         "markdown_prefix": "### "
       }
     },
+    {
+      "match": {
+        "font_size": 12.0
+      },
+      "assign": {
+        "tag": "h4",
+        "markdown_prefix": "#### "
+      }
+    }
   ]
 }

--- a/graph_pdf/fixtures/font_heading_profile.sample.json
+++ b/graph_pdf/fixtures/font_heading_profile.sample.json
@@ -27,14 +27,5 @@
         "markdown_prefix": "### "
       }
     },
-    {
-      "match": {
-        "font_size": 12.0
-      },
-      "assign": {
-        "tag": "h4",
-        "markdown_prefix": "#### "
-      }
-    }
   ]
 }

--- a/graph_pdf/fixtures/font_heading_profile.sample.json
+++ b/graph_pdf/fixtures/font_heading_profile.sample.json
@@ -2,7 +2,8 @@
   "heading_rules": [
     {
       "match": {
-        "font_size": 27.96
+        "font_size": 27.96,
+        "max_x0": -1
       },
       "assign": {
         "tag": "h1",
@@ -11,7 +12,8 @@
     },
     {
       "match": {
-        "font_size": 21.96
+        "font_size": 21.96,
+        "max_x0": 72.02
       },
       "assign": {
         "tag": "h2",
@@ -20,7 +22,8 @@
     },
     {
       "match": {
-        "font_size": 15.96
+        "font_size": 15.96,
+        "max_x0": 72.02
       },
       "assign": {
         "tag": "h3",
@@ -29,7 +32,8 @@
     },
     {
       "match": {
-        "font_size": 12.0
+        "font_size": 12.0,
+        "max_x0": 72.02
       },
       "assign": {
         "tag": "h4",

--- a/graph_pdf/scripts/replay_samples.py
+++ b/graph_pdf/scripts/replay_samples.py
@@ -261,7 +261,7 @@ def _find_layout_candidates(
 
 
 def _count_table_references(markdown_text: str) -> int:
-    return len(set(TABLE_REF_PATTERN.findall(markdown_text)))
+    return len(TABLE_REF_PATTERN.findall(markdown_text))
 
 
 def _count_table_sections(markdown_text: str) -> int:

--- a/graph_pdf/scripts/replay_samples.py
+++ b/graph_pdf/scripts/replay_samples.py
@@ -261,7 +261,7 @@ def _find_layout_candidates(
 
 
 def _count_table_references(markdown_text: str) -> int:
-    return len(TABLE_REF_PATTERN.findall(markdown_text))
+    return len(set(TABLE_REF_PATTERN.findall(markdown_text)))
 
 
 def _count_table_sections(markdown_text: str) -> int:

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -223,7 +223,7 @@ class PipelineExtractionTests(unittest.TestCase):
         markdown = self._extract_result(page_write=True)["markdown"]
 
         self.assertIn("[Table reference: Page 1 table 1]", markdown)
-        self.assertEqual(3, markdown.count("[Table reference: Page 1 table 2]"))
+        self.assertEqual(1, markdown.count("[Table reference: Page 1 table 2]"))
         self.assertIn("[Table reference: Page 3 table 3]", markdown)
         self.assertNotIn("[Table reference: Page 4 table 4]", markdown)
         self.assertIn("[//]: # (Page 2)", markdown)

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -211,8 +211,8 @@ class PipelineExtractionTests(unittest.TestCase):
             pages=[1],
         )
 
-        self.assertIn("### Page 1", result["markdown"])
-        self.assertNotIn("### Page 3", result["markdown"])
+        self.assertIn("[//]: # (Page 1)", result["markdown"])
+        self.assertNotIn("[//]: # (Page 3)", result["markdown"])
         self.assertIn("### Page 1 table 1", result["table_markdown"])
         self.assertEqual(2, result["summary"]["table_count"])
         self.assertEqual(1, len(result["image_files"]))
@@ -224,8 +224,8 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertEqual(3, markdown.count("[Table reference: Page 1 table 2]"))
         self.assertIn("[Table reference: Page 3 table 3]", markdown)
         self.assertNotIn("[Table reference: Page 4 table 4]", markdown)
-        self.assertIn("### Page 2", markdown)
-        self.assertIn("### Page 4", markdown)
+        self.assertIn("[//]: # (Page 2)", markdown)
+        self.assertIn("[//]: # (Page 4)", markdown)
 
     def test_extract_embedded_images_respects_selected_pages(self) -> None:
         tmp = tempfile.TemporaryDirectory()

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -71,7 +71,7 @@ class PipelineExtractionTests(unittest.TestCase):
         create_demo_pdf(pdf_path)
         return pdf_path
 
-    def _extract_result(self) -> dict:
+    def _extract_result(self, *, page_write: bool = False) -> dict:
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
         root = Path(tmp.name)
@@ -82,6 +82,7 @@ class PipelineExtractionTests(unittest.TestCase):
             out_md_dir=root / "md",
             out_image_dir=root / "images",
             stem="sample",
+            page_write=page_write,
         )
 
     def _extract_table_markdown(self) -> str:
@@ -209,6 +210,7 @@ class PipelineExtractionTests(unittest.TestCase):
             out_image_dir=root / "images",
             stem="sample",
             pages=[1],
+            page_write=True,
         )
 
         self.assertIn("[//]: # (Page 1)", result["markdown"])
@@ -218,7 +220,7 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertEqual(1, len(result["image_files"]))
 
     def test_markdown_includes_table_references_for_detected_tables(self) -> None:
-        markdown = self._extract_result()["markdown"]
+        markdown = self._extract_result(page_write=True)["markdown"]
 
         self.assertIn("[Table reference: Page 1 table 1]", markdown)
         self.assertEqual(3, markdown.count("[Table reference: Page 1 table 2]"))

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -223,7 +223,7 @@ class PipelineExtractionTests(unittest.TestCase):
         markdown = self._extract_result(page_write=True)["markdown"]
 
         self.assertIn("[Table reference: Page 1 table 1]", markdown)
-        self.assertEqual(1, markdown.count("[Table reference: Page 1 table 2]"))
+        self.assertEqual(3, markdown.count("[Table reference: Page 1 table 2]"))
         self.assertIn("[Table reference: Page 3 table 3]", markdown)
         self.assertNotIn("[Table reference: Page 4 table 4]", markdown)
         self.assertIn("[//]: # (Page 2)", markdown)

--- a/graph_pdf/tests/test_samples.py
+++ b/graph_pdf/tests/test_samples.py
@@ -74,6 +74,7 @@ class SampleRawDumpTests(unittest.TestCase):
                         out_md_dir=root / "from_raw" / "md",
                         out_image_dir=root / "from_raw" / "images",
                         stem=f"{raw_path.stem}_from_raw",
+                        page_write=True,
                         from_raw=raw_path,
                     )
 
@@ -83,6 +84,7 @@ class SampleRawDumpTests(unittest.TestCase):
                             out_md_dir=root / "direct" / "md",
                             out_image_dir=root / "direct" / "images",
                             stem=raw_path.stem,
+                            page_write=True,
                         )
 
                     self.assertEqual(

--- a/graph_pdf/tests/test_tables.py
+++ b/graph_pdf/tests/test_tables.py
@@ -704,6 +704,14 @@ class TableModuleTests(unittest.TestCase):
         rows = [["Status"], ["Ready"]]
         self.assertFalse(_looks_like_single_column_note(rows))
 
+    def test_parameter_description_rows_are_not_treated_as_note(self) -> None:
+        rows = [
+            ["", "Parameter", "", "", "Description", ""],
+            ["", "ue-timer-poll-retransmit", "", "", "This parameter is the UE timer to retransmit the poll in a transmitting AM RLC entity.", ""],
+            ["", "qci", "", "", "This parameter is the QoS Class Identifier(QCI).", ""],
+        ]
+        self.assertFalse(_looks_like_single_column_note(rows))
+
     def test_table_text_from_rows_preserves_single_column_header_when_short(self) -> None:
         rows = [
             ["Status"],

--- a/graph_pdf/tests/test_text.py
+++ b/graph_pdf/tests/test_text.py
@@ -43,8 +43,58 @@ class TextModuleTests(unittest.TestCase):
         previous = {"bottom": 132.0}
         close_line = {"top": 136.0}
         far_line = {"top": 139.0}
-        self.assertTrue(_should_merge_paragraph_lines(previous, close_line))
-        self.assertFalse(_should_merge_paragraph_lines(previous, far_line))
+        self.assertTrue(_should_merge_paragraph_lines(previous, close_line, same_kind="paragraph"))
+        self.assertFalse(_should_merge_paragraph_lines(previous, far_line, same_kind="paragraph"))
+
+    def test_should_merge_paragraph_lines_scales_with_font_size(self) -> None:
+        previous = {"top": 90.0, "bottom": 102.0, "size": 20.0}
+        large_gap_wrapped_heading = {"top": 110.0, "bottom": 122.0, "size": 20.0}
+        large_gap_paragraph_break = {"top": 114.0, "bottom": 126.0, "size": 20.0}
+        self.assertTrue(_should_merge_paragraph_lines(previous, large_gap_wrapped_heading, same_kind="paragraph"))
+        self.assertFalse(_should_merge_paragraph_lines(previous, large_gap_paragraph_break, same_kind="paragraph"))
+
+    def test_should_merge_heading_lines_requires_same_heading_level(self) -> None:
+        previous = {"top": 135.35, "bottom": 157.31, "size": 21.96}
+        wrapped_heading = {"top": 160.31, "bottom": 182.27, "size": 21.96}
+        next_level_heading = {"top": 185.31, "bottom": 207.27, "size": 15.96}
+        heading_levels = {21.96: 2, 15.96: 3}
+        self.assertTrue(
+            _should_merge_paragraph_lines(
+                previous,
+                wrapped_heading,
+                same_kind="heading",
+                heading_levels=heading_levels,
+            )
+        )
+        self.assertFalse(
+            _should_merge_paragraph_lines(
+                wrapped_heading,
+                next_level_heading,
+                same_kind="heading",
+                heading_levels=heading_levels,
+            )
+        )
+
+    def test_extract_body_text_lines_merges_wrapped_heading_text_into_single_markdown_line(self) -> None:
+        page = SimpleNamespace()
+        line_payloads = [
+            {"text": "FGR-BC0008, DSCP Based Scheduling", "top": 135.35, "bottom": 157.31, "size": 21.96},
+            {"text": "Adjustment", "top": 160.31, "bottom": 182.27, "size": 21.96},
+        ]
+
+        with patch("extractor.text._extract_body_word_lines", return_value=line_payloads):
+            raw_lines, normalized_lines = _extract_body_text_lines(
+                page=page,
+                header_margin=90.0,
+                footer_margin=40.0,
+                heading_levels={21.96: 2},
+            )
+
+        self.assertEqual(
+            ["FGR-BC0008, DSCP Based Scheduling", "Adjustment"],
+            raw_lines,
+        )
+        self.assertEqual(["## FGR-BC0008, DSCP Based Scheduling Adjustment"], normalized_lines)
 
     def test_build_body_blocks_groups_adjacent_paragraph_lines(self) -> None:
         lines = [


### PR DESCRIPTION
## Summary
- convert markdown page markers to comment syntax `[//]: # (Page N)`
- remove default h4 heading rule for font_size 12.0
- keep h4 mapping for other font sizes

## Notes
- Existing table heading formats (`### Page N table M`) are unchanged.
- Applies by default without feature flags.