### PR TITLE
Handle hyphenated line merges without extra space

### DIFF
--- a/graph_pdf/extractor/text.py
+++ b/graph_pdf/extractor/text.py
@@ -801,7 +801,15 @@ def _extract_body_word_lines(
 def _join_non_heading_block_lines(lines: Sequence[str]) -> str:
     # Paragraph blocks are intentionally flattened into one logical line for downstream indexing.
     joined = [str(raw_line or "").strip() for raw_line in lines if str(raw_line or "").strip()]
-    return " ".join(joined).strip()
+    if not joined:
+        return ""
+    merged: List[str] = [joined[0]]
+    for line in joined[1:]:
+        if merged[-1].endswith("-"):
+            merged[-1] = f"{merged[-1]}{line}"
+        else:
+            merged.append(line)
+    return " ".join(merged).strip()
 
 
 def _normalize_cell_lines(cell: str) -> List[str]:

--- a/graph_pdf/tests/test_text.py
+++ b/graph_pdf/tests/test_text.py
@@ -15,6 +15,7 @@ from extractor.text import (
     _is_non_watermark_obj,
     _is_shape_text_line,
     _normalize_cell_lines,
+    _join_non_heading_block_lines,
     _should_merge_paragraph_lines,
 )
 
@@ -38,6 +39,10 @@ class TextModuleTests(unittest.TestCase):
             ],
             _normalize_cell_lines(cell),
         )
+
+    def test_join_non_heading_block_lines_joins_hyphenated_wrap_without_space(self) -> None:
+        lines = ["An example of hyphen-", "ated words and normal continuation"]
+        self.assertEqual("An example of hyphen-ated words and normal continuation", _join_non_heading_block_lines(lines))
 
     def test_should_merge_paragraph_lines_uses_fixed_gap_threshold(self) -> None:
         previous = {"bottom": 132.0}


### PR DESCRIPTION
## Summary
- Merge wrapped paragraph lines without inserting a space when the previous line ends with '-'.
- Added a unit test to cover hyphenated line joining behavior in body text normalization.

## Changes
- Updated `graph_pdf/extractor/text.py` in `_join_non_heading_block_lines`.
- Added regression test in `graph_pdf/tests/test_text.py`.

Closes this feature request.