### PR TITLE
Fix: Extract 10-char document ID from H2 heading and use it for per-document outputs

### DIFF
--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -76,18 +76,16 @@ def _format_page_comment(page_no: int) -> str:
     return f"[//]: # (Page {page_no})"
 
 
-_DOC_ID_HEADING_PREFIX_RE = re.compile(r"^##\s+(?P<doc_id>\S{10})(?:\s|$)")
-_DOC_ID_PLAIN_PREFIX_RE = re.compile(r"^(?P<doc_id>[A-Za-z0-9._-]{10})(?:\s|$)")
+_DOC_ID_HEADING_PREFIX_RE = re.compile(r"^##\s+(?P<doc_id>.+?)\s*$")
 _UNSAFE_DOC_ID_CHARS_RE = re.compile(r"[^A-Za-z0-9._-]")
 
 
 def _extract_document_id_from_markdown_line(line: str) -> str | None:
     match = _DOC_ID_HEADING_PREFIX_RE.match(line.strip())
     if not match:
-        match = _DOC_ID_PLAIN_PREFIX_RE.match(line.strip())
-        if not match:
-            return None
-    return match.group("doc_id")
+        return None
+    doc_id = match.group("doc_id").strip()
+    return doc_id or None
 
 
 def _safe_document_id(document_id: str) -> str:

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -85,7 +85,12 @@ def _extract_document_id_from_markdown_line(line: str) -> str | None:
     if not match:
         return None
     doc_id = match.group("doc_id").strip()
-    return doc_id or None
+    if not doc_id:
+        return None
+    first_token = doc_id.split(maxsplit=1)[0]
+    if not first_token:
+        return None
+    return first_token[:10] if len(first_token) >= 10 else first_token
 
 
 def _safe_document_id(document_id: str) -> str:


### PR DESCRIPTION
## Summary
- Parse document ID from H2 heading text as requested.
- Use the first token from each H2 line and keep only its 10-character prefix.
- Route per-document outputs (markdown, table markdown, image filenames) by the extracted document ID during page-based document switching.
- Rebased on latest origin/main so already-merged commits were not reapplied.

## Notes
- Changes are in `graph_pdf/extractor/pipeline.py`.
