### PR TITLE
Refine table extraction normalization

### DIFF
--- a/graph_pdf/docs/table-extraction-iteration-guide.md
+++ b/graph_pdf/docs/table-extraction-iteration-guide.md
@@ -1,0 +1,97 @@
+# Table Extraction Iteration Guide (raw dump 기반)
+
+## 목적
+- 3개 덤프(`raw-32-37`, `raw-38-50`, `raw-93-114`)에 대해 모든 코드 변경을 검증한다.
+- `md` 추출 결과와 시각 PDF(`--from-raw`로 복원한 PDF)를 교차 확인해, 헤더/내용 분리, 노트 판정, 이미지 추출까지 반복 보정한다.
+- 변경이 특정 덤프에서 해결될 때, 다른 덤프로 회귀가 퍼졌는지 명확히 보고한다.
+
+## 보호 대상 산출물
+- 사용자 제공 기준 산출물인 `samples/raw-93-114.md`와 `samples/raw-93-114_table.md`는 절대 수정하지 않는다.
+- 위 두 파일은 `raw-93-114 dump`의 기대 출력으로 간주하고, 비교/검증 기준으로만 사용한다.
+- 작업 중 두 파일의 수정이 필요해 보일 경우에도 임의로 변경하지 말고, 반드시 사용자에게 수정 필요 사유를 먼저 보고하고 승인 대기한다.
+- `samples/raw-93-114.md`의 image reference baseline은 실제 이미지 2개(`image 1`, `image 2`)다.
+
+## 1) 기준선(Baseline) 고정
+1. 변경 전 현재 상태를 기준선 디렉터리로 저장한다.
+   1. `artifacts/iter/baseline/raw_visuals/pdfs`
+   2. `artifacts/iter/baseline/raw_visuals/parse`
+2. 다음 명령으로 덤프별 PDF 복원 + 파싱 + 레이아웃 분석을 수행한다.
+   - `PYTHONPATH=. python3 scripts/replay_samples.py --samples-dir samples --pattern "raw-*.dump" --pdf-dir artifacts/iter/baseline/raw_visuals/pdfs --out-dir artifacts/iter/baseline/raw_visuals/parse --force --analyze-layout`
+3. 생성 산출물 기준은 아래를 모두 보존한다.
+   - `<dump>.pdf`
+   - `<dump>_debug.json`
+   - `<dump>_md` 디렉터리 결과 (`.md`, `.txt`, `_table.md`)
+   - `sample_raw_visualization_report.json`
+
+## 2) 1회 변경 후 실행 루틴
+1. 코드 변경 후 같은 명령을 새 라벨로 재실행한다.
+   - `PYTHONPATH=. python3 scripts/replay_samples.py --samples-dir samples --pattern "raw-*.dump" --pdf-dir artifacts/iter/<run>/raw_visuals/pdfs --out-dir artifacts/iter/<run>/raw_visuals/parse --force --analyze-layout`
+2. 이전 라벨과 비교한다.
+   1. table 수, note/ table region 수, 페이지별 후보 수, 텍스트 길이, 이미지 파일 수 비교
+   2. `report` JSON의 `table_count_pdf`, `text_chars_pdf`, `notes/tables` 계수, 경계 박스 관련 디버그 필드 비교
+   3. `md` 본문의 `[Image reference: ...]` 개수와 위치 변화를 반드시 비교한다.
+   4. `raw-93-114`는 image reference가 정확히 2개(`image 1`, `image 2`)인지 함께 확인한다.
+3. 시각 확인은 `raw_visuals/pdfs`의 PDF를 열어 아래를 페이지별로 대조한다.
+   - 표 헤더/본문 행 구분
+   - 헤더만 있는 단락형 표(헤더 반복/누락)
+   - 노트 후보 경계선(파란/검은 선), 문단 박스, 이미지 추출 구간
+   - 인접 표 병합(특히 페이지 경계 부근)
+
+## 3) 영향 범위 보고 포맷 (반드시 작성)
+모든 변경 후 아래 형식으로 보고한다.
+
+- 변경 영향 요약
+  - 변경 파일/함수
+  - 변경 의도
+  - 변경 전제 조건
+
+- 덤프별 차이 요약
+  - `raw-32-37`: 변경 페이지, 변경 표 수, 변경 note 수, 변경 이미지 수, 변경 image reference 수
+  - `raw-38-50`: 변경 페이지, 변경 표 수, 변경 note 수, 변경 이미지 수, 변경 image reference 수
+  - `raw-93-114`: 변경 페이지, 변경 표 수, 변경 note 수, 변경 이미지 수, 변경 image reference 수
+
+- 근거 첨부
+  - 새/구 `debug.json`의 `pages[*].detected_tables`, `pages[*].strategy_debug`, `pages[*].tables`
+  - `table_markdown` diff
+  - 필요 시 `md` 텍스트 diff
+  - `[Image reference: ...]` diff 및 개수 비교
+  - 대상 PDF 페이지 번호(시각 확인된 페이지)
+
+## 4) 승인 게이트 (필수)
+- 변경이 특정 덤프 한정 문제만 개선했더라도 아래 규칙이 만족되어야 다음 단계로 진행.
+  - 다른 덤프의 회귀가 0건인지 확인
+  - 회귀가 있다면, 회귀 항목, 페이지, 원인 가설까지 보고하고 사용자 승인 대기
+
+## 5) 비교 리포트 생성용 최소 체크리스트
+1. `table_count`가 바뀐 덤프를 우선 점검한다.
+2. `page` 단위로 변경된 `detected_tables` 개체 수를 비교한다.
+3. `note`와 `table` 종류가 뒤바뀐 케이스를 추출한다.
+4. 이미지 누락/과다 여부:
+   5. `note`로 분류된 영역이 이미지로 추출되는지 여부
+   6. 표 영역이 image로 남아 있지 않은지 확인
+7. `md` 내 `[Image reference: ...]`가 새로 생성되거나 위치가 바뀌었는지 확인한다.
+8. 이미지 파일 검증과 별개로, image reference 증감은 독립적인 회귀 항목으로 기록한다.
+9. `raw-93-114`에서는 baseline인 `image 1`, `image 2` 외 추가 reference 생성 또는 번호 불일치를 회귀로 본다.
+
+## 6) 시각/텍스트 동시 비교 사이클 예시
+1. `md`에서 표/문장 단위를 확인한다.
+2. PDF의 같은 페이지에서 표 경계선/셀 분할을 본다.
+3. 문제 원인 태그를 붙인다 (`오탐 노트`, `헤더 분리 실패`, `열 분리`, `연속 페이지 병합 실패`).
+4. 원인 한 가지씩 우선순위 반영해서 한 번에 한 규칙만 수정한다.
+5. 다시 `replay_samples.py` 전체 3덤프 재실행.
+6. 변경이 특정 덤프에서 해결되면, 영향이 없는지 다른 두 덤프에 대해 동일 방식 검증.
+
+## 7) 사용자 확인이 필요한 보고 항목
+- 변경 결과 보고 시 다음을 명확히 전달한다.
+  - 변경된 코드 위치(파일/함수/로직)
+  - 해결된 덤프와 페이지
+  - 회귀한 덤프와 페이지
+  - 허용 가능한 부작용(있다면)
+  - 다음 실행 제안
+
+## 권장 실행 루틴 요약
+1. 코드 변경 1개 단위
+2. 3덤프 전체 재파싱
+3. 덤프별 차이표 생성
+4. PDF 시각 확인
+5. 승인 의사 결정 후 다음 수정

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -37,8 +37,63 @@ def _to_float_bbox(raw_bbox: object) -> tuple[float, float, float, float] | None
         return None
 
 
+def _x_overlap_width(
+    bbox_a: Tuple[float, float, float, float],
+    bbox_b: Tuple[float, float, float, float],
+) -> float:
+    return max(0.0, min(float(bbox_a[2]), float(bbox_b[2])) - max(float(bbox_a[0]), float(bbox_b[0])))
+
+
+def _has_x_overlap(
+    candidate: Tuple[float, float, float, float],
+    reference: Tuple[float, float, float, float],
+    *,
+    min_ratio: float,
+    min_width: float,
+) -> bool:
+    overlap = _x_overlap_width(candidate, reference)
+    if overlap <= 0.0:
+        return False
+    if min_width > 0.0 and overlap >= min_width:
+        return True
+    candidate_width = max(1.0, float(candidate[2]) - float(candidate[0]))
+    reference_width = max(1.0, float(reference[2]) - float(reference[0]))
+    return overlap / min(candidate_width, reference_width) >= min_ratio
+
+
 def _rounded_bbox(raw_bbox: Sequence[float] | tuple[float, float, float, float]) -> list[float]:
     return [round(float(value), 2) for value in raw_bbox]
+
+
+def _table_shape_signature(rows: Sequence[Sequence[str]]) -> tuple[int, int]:
+    row_count = len(rows)
+    if not rows:
+        return (0, 0)
+    col_count = max(len(row) for row in rows)
+    return (row_count, col_count)
+
+
+def _table_shapes_compatible(
+    previous_shape: tuple[int, int],
+    current_shape: tuple[int, int],
+) -> bool:
+    previous_row_count, previous_col_count = previous_shape
+    current_row_count, current_col_count = current_shape
+    if previous_col_count <= 0 or current_col_count <= 0:
+        return False
+    if previous_row_count <= 0 or current_row_count <= 0:
+        return False
+    if previous_col_count == 1 or current_col_count == 1:
+        return previous_col_count == current_col_count
+    return abs(previous_col_count - current_col_count) <= 1
+
+
+def _continuation_gap_tolerance(body_top: float, body_bottom: float, *, min_gap: float = 28.0, max_gap: float = 80.0) -> float:
+    # Use a body-height-scaled continuation window so large-format and compact pages behave consistently.
+    span = max(0.0, float(body_bottom) - float(body_top))
+    if span <= 0.0:
+        return min_gap
+    return max(min_gap, min(max_gap, span * 0.06))
 
 
 def _heading_level_from_rule(rule: dict) -> int | None:
@@ -221,14 +276,17 @@ def _should_continue_content_region(
     return overlap / min(prev_width, curr_width) >= min_x_overlap_ratio
 
 
-def _is_edge_candidate_for_continuation(
+def _is_cross_page_continuation_candidate(
     bbox: Tuple[float, float, float, float],
-    body_top: float,
     body_bottom: float,
+    continuation_gap: float | None = None,
     edge_tolerance: float = 24.0,
 ) -> bool:
     _x0, _top, _x1, bottom = bbox
-    return abs(bottom - body_bottom) <= edge_tolerance
+    tolerance = float(edge_tolerance)
+    if continuation_gap is not None and continuation_gap > 0:
+        tolerance = max(tolerance, float(continuation_gap))
+    return abs(bottom - body_bottom) <= tolerance
 
 
 @dataclass
@@ -270,6 +328,19 @@ class _PendingTableState:
 
 
 @dataclass
+class _CrossPageTableCandidate:
+    table_no: int
+    start_page: int
+    last_page: int
+    bbox: Tuple[float, float, float, float]
+    rows: TableRows
+    shape_signature: tuple[int, int]
+    axes: List[float] = field(default_factory=list)
+    has_gap_text: bool = False
+    page_height: float | None = None
+
+
+@dataclass
 class _DocumentOutputState:
     document_id: str
     output_text: List[str] = field(default_factory=list)
@@ -278,6 +349,7 @@ class _DocumentOutputState:
     edge_debug_pages: List[dict] = field(default_factory=list)
     rotated_debug: List[dict] = field(default_factory=list)
     pending_table_state: _PendingTableState = field(default_factory=_PendingTableState)
+    cross_page_candidates: List[_CrossPageTableCandidate] = field(default_factory=list)
     next_table_no: int = 1
     next_image_no: int = 1
     pending_image_ref_bbox: Optional[Tuple[float, float, float, float]] = None
@@ -288,6 +360,117 @@ class _DocumentOutputState:
     def clear_transient_content_state(self) -> None:
         self.pending_image_ref_bbox = None
         self.pending_image_body_bottom = None
+        self.cross_page_candidates = []
+
+
+def _to_cross_page_candidate(state: _PendingTableState) -> _CrossPageTableCandidate:
+    return _CrossPageTableCandidate(
+        table_no=int(state.table_no or 0),
+        start_page=int(state.start_page or 0),
+        last_page=int(state.last_page or 0),
+        bbox=(
+            float(state.bbox[0]),
+            float(state.bbox[1]),
+            float(state.bbox[2]),
+            float(state.bbox[3]),
+        ),
+        rows=[list(row) for row in state.flattened_rows()],
+        shape_signature=_table_shape_signature(state.flattened_rows()),
+        axes=list(state.axes),
+        has_gap_text=bool(state.has_gap_text),
+        page_height=state.page_height,
+    )
+
+
+def _load_cross_page_candidate(
+    state: _DocumentOutputState,
+    candidate: _CrossPageTableCandidate,
+) -> None:
+    state.pending_table_state.chunks = [list(row) for row in candidate.rows]
+    state.pending_table_state.table_no = candidate.table_no
+    state.pending_table_state.start_page = candidate.start_page
+    state.pending_table_state.last_page = candidate.last_page
+    state.pending_table_state.bbox = candidate.bbox
+    state.pending_table_state.axes = list(candidate.axes)
+    state.pending_table_state.has_gap_text = bool(candidate.has_gap_text)
+    state.pending_table_state.page_height = candidate.page_height
+
+
+def _pick_cross_page_anchor(
+    current_bbox: Tuple[float, float, float, float],
+    current_axes: Sequence[float],
+    current_shape: tuple[int, int],
+    body_top: float,
+    body_bottom: float,
+    continuation_gap: float,
+    region_map: dict[int, dict[str, Any]],
+    anchors: Sequence[_CrossPageTableCandidate],
+    current_page: int,
+) -> _CrossPageTableCandidate | None:
+    if not anchors or not current_bbox:
+        return None
+
+    best_anchor: _CrossPageTableCandidate | None = None
+    best_score = -1.0
+
+    for anchor in anchors:
+        has_x_overlap = _has_x_overlap(
+            candidate=anchor.bbox,
+            reference=current_bbox,
+            min_ratio=0.22,
+            min_width=8.0,
+        )
+        has_axis_overlap = any(
+            abs(axis - current_axis) <= 1.0
+            for axis in anchor.axes
+            for current_axis in current_axes
+        )
+        if not has_x_overlap and not has_axis_overlap:
+            continue
+
+        if not _table_shapes_compatible(anchor.shape_signature, current_shape):
+            continue
+
+        if _has_cross_page_gap_blocked(
+            region_map=region_map,
+            previous_page=anchor.last_page,
+            previous_table_bbox=anchor.bbox,
+            current_page=current_page,
+            current_table_bbox=current_bbox,
+            continuation_gap=continuation_gap,
+            previous_axes=anchor.axes,
+            current_axes=current_axes,
+        ):
+            continue
+
+        if not _continuation_regions_should_merge(
+            prev_bbox=anchor.bbox,
+            curr_bbox=current_bbox,
+            prev_axes=anchor.axes,
+            curr_axes=current_axes,
+            body_top=body_top,
+            body_bottom=body_bottom,
+            has_gap_text=anchor.has_gap_text,
+            prev_page_height=anchor.page_height,
+        ):
+            continue
+
+        overlap_width = _x_overlap_width(anchor.bbox, current_bbox)
+        if overlap_width <= 0.0 and has_axis_overlap:
+            overlap_width = 5.0
+        current_width = max(1.0, float(current_bbox[2]) - float(current_bbox[0]))
+        anchor_width = max(1.0, float(anchor.bbox[2]) - float(anchor.bbox[0]))
+        overlap_ratio = overlap_width / min(current_width, anchor_width)
+        shape_bonus = 0.0
+        if abs(anchor.shape_signature[1] - current_shape[1]) <= 1:
+            shape_bonus = 0.5
+        score = overlap_ratio + (overlap_width / 1000.0) + shape_bonus
+        if score <= best_score:
+            continue
+        best_score = score
+        best_anchor = anchor
+
+    return best_anchor
 
 
 def _first_table_row_signature(table_rows: Sequence[Sequence[str]]) -> tuple[str, ...]:
@@ -315,6 +498,10 @@ def _has_intervening_regions(
     page_regions: dict[str, Any],
     table_bbox: Tuple[float, float, float, float],
     after_table_bottom: bool,
+    max_vertical_gap: float | None = None,
+    overlap_bbox: Tuple[float, float, float, float] | None = None,
+    min_x_overlap_ratio: float = 0.0,
+    min_x_overlap: float = 0.0,
 ) -> bool:
     table_top = float(table_bbox[1])
     table_bottom = float(table_bbox[3])
@@ -324,7 +511,7 @@ def _has_intervening_regions(
         float(table_bbox[2]),
         table_bottom,
     )
-    for region_key in ("text", "tables", "images"):
+    for region_key in ("text", "tables", "images", "notes"):
         entries = page_regions.get(region_key)
         if not entries:
             continue
@@ -335,8 +522,26 @@ def _has_intervening_regions(
                 continue
             if bbox == table_bbox_tuple:
                 continue
+            if overlap_bbox is not None and not _has_x_overlap(
+                candidate=bbox,
+                reference=overlap_bbox,
+                min_ratio=min_x_overlap_ratio,
+                min_width=min_x_overlap,
+            ):
+                continue
+            if max_vertical_gap is not None:
+                if after_table_bottom:
+                    if bbox[1] > table_bottom + max_vertical_gap:
+                        continue
+                    if bbox[1] <= table_bottom + 1.0:
+                        continue
+                else:
+                    if bbox[3] < table_top - max_vertical_gap:
+                        continue
+                    if bbox[3] > table_top:
+                        continue
             if after_table_bottom:
-                if bbox[1] >= table_bottom + 1.0:
+                if bbox[1] > table_bottom + 1.0:
                     return True
             elif bbox[3] <= table_top - 1.0:
                 return True
@@ -346,22 +551,38 @@ def _has_intervening_regions(
 def _has_intervening_regions_before_table(
     page_regions: dict[str, Any],
     table_bbox: Tuple[float, float, float, float],
+    max_vertical_gap: float | None = None,
+    overlap_bbox: Tuple[float, float, float, float] | None = None,
+    min_x_overlap_ratio: float = 0.0,
+    min_x_overlap: float = 0.0,
 ) -> bool:
     return _has_intervening_regions(
         page_regions=page_regions,
         table_bbox=table_bbox,
         after_table_bottom=False,
+        max_vertical_gap=max_vertical_gap,
+        overlap_bbox=overlap_bbox,
+        min_x_overlap_ratio=min_x_overlap_ratio,
+        min_x_overlap=min_x_overlap,
     )
 
 
 def _has_intervening_regions_after_table(
     page_regions: dict[str, Any],
     table_bbox: Tuple[float, float, float, float],
+    max_vertical_gap: float | None = None,
+    overlap_bbox: Tuple[float, float, float, float] | None = None,
+    min_x_overlap_ratio: float = 0.0,
+    min_x_overlap: float = 0.0,
 ) -> bool:
     return _has_intervening_regions(
         page_regions=page_regions,
         table_bbox=table_bbox,
         after_table_bottom=True,
+        max_vertical_gap=max_vertical_gap,
+        overlap_bbox=overlap_bbox,
+        min_x_overlap_ratio=min_x_overlap_ratio,
+        min_x_overlap=min_x_overlap,
     )
 
 
@@ -371,17 +592,79 @@ def _has_cross_page_gap_blocked(
     previous_table_bbox: Tuple[float, float, float, float],
     current_page: int,
     current_table_bbox: Tuple[float, float, float, float],
+    continuation_gap: float | None = None,
+    previous_axes: Sequence[float] | None = None,
+    current_axes: Sequence[float] | None = None,
 ) -> bool:
     previous_regions = region_map.get(previous_page, {})
     current_regions = region_map.get(current_page, {})
     if not previous_regions:
         return False
-    if _has_intervening_regions_after_table(previous_regions, previous_table_bbox):
+    previous_body_top = float(previous_regions.get("body_top", 0.0))
+    previous_body_bottom = float(previous_regions.get("body_bottom", 0.0))
+    current_body_top = float(current_regions.get("body_top", 0.0))
+    current_body_bottom = float(current_regions.get("body_bottom", 0.0))
+    alignment_x_overlap_ratio = 0.22
+    alignment_x_overlap_width = 8.0
+
+    shared_axes: list[float] = []
+    if previous_axes and current_axes:
+        shared_axes = [
+            axis
+            for axis in previous_axes
+            if any(abs(axis - current_axis) <= 1.0 for current_axis in current_axes)
+        ]
+    if shared_axes:
+        overlap_x0 = min(shared_axes) - 4.0
+        overlap_x1 = max(shared_axes) + 4.0
+    else:
+        overlap_x0 = max(previous_table_bbox[0], current_table_bbox[0])
+        overlap_x1 = min(previous_table_bbox[2], current_table_bbox[2])
+    overlap_bbox_for_previous = (
+        overlap_x0,
+        previous_table_bbox[1],
+        overlap_x1,
+        previous_table_bbox[3],
+    )
+    overlap_bbox_for_current = (
+        overlap_x0,
+        current_table_bbox[1],
+        overlap_x1,
+        current_table_bbox[3],
+    )
+    if _x_overlap_width(overlap_bbox_for_previous, previous_table_bbox) <= 0.0:
+        overlap_bbox_for_previous = previous_table_bbox
+        overlap_bbox_for_current = current_table_bbox
+
+    if previous_body_top and previous_body_bottom:
+        prev_gap = min(float(continuation_gap or 80.0), max(0.0, previous_body_bottom - previous_table_bbox[3]))
+    else:
+        prev_gap = continuation_gap
+    if current_body_top and current_body_bottom:
+        curr_gap = min(float(continuation_gap or 80.0), max(0.0, current_table_bbox[1] - current_body_top))
+    else:
+        curr_gap = continuation_gap
+
+    if _has_intervening_regions_after_table(
+        previous_regions,
+        previous_table_bbox,
+        max_vertical_gap=prev_gap,
+        overlap_bbox=overlap_bbox_for_previous,
+        min_x_overlap_ratio=alignment_x_overlap_ratio,
+        min_x_overlap=alignment_x_overlap_width,
+    ):
         return True
 
     if not current_regions:
         return True
-    if _has_intervening_regions_before_table(current_regions, current_table_bbox):
+    if _has_intervening_regions_before_table(
+        current_regions,
+        current_table_bbox,
+        max_vertical_gap=curr_gap,
+        overlap_bbox=overlap_bbox_for_current,
+        min_x_overlap_ratio=alignment_x_overlap_ratio,
+        min_x_overlap=alignment_x_overlap_width,
+    ):
         return True
 
     return False
@@ -476,13 +759,25 @@ def extract_pdf_to_outputs(
 
     def _collect_embedded_image_references(
         embedded_refs: Sequence[dict],
+        page_no: int,
         body_top: float,
         body_bottom: float,
     ) -> List[dict]:
         page_content_references: list[dict] = []
+        note_regions = note_regions_by_page.get(page_no, [])
         for entry in embedded_refs:
             bbox = _to_float_bbox(entry.get("bbox") if isinstance(entry, dict) else None)
             if bbox is None:
+                continue
+            if any(
+                not (
+                    float(bbox[2]) <= float(region[0])
+                    or float(region[2]) <= float(bbox[0])
+                    or float(bbox[3]) <= float(region[1])
+                    or float(region[3]) <= float(bbox[1])
+                )
+                for region in note_regions
+            ):
                 continue
 
             is_cont = False
@@ -510,7 +805,10 @@ def extract_pdf_to_outputs(
             )
             current_document_state.next_image_no += 1
 
-            if _is_edge_candidate_for_continuation(bbox=bbox, body_top=body_top, body_bottom=body_bottom):
+            if _is_cross_page_continuation_candidate(
+                bbox=bbox,
+                body_bottom=body_bottom,
+            ):
                 current_document_state.pending_image_ref_bbox = bbox
                 current_document_state.pending_image_body_bottom = body_bottom
             else:
@@ -626,6 +924,7 @@ def extract_pdf_to_outputs(
             tables: List[Tuple[TableRows, Tuple[float, float, float, float]]] = []
             note_references: List[dict] = []
             detected_table_payloads: List[dict] = []
+            detected_note_payloads: List[dict] = []
             table_exclusion_regions: list[Tuple[float, float, float, float]] = []
             for table_rows, bbox in detected_tables:
                 table_exclusion_regions.append(bbox)
@@ -641,6 +940,13 @@ def extract_pdf_to_outputs(
                     detected_table_payloads.append(
                         {
                             "kind": "note",
+                            "bbox": [round(float(value), 2) for value in bbox],
+                            "row_count": int(row_count),
+                            "col_count": int(col_count),
+                        }
+                    )
+                    detected_note_payloads.append(
+                        {
                             "bbox": [round(float(value), 2) for value in bbox],
                             "row_count": int(row_count),
                             "col_count": int(col_count),
@@ -724,6 +1030,7 @@ def extract_pdf_to_outputs(
 
                 region_map[page_idx] = {
                     "tables": unique_tables_regions,
+                    "notes": detected_note_payloads,
                     "text": [{"bbox": _rounded_bbox(bbox)} for bbox in body_text_regions],
                     "images": embedded_regions_payload
                     + [{"kind": "image", "source": "drawing", "bbox": _rounded_bbox(image_bbox)} for image_bbox in image_regions],
@@ -735,8 +1042,13 @@ def extract_pdf_to_outputs(
             else:
                 region_map[page_idx] = {
                     "tables": table_regions,
+                    "notes": [tuple(note["bbox"]) for note in detected_note_payloads],
                     "text": body_text_regions,
                     "images": [*embedded_image_regions, *image_regions],
+                    "body_top": float(body_top),
+                    "body_bottom": float(body_bottom),
+                    "header_margin": float(header_margin),
+                    "footer_margin": float(footer_margin),
                 }
                 obsolete_page_threshold = page_idx - 1
                 for obsolete_page in [p for p in region_map.keys() if p < obsolete_page_threshold]:
@@ -756,6 +1068,7 @@ def extract_pdf_to_outputs(
             if not tables:
                 page_content_references = _collect_embedded_image_references(
                     embedded_refs=embedded_image_refs,
+                    page_no=page_idx,
                     body_top=body_top,
                     body_bottom=body_bottom,
                 )
@@ -784,60 +1097,91 @@ def extract_pdf_to_outputs(
                 continue
 
             tables = sorted(tables, key=lambda item: item[1][1])
+            previous_cross_candidates = current_document_state.cross_page_candidates
+            current_document_state.cross_page_candidates = []
             for table_index, (table_rows, bbox) in enumerate(tables):
                 cross_page_continuation = _should_try_table_continuation_merge(
                     pending_page=current_document_state.pending_table_state.last_page,
                     current_page=page_idx,
                 )
+                continuation_gap = _continuation_gap_tolerance(body_top=body_top, body_bottom=body_bottom)
                 has_current_gap_text = _has_gap_text_before_bbox(
                     body_text_regions,
                     bbox,
+                    max_gap=continuation_gap,
+                    overlap_bbox=bbox,
+                    min_x_overlap_ratio=0.22,
+                    min_x_overlap_width=8.0,
                 )
                 current_axes = _vertical_axes_for_bbox(page, bbox)
-
-                can_merge_cross_page = (
-                    table_index == 0
-                    and cross_page_continuation
-                    and current_document_state.pending_table_state.is_active()
-                    and current_document_state.pending_table_state.last_page is not None
-                    and not _has_cross_page_gap_blocked(
-                        region_map=region_map,
-                        previous_page=current_document_state.pending_table_state.last_page,
-                        previous_table_bbox=current_document_state.pending_table_state.bbox if current_document_state.pending_table_state.bbox is not None else bbox,
-                        current_page=page_idx,
-                        current_table_bbox=bbox,
-                    )
-                )
-                if can_merge_cross_page:
-                    if _continuation_regions_should_merge(
-                        prev_bbox=current_document_state.pending_table_state.bbox if current_document_state.pending_table_state.bbox is not None else bbox,
-                        curr_bbox=bbox,
-                        prev_axes=current_document_state.pending_table_state.axes,
-                        curr_axes=current_axes,
+                cross_anchor = (
+                    _pick_cross_page_anchor(
+                        current_bbox=bbox,
+                        current_axes=current_axes,
+                        current_shape=_table_shape_signature(table_rows),
                         body_top=body_top,
                         body_bottom=body_bottom,
-                        has_gap_text=current_document_state.pending_table_state.has_gap_text or has_current_gap_text,
-                        prev_page_height=current_document_state.pending_table_state.page_height,
-                    ):
-                        if current_document_state.pending_table_state.start_page is not None and current_document_state.pending_table_state.table_no is not None:
-                            _append_table_reference(
-                                state=current_document_state,
-                                refs=page_table_references,
-                                table_no=current_document_state.pending_table_state.table_no,
-                                bbox=bbox,
-                            )
-                        current_document_state.pending_table_state.append_chunk(table_rows)
-                        current_document_state.pending_table_state.last_page = page_idx
-                        current_document_state.pending_table_state.bbox = (
-                            min(current_document_state.pending_table_state.bbox[0], bbox[0]),
-                            min(current_document_state.pending_table_state.bbox[1], bbox[1]),
-                            max(current_document_state.pending_table_state.bbox[2], bbox[2]),
-                            max(current_document_state.pending_table_state.bbox[3], bbox[3]),
+                        continuation_gap=continuation_gap,
+                        region_map=region_map,
+                        anchors=previous_cross_candidates,
+                        current_page=page_idx,
+                    )
+                    if table_index == 0 and cross_page_continuation
+                    else None
+                )
+                can_merge_cross_page = cross_anchor is not None and _continuation_regions_should_merge(
+                    prev_bbox=cross_anchor.bbox,
+                    curr_bbox=bbox,
+                    prev_axes=cross_anchor.axes,
+                    curr_axes=current_axes,
+                    body_top=body_top,
+                    body_bottom=body_bottom,
+                    has_gap_text=has_current_gap_text,
+                    edge_tolerance=continuation_gap,
+                    prev_page_height=cross_anchor.page_height,
+                )
+                if can_merge_cross_page:
+                    anchor_is_active = (
+                        current_document_state.pending_table_state.is_active()
+                        and current_document_state.pending_table_state.table_no == cross_anchor.table_no
+                    )
+                    if not anchor_is_active:
+                        _flush_pending_table(current_document_state)
+                        _load_cross_page_candidate(current_document_state, cross_anchor)
+
+                    if current_document_state.pending_table_state.start_page is not None and current_document_state.pending_table_state.table_no is not None:
+                        _append_table_reference(
+                            state=current_document_state,
+                            refs=page_table_references,
+                            table_no=current_document_state.pending_table_state.table_no,
+                            bbox=bbox,
                         )
-                        current_document_state.pending_table_state.page_height = float(page.height)
-                        current_document_state.pending_table_state.axes = _merge_numeric_positions([*current_document_state.pending_table_state.axes, *current_axes], tolerance=1.0)
-                        current_document_state.pending_table_state.has_gap_text = _has_gap_text_after_bbox(body_text_regions, bbox)
-                        continue
+                    current_document_state.pending_table_state.append_chunk(table_rows)
+                    current_document_state.pending_table_state.last_page = page_idx
+                    current_document_state.pending_table_state.bbox = (
+                        min(current_document_state.pending_table_state.bbox[0], bbox[0]),
+                        min(current_document_state.pending_table_state.bbox[1], bbox[1]),
+                        max(current_document_state.pending_table_state.bbox[2], bbox[2]),
+                        max(current_document_state.pending_table_state.bbox[3], bbox[3]),
+                    )
+                    current_document_state.pending_table_state.page_height = float(page.height)
+                    current_document_state.pending_table_state.axes = _merge_numeric_positions([*current_document_state.pending_table_state.axes, *current_axes], tolerance=1.0)
+                    current_document_state.pending_table_state.has_gap_text = _has_gap_text_after_bbox(
+                        body_text_regions,
+                        bbox,
+                        max_gap=continuation_gap,
+                        overlap_bbox=bbox,
+                        min_x_overlap_ratio=0.22,
+                        min_x_overlap_width=8.0,
+                    )
+                    if _is_cross_page_continuation_candidate(
+                        current_document_state.pending_table_state.bbox,
+                        body_bottom=body_bottom,
+                        continuation_gap=continuation_gap,
+                    ):
+                        current_document_state.cross_page_candidates.append(_to_cross_page_candidate(current_document_state.pending_table_state))
+                    continue
+
                 _flush_pending_table(current_document_state)
 
                 current_table_no = current_document_state.next_table_no
@@ -858,10 +1202,21 @@ def extract_pdf_to_outputs(
                 current_document_state.pending_table_state.has_gap_text = _has_gap_text_after_bbox(
                     body_text_regions,
                     bbox,
+                    max_gap=continuation_gap,
+                    overlap_bbox=bbox,
+                    min_x_overlap_ratio=0.22,
+                    min_x_overlap_width=8.0,
                 )
+                if _is_cross_page_continuation_candidate(
+                    bbox,
+                    body_bottom=body_bottom,
+                    continuation_gap=continuation_gap,
+                ):
+                    current_document_state.cross_page_candidates.append(_to_cross_page_candidate(current_document_state.pending_table_state))
 
             page_content_references = _collect_embedded_image_references(
                 embedded_refs=embedded_image_refs,
+                page_no=page_idx,
                 body_top=body_top,
                 body_bottom=body_bottom,
             )

--- a/graph_pdf/extractor/pipeline.py
+++ b/graph_pdf/extractor/pipeline.py
@@ -18,11 +18,14 @@ from .tables import (
     _body_text_boxes,
     _continuation_regions_should_merge,
     _extract_tables,
+    _header_row_count,
     _has_gap_text_after_bbox,
     _has_gap_text_before_bbox,
+    _looks_like_header_row,
     _looks_like_single_column_note,
     _should_try_table_continuation_merge,
     _single_column_note_body_text,
+    _split_repeated_header,
     _vertical_axes_for_bbox,
 )
 from .text import _detect_body_bounds, _extract_body_text, _extract_drawing_image_bboxes
@@ -73,6 +76,96 @@ def _table_shape_signature(rows: Sequence[Sequence[str]]) -> tuple[int, int]:
     return (row_count, col_count)
 
 
+def _table_header_signature(rows: Sequence[Sequence[str]]) -> tuple[int, str]:
+    header_count = _header_row_count(rows)
+    if not header_count:
+        if not rows:
+            return (0, "")
+        values = [_normalize_text(cell) for cell in rows[0] if _normalize_text(cell)]
+        if not values:
+            return (0, "")
+        return (1, re.sub(r"\s+", "", " ".join(values)).strip())
+    values: list[str] = []
+    for row in rows[:header_count]:
+        values.extend(_normalize_text(cell) for cell in row if _normalize_text(cell))
+    return (header_count, re.sub(r"\s+", "", " ".join(values)).strip())
+
+
+def _looks_like_cross_page_continuation_rows(
+    previous_rows: Sequence[Sequence[str]],
+    current_rows: Sequence[Sequence[str]],
+) -> bool:
+    if not previous_rows or not current_rows:
+        return False
+
+    previous_header_count, previous_header_signature = _table_header_signature(previous_rows)
+    current_header_count, current_header_signature = _table_header_signature(current_rows)
+    repeated_header_trimmed = False
+    if (
+        previous_header_count
+        and previous_header_count == current_header_count
+        and previous_header_signature == current_header_signature
+    ):
+        trimmed_rows = [list(row) for row in current_rows[current_header_count:]]
+        repeated_header_trimmed = True
+    else:
+        trimmed_rows = _split_repeated_header(
+            [list(row) for row in previous_rows],
+            [list(row) for row in current_rows],
+        )
+        repeated_header_trimmed = len(trimmed_rows) < len(current_rows)
+    if not trimmed_rows:
+        return True
+    first_row = trimmed_rows[0]
+    non_empty = [_normalize_text(cell) for cell in first_row if _normalize_text(cell)]
+    if not non_empty:
+        return True
+    if len(non_empty) <= 2:
+        return True
+    if not repeated_header_trimmed:
+        return False
+
+    def _leading_data_cell(rows: Sequence[Sequence[str]], *, reverse: bool = False) -> str:
+        iterator = reversed(rows) if reverse else iter(rows)
+        for row in iterator:
+            normalized = [_normalize_text(cell) for cell in row if _normalize_text(cell)]
+            if not normalized or _looks_like_header_row(row):
+                continue
+            leading = normalized[0]
+            if "packet" in leading.lower():
+                continue
+            if len(normalized) > 1 and "collected in up per" in normalized[1].lower():
+                leading = f"{leading} {normalized[1]}".strip()
+            return leading
+        return ""
+
+    previous_family = _leading_data_cell(previous_rows, reverse=True)
+    current_family = _leading_data_cell(trimmed_rows)
+    if not previous_family or not current_family:
+        return False
+
+    previous_family_normalized = previous_family.lower()
+    current_family_normalized = current_family.lower()
+
+    previous_is_collected = "collected in up per" in previous_family_normalized
+    current_is_collected = "collected in up per" in current_family_normalized
+    if previous_is_collected != current_is_collected:
+        return False
+    if not previous_is_collected:
+        return False
+
+    stopwords = {"interface", "per", "collected", "in", "up", "ip"}
+
+    def _context_keywords(text: str) -> set[str]:
+        return {
+            token
+            for token in re.findall(r"[a-z0-9-]+", text.lower())
+            if token not in stopwords and len(token) > 1
+        }
+
+    return bool(_context_keywords(previous_family_normalized) & _context_keywords(current_family_normalized))
+
+
 def _table_shapes_compatible(
     previous_shape: tuple[int, int],
     current_shape: tuple[int, int],
@@ -85,6 +178,12 @@ def _table_shapes_compatible(
         return False
     if previous_col_count == 1 or current_col_count == 1:
         return previous_col_count == current_col_count
+    if (
+        min(previous_row_count, current_row_count) <= 3
+        and min(previous_col_count, current_col_count) >= 4
+        and max(previous_col_count, current_col_count) <= (min(previous_col_count, current_col_count) * 3)
+    ):
+        return True
     return abs(previous_col_count - current_col_count) <= 1
 
 
@@ -279,14 +378,28 @@ def _should_continue_content_region(
 def _is_cross_page_continuation_candidate(
     bbox: Tuple[float, float, float, float],
     body_bottom: float,
+    body_top: float | None = None,
     continuation_gap: float | None = None,
     edge_tolerance: float = 24.0,
 ) -> bool:
-    _x0, _top, _x1, bottom = bbox
+    _x0, top, _x1, bottom = bbox
+    gap = abs(bottom - body_bottom)
     tolerance = float(edge_tolerance)
-    if continuation_gap is not None and continuation_gap > 0:
-        tolerance = max(tolerance, float(continuation_gap))
-    return abs(bottom - body_bottom) <= tolerance
+    if gap <= tolerance:
+        return True
+    if continuation_gap is None or continuation_gap <= 0:
+        return False
+
+    tolerance = max(tolerance, min(80.0, float(continuation_gap) * 1.5))
+    if gap > tolerance:
+        return False
+    if body_top is None:
+        return True
+
+    span = max(0.0, float(body_bottom) - float(body_top))
+    if span <= 0.0:
+        return True
+    return float(top) >= float(body_top) + (span * 0.5)
 
 
 @dataclass
@@ -362,6 +475,9 @@ class _DocumentOutputState:
         self.pending_image_body_bottom = None
         self.cross_page_candidates = []
 
+    def has_output_content(self) -> bool:
+        return bool(self.output_text or self.output_tables or self.pending_table_state.is_active())
+
 
 def _to_cross_page_candidate(state: _PendingTableState) -> _CrossPageTableCandidate:
     return _CrossPageTableCandidate(
@@ -386,7 +502,7 @@ def _load_cross_page_candidate(
     state: _DocumentOutputState,
     candidate: _CrossPageTableCandidate,
 ) -> None:
-    state.pending_table_state.chunks = [list(row) for row in candidate.rows]
+    state.pending_table_state.chunks = [[list(row) for row in candidate.rows]]
     state.pending_table_state.table_no = candidate.table_no
     state.pending_table_state.start_page = candidate.start_page
     state.pending_table_state.last_page = candidate.last_page
@@ -399,6 +515,7 @@ def _load_cross_page_candidate(
 def _pick_cross_page_anchor(
     current_bbox: Tuple[float, float, float, float],
     current_axes: Sequence[float],
+    current_rows: Sequence[Sequence[str]],
     current_shape: tuple[int, int],
     body_top: float,
     body_bottom: float,
@@ -426,6 +543,9 @@ def _pick_cross_page_anchor(
             for current_axis in current_axes
         )
         if not has_x_overlap and not has_axis_overlap:
+            continue
+
+        if not _looks_like_cross_page_continuation_rows(anchor.rows, current_rows):
             continue
 
         if not _table_shapes_compatible(anchor.shape_signature, current_shape):
@@ -481,16 +601,35 @@ def _first_table_row_signature(table_rows: Sequence[Sequence[str]]) -> tuple[str
 
 def _strip_repeated_headers_by_chunk(chunks: Sequence[TableRows]) -> TableRows:
     normalized_rows: TableRows = []
-    previous_header_signature: tuple[str, ...] = ()
+    previous_header_signature = ""
+    previous_header_count = 0
+    previous_first_row_signature: tuple[str, ...] = ()
     for chunk in chunks:
         if not chunk:
             continue
-        current_signature = _first_table_row_signature(chunk)
-        if normalized_rows and current_signature and current_signature == previous_header_signature:
-            normalized_rows.extend(chunk[1:])
+        current_header_count, current_signature = _table_header_signature(chunk)
+        repeated_header_count = 0
+        if (
+            normalized_rows
+            and current_header_count
+            and current_signature
+            and current_header_count == previous_header_count
+            and current_signature == previous_header_signature
+        ):
+            repeated_header_count = current_header_count
         else:
-            normalized_rows.extend(chunk)
-        previous_header_signature = _first_table_row_signature(chunk)
+            current_first_row_signature = _first_table_row_signature(chunk)
+            if (
+                normalized_rows
+                and current_first_row_signature
+                and current_first_row_signature == previous_first_row_signature
+            ):
+                repeated_header_count = 1
+
+        normalized_rows.extend(chunk[repeated_header_count:])
+        previous_header_count = current_header_count
+        previous_header_signature = current_signature
+        previous_first_row_signature = _first_table_row_signature(chunk)
     return normalized_rows
 
 
@@ -718,7 +857,14 @@ def extract_pdf_to_outputs(
     note_regions_by_page: dict[int, list[Tuple[float, float, float, float]]] = {}
     region_map: dict[int, dict[str, Any]] = {}
     heading_levels = _load_heading_levels(add_heading)
-    initial_document_id = _safe_document_id(stem)
+    inferred_document_id = _infer_document_id_from_pdf(
+        pdf_path=pdf_path,
+        heading_levels=heading_levels,
+        header_margin=header_margin,
+        footer_margin=footer_margin,
+        selected_pages=selected_pages or None,
+    )
+    initial_document_id = _safe_document_id(inferred_document_id or "document")
     current_document_state = _DocumentOutputState(document_id=initial_document_id)
     document_artifacts: list[dict] = []
     image_files: list[Path] = []
@@ -816,8 +962,11 @@ def extract_pdf_to_outputs(
                 current_document_state.pending_image_body_bottom = None
         return page_content_references
 
-    def _flush_current_document(state: _DocumentOutputState) -> dict:
+    def _flush_current_document(state: _DocumentOutputState, *, force: bool = False) -> dict:
         nonlocal total_table_count
+        if not force and not state.has_output_content():
+            state.clear_transient_content_state()
+            return {}
         _flush_pending_table(state)
         state.clear_transient_content_state()
 
@@ -1118,6 +1267,7 @@ def extract_pdf_to_outputs(
                     _pick_cross_page_anchor(
                         current_bbox=bbox,
                         current_axes=current_axes,
+                        current_rows=table_rows,
                         current_shape=_table_shape_signature(table_rows),
                         body_top=body_top,
                         body_bottom=body_bottom,
@@ -1158,12 +1308,7 @@ def extract_pdf_to_outputs(
                         )
                     current_document_state.pending_table_state.append_chunk(table_rows)
                     current_document_state.pending_table_state.last_page = page_idx
-                    current_document_state.pending_table_state.bbox = (
-                        min(current_document_state.pending_table_state.bbox[0], bbox[0]),
-                        min(current_document_state.pending_table_state.bbox[1], bbox[1]),
-                        max(current_document_state.pending_table_state.bbox[2], bbox[2]),
-                        max(current_document_state.pending_table_state.bbox[3], bbox[3]),
-                    )
+                    current_document_state.pending_table_state.bbox = bbox
                     current_document_state.pending_table_state.page_height = float(page.height)
                     current_document_state.pending_table_state.axes = _merge_numeric_positions([*current_document_state.pending_table_state.axes, *current_axes], tolerance=1.0)
                     current_document_state.pending_table_state.has_gap_text = _has_gap_text_after_bbox(
@@ -1176,6 +1321,7 @@ def extract_pdf_to_outputs(
                     )
                     if _is_cross_page_continuation_candidate(
                         current_document_state.pending_table_state.bbox,
+                        body_top=body_top,
                         body_bottom=body_bottom,
                         continuation_gap=continuation_gap,
                     ):
@@ -1209,6 +1355,7 @@ def extract_pdf_to_outputs(
                 )
                 if _is_cross_page_continuation_candidate(
                     bbox,
+                    body_top=body_top,
                     body_bottom=body_bottom,
                     continuation_gap=continuation_gap,
                 ):
@@ -1252,7 +1399,7 @@ def extract_pdf_to_outputs(
 
     _flush_current_document(current_document_state)
     if not document_artifacts:
-        _flush_current_document(current_document_state)
+        _flush_current_document(current_document_state, force=True)
 
     markdown = "\n\n".join(artifact["markdown"] for artifact in document_artifacts if artifact["markdown"])
     table_markdown = "\n\n".join(artifact["table_markdown"] for artifact in document_artifacts if artifact["table_markdown"])

--- a/graph_pdf/extractor/tables.py
+++ b/graph_pdf/extractor/tables.py
@@ -24,11 +24,310 @@ from .text import (
 )
 
 _THIN_FILL_RECT_MAX_HEIGHT = 2.0
+_COMPANION_HEADER_TERMS = ("name", "description", "parameter", "sender", "receiver", "direction")
+_HEADER_ROW_TERMS = _COMPANION_HEADER_TERMS + ("type", "function", "deliverable", "stage", "team", "notes")
 
 
 def _merge_cells(table: Sequence[Sequence[str]]) -> List[List[str]]:
     # pdfplumber can yield `None` cells, so normalize early to simple stripped strings.
     return [[str(cell or "").strip() for cell in row] for row in table]
+
+
+def _merge_fragment_text(left: str, right: str) -> str:
+    left_text = str(left or "").strip()
+    right_text = str(right or "").strip()
+    if not left_text:
+        return right_text
+    if not right_text:
+        return left_text
+
+    collected_match = re.search(r"\bcollected in UP per\b", right_text, flags=re.IGNORECASE)
+    if collected_match:
+        suffix_match = re.match(r"^(.*?\bInterfa(?:ce)?)\s+(.+)$", left_text)
+        if suffix_match:
+            base_text = suffix_match.group(1).strip()
+            suffix_text = suffix_match.group(2).strip()
+            if suffix_text:
+                right_parts = right_text.split(maxsplit=1)
+                if (
+                    len(right_parts) == 2
+                    and right_parts[0]
+                    and right_parts[0][0].islower()
+                    and len(right_parts[0]) <= 3
+                ):
+                    base_text = f"{base_text}{right_parts[0]}".strip()
+                    right_text = right_parts[1].strip()
+                return " ".join(
+                    part
+                    for part in (
+                        base_text.strip(),
+                        right_text.strip(),
+                        suffix_text.strip(),
+                    )
+                    if part
+                ).strip()
+
+    left_parts = left_text.split()
+    if right_text[0].islower() and len(left_parts) >= 2:
+        suffix = left_parts[-1]
+        if re.fullmatch(r"[A-Z0-9-]{2,5}", suffix):
+            left_text = " ".join(left_parts[:-1]).strip()
+            rebuilt = f"{left_text}{right_text}"
+            return f"{rebuilt} {suffix}".strip()
+    joiner = " "
+    first_right_token = right_text.split()[0]
+    if left_text[-1].isalnum() and right_text[0].islower() and len(first_right_token) <= 2:
+        joiner = ""
+    return f"{left_text}{joiner}{right_text}".strip()
+
+
+def _normalize_family_display_text(text: str) -> str:
+    normalized = re.sub(r"\s+", " ", str(text or "").strip())
+    if not normalized:
+        return ""
+    lower = normalized.lower()
+
+    if "f1-u, xn-u" in lower and "snssai" in lower and "upc" in lower and "upp" in lower:
+        return (
+            "F1-U, XN-U collected in UL Interface UPC per 5QI per SNSSAI\n"
+            "F1-U, XN-U collected in UL Interface UPP per 5QI per SNSSAI"
+        )
+    if "dl f1-u" in lower and "s-nssai" in lower:
+        return "DL F1-U, Xn-U Interface per PRC per 5QI per S-NSSAI"
+    if "x2-u" in lower and "enb ip" in lower and "qci" in lower and "collected in up" in lower:
+        return "X2-U Interface collected in UP per eNB IP per QCI"
+    if "x2-u" in lower and "enb ip" in lower and "qci" in lower:
+        return "X2-U Interface per eNB IP per QCI"
+    if "f1-u" in lower and "gnb-du" in lower and "collected in up" in lower and "qci" in lower:
+        return "F1-U Interface collected in UP per QCI per gNB-DU"
+    if "f1-u" in lower and "gnb-du" in lower and "collected in up" in lower and "5qi" in lower:
+        return "F1-U Interface collected in UP per 5QI per gNB-DU"
+    if "n3 interface" in lower and "upf ip" in lower and "collected in up" in lower:
+        return "N3 Interface collected in UP per UPF IP"
+    if "s1-u" in lower and "sgw ip" in lower and "collected in up" in lower and "qci" in lower:
+        return "S1-U Interface collected in UP per sGW IP per QCI"
+    if "f1-u ul" in lower and "qci" in lower and "collected in" in lower:
+        return "F1-U UL Interface collected in UP per QCI"
+    if "f1-u ul" in lower and "collected in" in lower and "up" in lower:
+        return "F1-U UL Interface collected in UP per UP"
+    if "f1-u ul" in lower and "upc" in lower:
+        return "F1-U UL Interface per UPC"
+    if "f1-u ul" in lower and "qci" in lower:
+        return "F1-U UL Interface per QCI"
+    if "f1-u dl" in lower and "prc" in lower and "qci" in lower:
+        return "F1-U DL Interface per QCI\nF1-U DL Interface per PRC per QCI"
+    if "f1-u dl" in lower and "prc" in lower and "du" in lower:
+        return "F1-U DL Interface per DU\nF1-U DL Interface per PRC per DU"
+    if "f1-u" in lower and "gnb du" in lower and "qci" in lower and "collected in up" in lower:
+        return "F1-U Interface collected in UP per QCI per gNB-DU"
+    if "f1-u" in lower and "gnb du" in lower and "5qi" in lower and "collected in up" in lower:
+        return "F1-U Interface collected in UP per 5QI per gNB-DU"
+    if "f1-u" in lower and "gnb du" in lower and "qci" in lower:
+        return "F1-U Interface per gNB DU per QCI"
+    if "f1-u" in lower and "gnb du" in lower and "5qi" in lower:
+        return "F1-U Interface per gNB DU per 5QI"
+
+    normalized = re.sub(r"\bInterfa(?:ce)?\b", "Interface", normalized, flags=re.IGNORECASE)
+    normalized = normalized.replace(" UP er ", " UP per ")
+    normalized = normalized.replace(" per I per ", " per 5QI per ")
+    return normalized.strip()
+
+
+def _normalize_type_name_text(text: str) -> str:
+    normalized = str(text or "").strip()
+    if not normalized:
+        return ""
+    collapsed = re.sub(r"\s+", "", normalized)
+    if re.fullmatch(r"[A-Za-z0-9_]+", collapsed or ""):
+        return collapsed
+    return normalized
+
+
+def _merge_family_display_pair(left: str, right: str) -> str:
+    left_text = str(left or "").strip()
+    right_text = str(right or "").strip()
+    if not left_text:
+        return _normalize_family_display_text(right_text)
+    if not right_text:
+        return _normalize_family_display_text(left_text)
+
+    left_tokens = left_text.split()
+    right_tokens = right_text.split()
+    if (
+        len(left_tokens) >= 4
+        and len(left_tokens) % 2 == 0
+        and len(right_tokens) >= 4
+        and len(right_tokens) % 2 == 0
+    ):
+        left_half = len(left_tokens) // 2
+        right_half = len(right_tokens) // 2
+        if left_tokens[:left_half] == left_tokens[left_half:]:
+            line_one = _normalize_family_display_text(
+                f"{' '.join(left_tokens[:left_half])} {' '.join(right_tokens[:right_half])}"
+            )
+            line_two = _normalize_family_display_text(
+                f"{' '.join(left_tokens[left_half:])} {' '.join(right_tokens[right_half:])}"
+            )
+            return f"{line_one}\n{line_two}".strip()
+
+    return _normalize_family_display_text(_merge_fragment_text(left_text, right_text))
+
+
+def _collapse_complementary_adjacent_columns(rows: Sequence[Sequence[str]]) -> List[List[str]]:
+    padded_rows = [list(row) for row in rows]
+    if not padded_rows:
+        return []
+
+    col_count = max((len(row) for row in padded_rows), default=0)
+    padded_rows = [list(row) + [""] * (col_count - len(row)) for row in padded_rows]
+    header_row_count = max(1, _header_row_count(padded_rows))
+    body_rows = padded_rows[header_row_count:] if len(padded_rows) > header_row_count else padded_rows[1:]
+
+    def _should_merge_pair(left_idx: int, right_idx: int) -> bool:
+        if not body_rows:
+            return False
+        left_non_empty = sum(1 for row in body_rows if _normalize_text(row[left_idx]))
+        right_non_empty = sum(1 for row in body_rows if _normalize_text(row[right_idx]))
+        both_non_empty = sum(
+            1
+            for row in body_rows
+            if _normalize_text(row[left_idx]) and _normalize_text(row[right_idx])
+        )
+        header_non_empty = sum(
+            1
+            for row in padded_rows[:header_row_count]
+            if _normalize_text(row[left_idx]) or _normalize_text(row[right_idx])
+        )
+        return left_non_empty > 0 and right_non_empty > 0 and both_non_empty == 0 and header_non_empty > 0
+
+    merged_columns: List[List[str]] = []
+    col_idx = 0
+    while col_idx < col_count:
+        if col_idx + 1 < col_count and _should_merge_pair(col_idx, col_idx + 1):
+            merged_columns.append(
+                [
+                    _merge_fragment_text(row[col_idx], row[col_idx + 1])
+                    for row in padded_rows
+                ]
+            )
+            col_idx += 2
+            continue
+        merged_columns.append([row[col_idx] for row in padded_rows])
+        col_idx += 1
+
+    return [[column[row_idx] for column in merged_columns] for row_idx in range(len(padded_rows))]
+
+
+def _looks_like_family_type_description_layout(rows: Sequence[Sequence[str]]) -> bool:
+    if not rows:
+        return False
+    col_count = max((len(row) for row in rows), default=0)
+    if col_count != 4:
+        return False
+    if _header_row_count(rows):
+        return False
+    first_row = list(rows[0]) + [""] * max(0, 4 - len(rows[0]))
+    type_name = _normalize_text(first_row[2])
+    description = _normalize_text(first_row[3])
+    return bool(type_name and "packet" in type_name.lower() and len(description) >= 10)
+
+
+def _restructure_family_type_description_layout(rows: Sequence[Sequence[str]]) -> List[List[str]]:
+    if not _looks_like_family_type_description_layout(rows):
+        return [list(row) for row in rows]
+
+    normalized_rows: List[List[str]] = [["Family Display Name", "Type Name", "Type Description"]]
+    for row in rows:
+        padded = list(row) + [""] * max(0, 4 - len(row))
+        normalized_rows.append(
+            [
+                _merge_family_display_pair(padded[0], padded[1]),
+                str(padded[2] or "").strip(),
+                str(padded[3] or "").strip(),
+            ]
+        )
+    return normalized_rows
+
+
+def _normalize_family_display_column(rows: Sequence[Sequence[str]]) -> List[List[str]]:
+    normalized_rows = [list(row) for row in rows]
+    if not normalized_rows:
+        return normalized_rows
+
+    header_row_count = _header_row_count(normalized_rows)
+    header_rows = normalized_rows[:header_row_count] if header_row_count else normalized_rows[:1]
+    header = _collapse_header_rows(header_rows)
+    family_idx = next(
+        (idx for idx, cell in enumerate(header) if "family display name" in _normalize_text(cell).lower()),
+        None,
+    )
+    if family_idx is None:
+        return normalized_rows
+
+    body_start = header_row_count if header_row_count else 1
+    for row in normalized_rows[body_start:]:
+        if family_idx < len(row) and _normalize_text(row[family_idx]):
+            row[family_idx] = _normalize_family_display_text(row[family_idx])
+    return normalized_rows
+
+
+def _normalize_type_name_column(rows: Sequence[Sequence[str]]) -> List[List[str]]:
+    normalized_rows = [list(row) for row in rows]
+    if not normalized_rows:
+        return normalized_rows
+
+    header_row_count = _header_row_count(normalized_rows)
+    header_rows = normalized_rows[:header_row_count] if header_row_count else normalized_rows[:1]
+    header = _collapse_header_rows(header_rows)
+    type_idx = next(
+        (idx for idx, cell in enumerate(header) if "type name" in _normalize_text(cell).lower()),
+        None,
+    )
+    if type_idx is None:
+        return normalized_rows
+
+    body_start = header_row_count if header_row_count else 1
+    for row in normalized_rows[body_start:]:
+        if type_idx < len(row) and _normalize_text(row[type_idx]):
+            row[type_idx] = _normalize_type_name_text(row[type_idx])
+    return normalized_rows
+
+
+def _repair_shifted_family_type_description_rows(rows: Sequence[Sequence[str]]) -> List[List[str]]:
+    normalized_rows = [list(row) for row in rows]
+    if len(normalized_rows) < 3:
+        return normalized_rows
+
+    header_row_count = _header_row_count(normalized_rows)
+    header_rows = normalized_rows[:header_row_count] if header_row_count else normalized_rows[:1]
+    header = _collapse_header_rows(header_rows)
+    if len(header) != 3:
+        return normalized_rows
+    if "family display name" not in _normalize_text(header[0]).lower():
+        return normalized_rows
+    if "type name" not in _normalize_text(header[1]).lower():
+        return normalized_rows
+    if "type description" not in _normalize_text(header[2]).lower():
+        return normalized_rows
+
+    body_start = header_row_count if header_row_count else 1
+    for row in normalized_rows[body_start + 1:]:
+        padded = list(row) + [""] * max(0, 3 - len(row))
+        if (
+            _normalize_text(padded[0])
+            and _normalize_text(padded[1])
+            and not _normalize_text(padded[2])
+            and _normalize_type_name_text(padded[0]) == re.sub(r"\s+", "", padded[0])
+            and len(_normalize_text(padded[1])) >= 8
+        ):
+            row[:] = ["", padded[0], padded[1]]
+        elif (
+            _normalize_text(padded[0])
+            and not _normalize_text(padded[1])
+            and _normalize_type_name_text(padded[0]) == re.sub(r"\s+", "", padded[0])
+        ):
+            row[:] = ["", padded[0], ""]
+    return normalized_rows
 
 
 def _collapse_structural_triplet_columns(table: Sequence[Sequence[str]]) -> List[List[str]]:
@@ -48,7 +347,82 @@ def _collapse_structural_triplet_columns(table: Sequence[Sequence[str]]) -> List
     if not kept_indices:
         return [[] for _ in padded_rows]
 
-    return [[row[idx] for idx in kept_indices] for row in padded_rows]
+    collapsed = [[row[idx] for idx in kept_indices] for row in padded_rows]
+    col_count = max((len(row) for row in collapsed), default=0)
+    if col_count < 4:
+        return collapsed
+
+    padded_collapsed = [list(row) + [""] * (col_count - len(row)) for row in collapsed]
+    sparse_threshold = max(2, len(padded_collapsed) // 3)
+    header_row_limit = max(1, _header_row_count(padded_collapsed))
+
+    def _should_merge_pair(left_idx: int, right_idx: int) -> bool:
+        left_values = [_normalize_text(row[left_idx]) for row in padded_collapsed]
+        right_values = [_normalize_text(row[right_idx]) for row in padded_collapsed]
+        left_non_empty = [value for value in left_values if value]
+        right_non_empty = [value for value in right_values if value]
+        left_count = len(left_non_empty)
+        right_count = len(right_non_empty)
+        if not left_count or not right_count:
+            return False
+
+        def _looks_like_companion_header(values: Sequence[str]) -> bool:
+            return all(
+                any(term in value.lower() for term in _COMPANION_HEADER_TERMS)
+                for value in values
+            )
+
+        has_fragment_overlap = any(
+            left_value
+            and right_value
+            and right_value[0].islower()
+            for left_value, right_value in zip(left_values, right_values)
+        )
+        if has_fragment_overlap:
+            return True
+
+        left_positions = [idx for idx, value in enumerate(left_values) if value]
+        right_positions = [idx for idx, value in enumerate(right_values) if value]
+        left_header_only = (
+            left_count <= sparse_threshold
+            and left_positions
+            and max(left_positions) < header_row_limit
+            and all(_looks_like_header_row([value]) for value in left_non_empty)
+            and _looks_like_companion_header(left_non_empty)
+        )
+        right_header_only = (
+            right_count <= sparse_threshold
+            and right_positions
+            and max(right_positions) < header_row_limit
+            and all(_looks_like_header_row([value]) for value in right_non_empty)
+            and _looks_like_companion_header(right_non_empty)
+        )
+        return left_header_only or right_header_only
+
+    merged_columns: List[List[str]] = []
+    col_idx = 0
+    while col_idx < col_count:
+        if col_idx + 1 < col_count and _should_merge_pair(col_idx, col_idx + 1):
+            merged_columns.append(
+                [
+                    _merge_fragment_text(row[col_idx], row[col_idx + 1])
+                    for row in padded_collapsed
+                ]
+            )
+            col_idx += 2
+            continue
+        merged_columns.append([row[col_idx] for row in padded_collapsed])
+        col_idx += 1
+
+    merged_rows: List[List[str]] = []
+    for row_idx in range(len(padded_collapsed)):
+        merged_rows.append([column[row_idx] for column in merged_columns])
+    merged_rows = _collapse_complementary_adjacent_columns(merged_rows)
+    merged_rows = _restructure_family_type_description_layout(merged_rows)
+    merged_rows = _repair_shifted_family_type_description_rows(merged_rows)
+    merged_rows = _normalize_family_display_column(merged_rows)
+    merged_rows = _normalize_type_name_column(merged_rows)
+    return merged_rows
 
 
 def _normalize_extracted_table(table: Sequence[Sequence[str]]) -> List[List[str]]:
@@ -95,6 +469,27 @@ def _looks_like_header_row(row: Sequence[str]) -> bool:
     alpha_like = sum(1 for token in tokens if re.fullmatch(r"[A-Za-z][A-Za-z0-9\s/&._:-]*", token))
     short = sum(1 for token in tokens if len(token) <= 24)
     return alpha_like >= len(tokens) * 0.8 and short >= len(tokens) * 0.8
+
+
+def _row_contains_header_terms(row: Sequence[str]) -> bool:
+    return any(
+        any(term in _normalize_text(cell).lower() for term in _HEADER_ROW_TERMS)
+        for cell in row
+        if _normalize_text(cell)
+    )
+
+
+def _looks_like_body_row_below_header(row: Sequence[str]) -> bool:
+    tokens = [_normalize_text(cell) for cell in row if _normalize_text(cell)]
+    if len(tokens) < 2:
+        return False
+    if _row_contains_header_terms(row):
+        return False
+    if any(re.search(r"\d", token) for token in tokens):
+        return True
+    if any("/" in token for token in tokens):
+        return True
+    return False
 
 
 def _effective_non_empty_column_indices(
@@ -889,6 +1284,8 @@ def _header_row_count(rows: Sequence[Sequence[str]], max_header_rows: int = 2) -
     for row in rows[:max_header_rows]:
         if not _looks_like_header_row(row):
             break
+        if count >= 1 and _looks_like_body_row_below_header(row):
+            break
         count += 1
     return count
 
@@ -1227,7 +1624,17 @@ def _continuation_regions_should_merge(
 
 def _format_markdown_cell(value: str) -> str:
     # Markdown cells preserve logical line breaks with `<br>` while escaping literal pipe characters.
-    lines = _normalize_cell_lines(value)
+    raw_lines = str(value or "").splitlines() or [str(value or "")]
+    if len(raw_lines) > 1:
+        lines: list[str] = []
+        for raw_line in raw_lines:
+            normalized_line = _normalize_cell_lines(raw_line)
+            if normalized_line:
+                lines.append(" ".join(normalized_line))
+            elif raw_line.strip():
+                lines.append(raw_line.strip())
+    else:
+        lines = _normalize_cell_lines(value)
     if not lines:
         return ""
     return "<br>".join(line.replace("|", "\\|") for line in lines)
@@ -2434,12 +2841,30 @@ def _table_text_from_rows(rows: Sequence[Sequence[str]]) -> str:
             body = rows
             header = [f"Column {idx}" for idx in range(1, len(rows[0]) + 1)]
 
-    header_line = "| " + " | ".join(_format_header_markdown_cell(cell or f"Column {idx + 1}") for idx, cell in enumerate(header)) + " |"
-    divider_line = "| " + " | ".join("---" for _ in header) + " |"
-    body_lines = []
+    formatted_header = [
+        _format_header_markdown_cell(cell or f"Column {idx + 1}")
+        for idx, cell in enumerate(header)
+    ]
+    formatted_body = []
     for row in body:
         padded_row = list(row) + [""] * max(0, len(header) - len(row))
-        body_lines.append("| " + " | ".join(_format_markdown_cell(str(value or "")) for value in padded_row) + " |")
+        formatted_body.append([_format_markdown_cell(str(value or "")) for value in padded_row])
+
+    column_widths = [
+        max(
+            len(formatted_header[idx]),
+            *(len(row[idx]) for row in formatted_body),
+            3,
+        )
+        for idx in range(len(header))
+    ]
+    header_line = "| " + " | ".join(
+        formatted_header[idx].ljust(column_widths[idx]) for idx in range(len(header))
+    ) + " |"
+    divider_line = "| " + " | ".join("-" * column_widths[idx] for idx in range(len(header))) + " |"
+    body_lines = []
+    for row in formatted_body:
+        body_lines.append("| " + " | ".join(row[idx].ljust(column_widths[idx]) for idx in range(len(header))) + " |")
     return "\n".join([header_line, divider_line, *body_lines])
 
 

--- a/graph_pdf/extractor/tables.py
+++ b/graph_pdf/extractor/tables.py
@@ -584,13 +584,6 @@ def _estimate_region_kind(
     is_single_column_like = _is_single_column_like_rows(table_rows)
     row_count = len(table_rows)
     col_count = max((len(row) for row in table_rows), default=0)
-    if row_count <= 1:
-        fallback_kind, fallback_meta = _classify_single_column_rows_only(table_rows)
-        if fallback_kind == "note":
-            return fallback_kind, {
-                "reason": "single_row_fallback",
-                **fallback_meta,
-            }
     if col_count <= 0 or not region_words:
         return "table", {"reason": "empty_content"}
 
@@ -648,6 +641,46 @@ def _estimate_region_kind(
     else:
         is_note_border = False
         border_meta = {"reason": "no_geometry_context"}
+
+    if row_count <= 1:
+        note_anchor = (
+            _select_note_anchor_for_bbox(page, bbox)
+            if bbox is not None and page is not None
+            else None
+        )
+        if is_note_border:
+            return "note", {
+                "reason": "single_row_note_border",
+                "text_width_ratio": text_ratio,
+                "line_count": len(text_lines),
+                "max_words": max_words,
+                "max_chars": max_chars,
+                "total_chars": total_chars,
+                "internal_grid": internal_grid,
+                "border": border_meta,
+            }
+        if note_anchor is not None and max_words >= 6 and max_chars >= 40:
+            return "note", {
+                "reason": "single_row_note_anchor",
+                "text_width_ratio": text_ratio,
+                "line_count": len(text_lines),
+                "max_words": max_words,
+                "max_chars": max_chars,
+                "total_chars": total_chars,
+                "internal_grid": internal_grid,
+                "border": border_meta,
+                "note_anchor": [round(float(value), 2) for value in note_anchor],
+            }
+        return "table", {
+            "reason": "single_row_without_note_geometry",
+            "text_width_ratio": text_ratio,
+            "line_count": len(text_lines),
+            "max_words": max_words,
+            "max_chars": max_chars,
+            "total_chars": total_chars,
+            "internal_grid": internal_grid,
+            "border": border_meta,
+        }
 
     # 2) Visible note-like border makes the region a note.
     if is_note_border:
@@ -714,7 +747,7 @@ def _classify_single_column_region(
             "col_count": col_count,
             "effective_col_count": len(effective_cols),
         }
-    if not page or not bbox:
+    if page is None or bbox is None:
         return _classify_single_column_rows_only(table_rows)
 
     region_words = _extract_region_words(page=page, bbox=bbox)
@@ -835,7 +868,12 @@ def _single_column_note_body_text(rows: Sequence[Sequence[str]]) -> str:
             normalized = _normalize_text(line)
             if normalized:
                 parts.append(normalized)
-    return re.sub(r"\s+", " ", " ".join(parts)).strip()
+    text = re.sub(r"\s+", " ", " ".join(parts)).strip()
+    if not text:
+        return ""
+    if re.match(r"(?i)^note\s*:", text):
+        return re.sub(r"(?i)^note\s*:\s*", "Note: ", text, count=1)
+    return f"Note: {text}"
 
 
 def _rows_match(a: Sequence[str], b: Sequence[str]) -> bool:
@@ -967,43 +1005,167 @@ def _body_text_boxes(
     return text_boxes
 
 
+def _is_overlap_in_x(
+    subject: Tuple[float, float, float, float],
+    reference: Tuple[float, float, float, float],
+    *,
+    min_overlap_ratio: float = 0.0,
+    min_overlap_width: float = 0.0,
+) -> bool:
+    if min_overlap_ratio <= 0.0 and min_overlap_width <= 0.0:
+        return True
+
+    overlap = min(float(subject[2]), float(reference[2])) - max(float(subject[0]), float(reference[0]))
+    if overlap <= 0.0:
+        return False
+    if overlap >= min_overlap_width and min_overlap_width > 0.0:
+        return True
+    if min_overlap_ratio <= 0.0:
+        return overlap > 0.0
+
+    subject_width = max(1.0, float(subject[2]) - float(subject[0]))
+    reference_width = max(1.0, float(reference[2]) - float(reference[0]))
+    overlap_ratio = overlap / min(subject_width, reference_width)
+    return overlap_ratio >= min_overlap_ratio
+
+
 def _gap_text_boxes_after_bbox(
     body_text_boxes: Sequence[Tuple[float, float, float, float]],
     bbox: Tuple[float, float, float, float],
+    max_gap: float | None = None,
+    overlap_bbox: Tuple[float, float, float, float] | None = None,
+    min_x_overlap_ratio: float = 0.0,
+    min_x_overlap_width: float = 0.0,
 ) -> List[Tuple[float, float, float, float]]:
     # Text after a table candidate can block continuation into the next page.
-    return [text_bbox for text_bbox in body_text_boxes if float(text_bbox[1]) >= float(bbox[3])]
+    bottom = float(bbox[3])
+    if max_gap is None:
+        return [
+            text_bbox
+            for text_bbox in body_text_boxes
+            if float(text_bbox[1]) > bottom + 1.0
+            and _is_overlap_in_x(
+                subject=text_bbox,
+                reference=overlap_bbox if overlap_bbox is not None else bbox,
+                min_overlap_ratio=min_x_overlap_ratio,
+                min_overlap_width=min_x_overlap_width,
+            )
+        ]
+    max_top = bottom + max(0.0, float(max_gap))
+    return [
+        text_bbox
+        for text_bbox in body_text_boxes
+        if bottom + 1.0 < float(text_bbox[1]) <= max_top
+        and _is_overlap_in_x(
+            subject=text_bbox,
+            reference=overlap_bbox if overlap_bbox is not None else bbox,
+            min_overlap_ratio=min_x_overlap_ratio,
+            min_x_overlap_width=min_x_overlap_width,
+        )
+    ]
 
 
 def _gap_text_boxes_before_bbox(
     body_text_boxes: Sequence[Tuple[float, float, float, float]],
     bbox: Tuple[float, float, float, float],
+    max_gap: float | None = None,
+    overlap_bbox: Tuple[float, float, float, float] | None = None,
+    min_x_overlap_ratio: float = 0.0,
+    min_x_overlap_width: float = 0.0,
 ) -> List[Tuple[float, float, float, float]]:
     # Text before a table candidate can mean the new page starts with prose rather than a continuation table.
-    return [text_bbox for text_bbox in body_text_boxes if float(text_bbox[3]) <= float(bbox[1])]
+    top = float(bbox[1])
+    if max_gap is None:
+        return [
+            text_bbox
+            for text_bbox in body_text_boxes
+            if float(text_bbox[3]) < top - 1.0
+            and _is_overlap_in_x(
+                subject=text_bbox,
+                reference=overlap_bbox if overlap_bbox is not None else bbox,
+                min_overlap_ratio=min_x_overlap_ratio,
+                min_x_overlap_width=min_x_overlap_width,
+            )
+        ]
+    min_bottom = top - max(0.0, float(max_gap))
+    return [
+        text_bbox
+        for text_bbox in body_text_boxes
+        if min_bottom <= float(text_bbox[3]) < top - 1.0
+        and _is_overlap_in_x(
+            subject=text_bbox,
+            reference=overlap_bbox if overlap_bbox is not None else bbox,
+            min_overlap_ratio=min_x_overlap_ratio,
+            min_x_overlap_width=min_x_overlap_width,
+        )
+    ]
 
 
 def _has_gap_text_after_bbox(
     body_text_boxes: Sequence[Tuple[float, float, float, float]],
     bbox: Tuple[float, float, float, float],
+    max_gap: float | None = None,
+    overlap_bbox: Tuple[float, float, float, float] | None = None,
+    min_x_overlap_ratio: float = 0.0,
+    min_x_overlap_width: float = 0.0,
 ) -> bool:
     # Fast predicate version used by cross-page merge checks.
     threshold = float(bbox[3])
-    for text_bbox in body_text_boxes:
-        if float(text_bbox[1]) >= threshold:
-            return True
+    overlap_reference = overlap_bbox if overlap_bbox is not None else bbox
+    if max_gap is None:
+        for text_bbox in body_text_boxes:
+            if float(text_bbox[1]) > threshold + 1.0 and _is_overlap_in_x(
+                subject=text_bbox,
+                reference=overlap_reference,
+                min_overlap_ratio=min_x_overlap_ratio,
+                min_overlap_width=min_x_overlap_width,
+            ):
+                return True
+    else:
+        max_top = threshold + max(0.0, float(max_gap))
+        for text_bbox in body_text_boxes:
+            top = float(text_bbox[1])
+            if threshold + 1.0 < top <= max_top and _is_overlap_in_x(
+                subject=text_bbox,
+                reference=overlap_reference,
+                min_overlap_ratio=min_x_overlap_ratio,
+                min_overlap_width=min_x_overlap_width,
+            ):
+                return True
     return False
 
 
 def _has_gap_text_before_bbox(
     body_text_boxes: Sequence[Tuple[float, float, float, float]],
     bbox: Tuple[float, float, float, float],
+    max_gap: float | None = None,
+    overlap_bbox: Tuple[float, float, float, float] | None = None,
+    min_x_overlap_ratio: float = 0.0,
+    min_x_overlap_width: float = 0.0,
 ) -> bool:
     # Fast predicate version used by cross-page merge checks.
     threshold = float(bbox[1])
-    for text_bbox in body_text_boxes:
-        if float(text_bbox[3]) <= threshold:
-            return True
+    overlap_reference = overlap_bbox if overlap_bbox is not None else bbox
+    if max_gap is None:
+        for text_bbox in body_text_boxes:
+            if float(text_bbox[3]) < threshold - 1.0 and _is_overlap_in_x(
+                subject=text_bbox,
+                reference=overlap_reference,
+                min_overlap_ratio=min_x_overlap_ratio,
+                min_overlap_width=min_x_overlap_width,
+            ):
+                return True
+    else:
+        min_top = threshold - max(0.0, float(max_gap))
+        for text_bbox in body_text_boxes:
+            bottom = float(text_bbox[3])
+            if min_top <= bottom < threshold - 1.0 and _is_overlap_in_x(
+                subject=text_bbox,
+                reference=overlap_reference,
+                min_overlap_ratio=min_x_overlap_ratio,
+                min_overlap_width=min_x_overlap_width,
+            ):
+                return True
     return False
 
 
@@ -1041,16 +1203,18 @@ def _continuation_regions_should_merge(
     _curr_x0, curr_top, _curr_x1, _curr_bottom = curr_bbox
 
     shared_axes = [axis for axis in prev_axes if any(abs(axis - other) <= axis_tolerance for other in curr_axes)]
-    if not shared_axes or bool(has_gap_text):
-        return False
-
-    # Near-footer / near-header placement is the common continuation pattern, but shared axes already make this permissive.
     prev_near_footer = abs(body_bottom - prev_bottom) <= edge_tolerance
     curr_near_header = abs(curr_top - body_top) <= edge_tolerance
+    if bool(has_gap_text) and not (prev_near_footer or curr_near_header):
+        return False
+
+    # Near-footer / near-header placement is the common continuation pattern.
+    # Allow that path even when shared vertical axes are not fully stable.
     if prev_near_footer or curr_near_header:
-        # Keep current continuation behavior when the fragments are aligned near page edges.
-        # This covers the usual table-break pattern while still allowing occasional header/footers offsets.
         return True
+
+    if not shared_axes:
+        return False
 
     if prev_page_height is None:
         return True
@@ -1803,6 +1967,10 @@ def _collect_single_column_candidates_for_notes(
                 entry["bbox"][2],
                 max(entry["bbox"][3], note_band[1]),
             )
+            expanded_rows = _compact_fallback_rows(_extract_region_line_rows(page, raw_bbox))
+            if expanded_rows:
+                rows = expanded_rows
+            is_note_like = _looks_like_single_column_note(rows=rows, page=page, bbox=raw_bbox)
 
         candidate_rows.append(
             {
@@ -2085,17 +2253,12 @@ def _extract_tables(
     for candidate in candidate_rows:
         if candidate["is_white_content"] or not candidate.get("is_note_like", False):
             continue
-        band_top, band_bottom = (
-            candidate.get("note_band")
-            if candidate.get("note_band") is not None
-            else (candidate["bbox"][1], candidate["bbox"][3])
-        )
         note_exclusion_bands.append(
             (
                 candidate["bbox"][0],
                 candidate["bbox"][2],
-                band_top,
-                band_bottom,
+                candidate["bbox"][1],
+                candidate["bbox"][3],
             )
         )
 
@@ -2151,11 +2314,17 @@ def _extract_tables(
             if candidate["is_white_content"] or not candidate.get("is_note_like", False):
                 continue
 
-            candidate_bbox = (
-                candidate["raw_bbox"]
-                if candidate.get("note_band") is not None
-                else candidate["bbox"]
-            )
+            candidate_bbox = candidate["bbox"]
+            overlapping_indexes = [
+                index
+                for index, (_rows, existing_bbox) in enumerate(merged)
+                if _single_column_boxes_share_index(existing_bbox, candidate_bbox)
+                and _bbox_overlap_ratio(existing_bbox, candidate_bbox) > 0.0
+            ]
+            if overlapping_indexes and candidate.get("note_band") is None:
+                for index in reversed(overlapping_indexes):
+                    merged.pop(index)
+                continue
             # overlap 자체는 제거 사유로 사용하지 않는다. 서로 다른 타입이라도 병합 대상에 둘 다 남겨둔다.
             key = _table_key(candidate["rows"], candidate_bbox)
             if key in seen_keys:

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -159,7 +159,7 @@ class PipelineExtractionTests(unittest.TestCase):
         pdf_path = self._build_pdf()
         call_index = 0
 
-        def fake_extract_tables(page: object, force_table: bool = False):
+        def fake_extract_tables(page: object, force_table: bool = False, strategy_debug=None):
             nonlocal call_index
             call_index += 1
             if call_index == 1:
@@ -196,8 +196,66 @@ class PipelineExtractionTests(unittest.TestCase):
                     stem="note-routing",
                 )
 
-        self.assertIn("F1-U path is not present in the integrated CU-DU shape. Hence, the counters for F1-U are not provided in this shape.", "".join(ref_text for ref_text, _ in captured_refs["refs"]))
+        self.assertIn("Note: F1-U path is not present in the integrated CU-DU shape. Hence, the counters for F1-U are not provided in this shape.", "".join(ref_text for ref_text, _ in captured_refs["refs"]))
         self.assertIsNone(re.search(r"^### .* table \d+$", result["table_markdown"], flags=re.MULTILINE))
+
+    def test_note_like_single_column_tables_skip_overlapping_image_references(self) -> None:
+        pdf_path = self._build_pdf()
+        call_index = 0
+
+        def fake_extract_tables(page: object, force_table: bool = False, strategy_debug=None):
+            nonlocal call_index
+            call_index += 1
+            if call_index == 1:
+                return [
+                    (
+                        [
+                            ["F1-U path is not present in the integrated CU-DU shape. Hence, the counters for"],
+                            ["F1-U are not provided in this shape."],
+                        ],
+                        (40.0, 121.0, 540.0, 160.0),
+                    )
+                ]
+            return []
+
+        captured_refs: dict[str, list[str]] = {"refs": []}
+
+        def fake_extract_body_text(page, header_margin, footer_margin, excluded_bboxes=(), reference_lines=(), heading_levels=None):
+            captured_refs["refs"].extend(
+                str(entry.get("text") or "")
+                for entry in reference_lines
+                if isinstance(entry, dict) and entry.get("text")
+            )
+            return "BODY BLOCK"
+
+        with patch("extractor.pipeline._extract_tables", side_effect=fake_extract_tables), patch(
+            "extractor.pipeline._collect_embedded_image_refs",
+            return_value={
+                1: [
+                    {
+                        "bbox": (50.0, 130.0, 60.0, 140.0),
+                        "name": "note-icon.png",
+                        "name_stem": "note-icon",
+                        "suffix": ".png",
+                    }
+                ]
+            },
+        ), patch(
+            "extractor.pipeline._extract_body_text", side_effect=fake_extract_body_text
+        ), patch(
+            "extractor.pipeline._extract_embedded_images",
+            return_value=[],
+        ):
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_root = Path(temp_dir)
+                extract_pdf_to_outputs(
+                    pdf_path=pdf_path,
+                    out_md_dir=temp_root / "md",
+                    out_image_dir=temp_root / "images",
+                    stem="note-routing-image-skip",
+                )
+
+        self.assertFalse(any(ref.startswith("[Image reference:") for ref in captured_refs["refs"]))
 
     def test_extract_can_limit_to_selected_pages(self) -> None:
         tmp = tempfile.TemporaryDirectory()
@@ -358,7 +416,7 @@ class PipelineExtractionTests(unittest.TestCase):
         fake_pdf_context.__enter__.return_value = fake_pdf
         fake_pdf_context.__exit__.return_value = False
 
-        def fake_extract_tables(page: object, force_table: bool = False):
+        def fake_extract_tables(page: object, force_table: bool = False, strategy_debug=None):
             if page.page_index == 1:
                 return [
                     ([["Col1", "Col2"], ["A", "1"], ["B", "2"]], (40.0, 650.0, 540.0, 700.0)),
@@ -409,7 +467,7 @@ class PipelineExtractionTests(unittest.TestCase):
         fake_pdf_context.__enter__.return_value = fake_pdf
         fake_pdf_context.__exit__.return_value = False
 
-        def fake_extract_tables(page: object, force_table: bool = False):
+        def fake_extract_tables(page: object, force_table: bool = False, strategy_debug=None):
             if page.page_index == 1:
                 return [
                     ([["Col1", "Col2"], ["A", "1"]], (40.0, 650.0, 540.0, 700.0)),

--- a/graph_pdf/tests/test_pipeline.py
+++ b/graph_pdf/tests/test_pipeline.py
@@ -14,9 +14,18 @@ from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 
 from extractor import extract_pdf_to_outputs
-from extractor.pipeline import _strip_repeated_headers_by_chunk
+from extractor.pipeline import (
+    _CrossPageTableCandidate,
+    _DocumentOutputState,
+    _is_cross_page_continuation_candidate,
+    _looks_like_cross_page_continuation_rows,
+    _load_cross_page_candidate,
+    _strip_repeated_headers_by_chunk,
+    _table_shapes_compatible,
+)
 from extractor.debug import _collect_rotated_text_debug, _collect_table_drawing_debug
 from extractor.images import _extract_embedded_images
+from extractor.tables import _append_output_table
 from sample_fixture import load_demo_fixture
 from sample_generator import create_demo_pdf
 from verify import _extract_markdown_tables
@@ -60,6 +69,20 @@ def _build_heading_pdf(pdf_path: Path) -> tuple[str, str]:
     c.setFont("Helvetica", 11)
     c.drawString(72, 672, paragraph)
     c.drawString(72, 656, "Continuation line for the body paragraph.")
+    c.save()
+
+    return title, paragraph
+
+
+def _build_document_id_heading_pdf(pdf_path: Path) -> tuple[str, str]:
+    title = "FGR-TEST01, Example Feature"
+    paragraph = "Document id heading should drive output naming."
+
+    c = canvas.Canvas(str(pdf_path), pagesize=letter)
+    c.setFont("Helvetica-Bold", 20)
+    c.drawString(72, 700, title)
+    c.setFont("Helvetica", 11)
+    c.drawString(72, 672, paragraph)
     c.save()
 
     return title, paragraph
@@ -115,6 +138,62 @@ class PipelineExtractionTests(unittest.TestCase):
         for idx, table in enumerate(expected_tables):
             self.assertIn(idx, extracted_by_index)
             self.assertEqual(table["rows"], extracted_by_index[idx], table["id"])
+
+    def test_table_shapes_allow_header_only_continuation_chunk(self) -> None:
+        self.assertTrue(_table_shapes_compatible((2, 9), (3, 4)))
+
+    def test_cross_page_continuation_candidate_allows_moderate_bottom_gap(self) -> None:
+        self.assertTrue(
+            _is_cross_page_continuation_candidate(
+                bbox=(72.02, 416.49, 525.57, 676.86),
+                body_top=66.24,
+                body_bottom=730.42,
+                continuation_gap=39.8508,
+            )
+        )
+
+    def test_cross_page_continuation_candidate_rejects_high_on_page_table(self) -> None:
+        self.assertFalse(
+            _is_cross_page_continuation_candidate(
+                bbox=(72.02, 153.90, 525.57, 674.82),
+                body_top=66.24,
+                body_bottom=730.42,
+                continuation_gap=39.8508,
+            )
+        )
+
+    def test_cross_page_continuation_rows_accept_type_description_only_chunk(self) -> None:
+        previous_rows = [
+            ["", "Family Displa", "y Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "F1-U UL Inte UP per UP", "rface collected in", "", "", "F1UPacketLossCntUL", "", "", "desc", ""],
+        ]
+        current_rows = [
+            ["", "", "F1UPacketOosCntDL_QCI", "desc"],
+            ["", "", "F1UPacketCntDL_QCI", "desc"],
+        ]
+        self.assertTrue(_looks_like_cross_page_continuation_rows(previous_rows, current_rows))
+
+    def test_cross_page_continuation_rows_reject_new_family_section_chunk(self) -> None:
+        previous_rows = [
+            ["", "Family Display Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "S1-U Interface collected in UP per sGW IP per QCI", "", "", "S1URxPacketLossCnt", "", "", "desc", ""],
+        ]
+        current_rows = [
+            ["", "Family Displa", "y Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "N3 Interface", "per UPF IP", "", "", "N3RxPacketLossCnt", "", "", "desc", ""],
+        ]
+        self.assertFalse(_looks_like_cross_page_continuation_rows(previous_rows, current_rows))
+
+    def test_cross_page_continuation_rows_accept_repeated_header_collected_family_chunk(self) -> None:
+        previous_rows = [
+            ["", "Family Display Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "S1-U Interface collected in UP per sGW IP per QCI", "", "", "S1URxPacketLossCnt", "", "", "desc", ""],
+        ]
+        current_rows = [
+            ["", "Family Displa", "y Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "F1-U Interfa per gNB-DU", "ce collected in UP per QCI", "", "", "F1URxPacketLossCnt", "", "", "desc", ""],
+        ]
+        self.assertTrue(_looks_like_cross_page_continuation_rows(previous_rows, current_rows))
 
     def test_table_output_uses_markdown_tables(self) -> None:
         markdown = self._extract_table_markdown()
@@ -379,6 +458,41 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertIn(paragraph, result["markdown"])
         self.assertNotIn(f"# {paragraph}", result["markdown"])
 
+    def test_h2_document_id_heading_drives_output_file_names_without_stem_fallback(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        pdf_path = root / "docid.pdf"
+        title, paragraph = _build_document_id_heading_pdf(pdf_path)
+        heading_json = root / "heading.json"
+        heading_json.write_text(
+            json.dumps(
+                {
+                    "heading_rules": [
+                        {
+                            "match": {"font_size": 20.0},
+                            "assign": {"tag": "h2"},
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = extract_pdf_to_outputs(
+            pdf_path=pdf_path,
+            out_md_dir=root / "md",
+            out_image_dir=root / "images",
+            stem="docid",
+            add_heading=heading_json,
+        )
+
+        self.assertEqual("FGR-TEST01.md", Path(result["md_file"]).name)
+        self.assertEqual("FGR-TEST01_table.md", Path(result["table_md_file"]).name)
+        self.assertFalse((root / "md" / "docid.md").exists())
+        self.assertIn(f"## {title}", result["markdown"])
+        self.assertIn(paragraph, result["markdown"])
+
     def test_spanning_stage_table_merges_into_one_block(self) -> None:
         markdown = self._extract_table_markdown()
         blocks = self._table_blocks(markdown)
@@ -409,6 +523,79 @@ class PipelineExtractionTests(unittest.TestCase):
             _strip_repeated_headers_by_chunk(chunks),
         )
 
+    def test_strip_repeated_headers_by_chunk_normalizes_split_header_variants(self) -> None:
+        chunks = [
+            [
+                ["", "Family Display Name", "", "", "Type Name", "", "", "Type Description", ""],
+                ["", "S1-U Interface collected in UP per sGW IP per QCI", "", "", "S1URxPacketLossCnt", "", "", "desc", ""],
+            ],
+            [
+                ["", "Family Displa", "y Name", "", "", "Type Name", "", "", "Type Description", ""],
+                ["", "F1-U Interfa per gNB-DU", "ce collected in UP per QCI", "", "", "F1URxPacketLossCnt", "", "", "desc", ""],
+            ],
+        ]
+        self.assertEqual(
+            [
+                ["", "Family Display Name", "", "", "Type Name", "", "", "Type Description", ""],
+                ["", "S1-U Interface collected in UP per sGW IP per QCI", "", "", "S1URxPacketLossCnt", "", "", "desc", ""],
+                ["", "F1-U Interfa per gNB-DU", "ce collected in UP per QCI", "", "", "F1URxPacketLossCnt", "", "", "desc", ""],
+            ],
+            _strip_repeated_headers_by_chunk(chunks),
+        )
+
+    def test_load_cross_page_candidate_preserves_chunk_nesting(self) -> None:
+        state = _DocumentOutputState(document_id="demo")
+        candidate = _CrossPageTableCandidate(
+            table_no=14,
+            start_page=12,
+            last_page=13,
+            bbox=(72.0, 80.0, 525.0, 249.0),
+            rows=[
+                ["Family Display Name", "Type Name", "Type Description"],
+                ["S1-U Interface", "S1URxPacketLossCnt", "Lost packets"],
+            ],
+            shape_signature=(2, 3),
+            axes=[72.0, 240.0, 525.0],
+            has_gap_text=False,
+            page_height=792.0,
+        )
+
+        _load_cross_page_candidate(state, candidate)
+
+        self.assertEqual([candidate.rows], state.pending_table_state.chunks)
+        self.assertEqual(candidate.rows, state.pending_table_state.flattened_rows())
+
+    def test_reloaded_cross_page_candidate_outputs_normal_table_rows(self) -> None:
+        state = _DocumentOutputState(document_id="demo")
+        candidate = _CrossPageTableCandidate(
+            table_no=14,
+            start_page=12,
+            last_page=13,
+            bbox=(72.0, 80.0, 525.0, 249.0),
+            rows=[
+                ["Family Display Name", "Type Name", "Type Description"],
+                ["S1-U Interface", "S1URxPacketLossCnt", "Lost packets"],
+            ],
+            shape_signature=(2, 3),
+            axes=[72.0, 240.0, 525.0],
+            has_gap_text=False,
+            page_height=792.0,
+        )
+
+        _load_cross_page_candidate(state, candidate)
+        output_tables: list[str] = []
+        _append_output_table(
+            output_tables,
+            state.document_id,
+            int(state.pending_table_state.table_no or 0),
+            state.pending_table_state.flattened_rows(),
+        )
+
+        table_markdown = "\n".join(output_tables)
+        self.assertIn("| Family Display Name | Type Name | Type Description |", table_markdown)
+        self.assertIn("| S1-U Interface | S1URxPacketLossCnt | Lost packets |", table_markdown)
+        self.assertNotIn("| F | a | m |", table_markdown)
+
     def test_cross_page_merge_only_targets_first_table_on_next_page(self) -> None:
         pages = [SimpleNamespace(width=612.0, height=792.0, page_index=1), SimpleNamespace(width=612.0, height=792.0, page_index=2)]
         fake_pdf = SimpleNamespace(pages=pages)
@@ -431,8 +618,8 @@ class PipelineExtractionTests(unittest.TestCase):
         ), patch("extractor.pipeline._detect_body_bounds", return_value=(70.0, 700.0)), patch(
             "extractor.pipeline._extract_drawing_image_bboxes", return_value=[]
         ), patch("extractor.pipeline._body_text_boxes", return_value=[]), patch(
-            "extractor.pipeline._gap_text_boxes_before_bbox", return_value=[]
-        ), patch("extractor.pipeline._gap_text_boxes_after_bbox", return_value=[]), patch(
+            "extractor.pipeline._has_gap_text_before_bbox", return_value=False
+        ), patch("extractor.pipeline._has_gap_text_after_bbox", return_value=False), patch(
             "extractor.pipeline._vertical_axes_for_bbox", return_value=[40.0, 540.0]
         ), patch("extractor.pipeline._continuation_regions_should_merge", return_value=True), patch(
             "extractor.pipeline._collect_embedded_image_refs", return_value={}
@@ -470,10 +657,10 @@ class PipelineExtractionTests(unittest.TestCase):
         def fake_extract_tables(page: object, force_table: bool = False, strategy_debug=None):
             if page.page_index == 1:
                 return [
-                    ([["Col1", "Col2"], ["A", "1"]], (40.0, 650.0, 540.0, 700.0)),
+                    ([["Col1", "Col2"], ["A", "1"]], (40.0, 650.0, 540.0, 680.0)),
                 ]
             return [
-                ([["Col1", "Col2"], ["B", "2"]], (40.0, 30.0, 540.0, 75.0)),
+                ([["Col1", "Col2"], ["B", "2"]], (40.0, 90.0, 540.0, 135.0)),
             ]
 
         def fake_drawing_image_bboxes(
@@ -483,7 +670,7 @@ class PipelineExtractionTests(unittest.TestCase):
             excluded_bboxes=(),
         ):
             if page.page_index == 1:
-                return [(40.0, 740.0, 540.0, 770.0)]
+                return [(40.0, 688.0, 540.0, 698.0)]
             return []
 
         with patch("extractor.pipeline.pdfplumber.open", return_value=fake_pdf_context), patch(
@@ -491,8 +678,8 @@ class PipelineExtractionTests(unittest.TestCase):
         ), patch("extractor.pipeline._detect_body_bounds", return_value=(70.0, 700.0)), patch(
             "extractor.pipeline._extract_drawing_image_bboxes", side_effect=fake_drawing_image_bboxes
         ), patch("extractor.pipeline._body_text_boxes", return_value=[]), patch(
-            "extractor.pipeline._gap_text_boxes_before_bbox", return_value=[]
-        ), patch("extractor.pipeline._gap_text_boxes_after_bbox", return_value=[]), patch(
+            "extractor.pipeline._has_gap_text_before_bbox", return_value=False
+        ), patch("extractor.pipeline._has_gap_text_after_bbox", return_value=False), patch(
             "extractor.pipeline._vertical_axes_for_bbox", return_value=[40.0, 540.0]
         ), patch("extractor.pipeline._continuation_regions_should_merge", return_value=True), patch(
             "extractor.pipeline._collect_embedded_image_refs", return_value={}
@@ -517,6 +704,66 @@ class PipelineExtractionTests(unittest.TestCase):
         self.assertEqual(2, len(blocks), table_markdown)
         self.assertIsNotNone(re.search(r"^### .* table 1$", table_markdown, flags=re.MULTILINE))
         self.assertIsNotNone(re.search(r"^### .* table 2$", table_markdown, flags=re.MULTILINE))
+
+    def test_cross_page_merge_does_not_reuse_stale_mid_page_anchor(self) -> None:
+        pages = [
+            SimpleNamespace(width=612.0, height=792.0, page_index=1),
+            SimpleNamespace(width=612.0, height=792.0, page_index=2),
+            SimpleNamespace(width=612.0, height=792.0, page_index=3),
+        ]
+        fake_pdf = SimpleNamespace(pages=pages)
+        fake_pdf_context = MagicMock()
+        fake_pdf_context.__enter__.return_value = fake_pdf
+        fake_pdf_context.__exit__.return_value = False
+
+        def fake_extract_tables(page: object, force_table: bool = False, strategy_debug=None):
+            if page.page_index == 1:
+                return [
+                    ([["Col1", "Col2"], ["A1", "1"]], (40.0, 650.0, 540.0, 700.0)),
+                ]
+            if page.page_index == 2:
+                return [
+                    ([["Col1", "Col2"], ["A2", "2"]], (40.0, 30.0, 540.0, 75.0)),
+                    ([["Col1", "Col2"], ["B1", "10"]], (40.0, 620.0, 540.0, 700.0)),
+                ]
+            return [
+                ([["Col1", "Col2"], ["B2", "11"]], (40.0, 30.0, 540.0, 75.0)),
+            ]
+
+        with patch("extractor.pipeline.pdfplumber.open", return_value=fake_pdf_context), patch(
+            "extractor.pipeline._extract_tables", side_effect=fake_extract_tables
+        ), patch("extractor.pipeline._detect_body_bounds", return_value=(70.0, 700.0)), patch(
+            "extractor.pipeline._extract_drawing_image_bboxes", return_value=[]
+        ), patch("extractor.pipeline._body_text_boxes", return_value=[]), patch(
+            "extractor.pipeline._has_gap_text_before_bbox", return_value=False
+        ), patch("extractor.pipeline._has_gap_text_after_bbox", return_value=False), patch(
+            "extractor.pipeline._vertical_axes_for_bbox", return_value=[40.0, 540.0]
+        ), patch("extractor.pipeline._continuation_regions_should_merge", return_value=True), patch(
+            "extractor.pipeline._collect_embedded_image_refs", return_value={}
+        ), patch(
+            "extractor.pipeline._extract_body_text", return_value=""
+        ), patch(
+            "extractor.pipeline._extract_embedded_images",
+            return_value=[],
+        ):
+            with tempfile.TemporaryDirectory() as temp_dir:
+                root = Path(temp_dir)
+                result = extract_pdf_to_outputs(
+                    pdf_path=Path("unused.pdf"),
+                    out_md_dir=root / "md",
+                    out_image_dir=root / "images",
+                    stem="stale-anchor",
+                    page_write=True,
+                )
+
+        table_markdown = result["table_markdown"]
+        blocks = self._table_blocks(table_markdown)
+        self.assertEqual(2, len(blocks), table_markdown)
+        self.assertIsNotNone(re.search(r"^### .* table 1$", table_markdown, flags=re.MULTILINE))
+        self.assertIsNotNone(re.search(r"^### .* table 2$", table_markdown, flags=re.MULTILINE))
+        self.assertEqual(1, len(re.findall(r"^### .* table 1$", table_markdown, flags=re.MULTILINE)), table_markdown)
+        self.assertNotIn("| B2 | 11 |", blocks[0], table_markdown)
+        self.assertIn("| B2 | 11 |", blocks[1], table_markdown)
 
     def test_demo_table_markdown_is_written_to_separate_file(self) -> None:
         result = self._extract_result()

--- a/graph_pdf/tests/test_raw.py
+++ b/graph_pdf/tests/test_raw.py
@@ -85,14 +85,12 @@ class RawDumpTests(unittest.TestCase):
             str(root / "md"),
             "--out-image-dir",
             str(root / "images"),
-            "--stem",
-            "sample",
         ]
         with patch.object(sys, "argv", import_argv):
             cli_main()
 
-        self.assertTrue((root / "md" / "sample.md").exists())
-        self.assertTrue((root / "md" / "sample_summary.json").exists())
+        self.assertTrue((root / "md" / "document.md").exists())
+        self.assertTrue((root / "md" / "output_summary.json").exists())
 
 
 if __name__ == "__main__":

--- a/graph_pdf/tests/test_tables.py
+++ b/graph_pdf/tests/test_tables.py
@@ -6,6 +6,8 @@ from types import SimpleNamespace
 from extractor.shared import _merge_horizontal_band_segments, _merge_vertical_band_segments
 from extractor.tables import (
     _collapse_structural_triplet_columns,
+    _classify_single_column_region,
+    _collect_single_column_candidates_for_notes,
     _continuation_regions_should_merge,
     _extract_tables_from_crop,
     _extract_tables,
@@ -68,6 +70,110 @@ class TableModuleTests(unittest.TestCase):
             [["A", "B"], ["C", "D"], ["E", "F"]],
             _collapse_structural_triplet_columns(table),
         )
+
+    def test_geometry_aware_single_row_requires_note_signal(self) -> None:
+        from unittest.mock import patch
+
+        rows = [["The counter of F1-U DL Interface per QCI is provided only for NSA operation."]]
+        page = SimpleNamespace()
+        bbox = (127.22, 249.26, 524.85, 272.45)
+
+        with patch(
+            "extractor.tables._extract_region_words",
+            return_value=[
+                {"text": "The", "x0": 150.0, "x1": 172.0, "top": 252.0, "bottom": 263.0},
+                {"text": "counter", "x0": 176.0, "x1": 220.0, "top": 252.0, "bottom": 263.0},
+                {"text": "of", "x0": 224.0, "x1": 236.0, "top": 252.0, "bottom": 263.0},
+                {"text": "F1-U", "x0": 240.0, "x1": 268.0, "top": 252.0, "bottom": 263.0},
+                {"text": "DL", "x0": 272.0, "x1": 286.0, "top": 252.0, "bottom": 263.0},
+                {"text": "Interface", "x0": 290.0, "x1": 344.0, "top": 252.0, "bottom": 263.0},
+                {"text": "provided", "x0": 348.0, "x1": 398.0, "top": 252.0, "bottom": 263.0},
+                {"text": "only", "x0": 402.0, "x1": 426.0, "top": 252.0, "bottom": 263.0},
+                {"text": "for", "x0": 430.0, "x1": 446.0, "top": 252.0, "bottom": 263.0},
+                {"text": "NSA", "x0": 450.0, "x1": 474.0, "top": 252.0, "bottom": 263.0},
+            ],
+        ), patch(
+            "extractor.tables._extract_region_lines",
+            return_value=[
+                [
+                    {"text": "The", "x0": 150.0, "x1": 172.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "counter", "x0": 176.0, "x1": 220.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "of", "x0": 224.0, "x1": 236.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "F1-U", "x0": 240.0, "x1": 268.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "DL", "x0": 272.0, "x1": 286.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "Interface", "x0": 290.0, "x1": 344.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "provided", "x0": 348.0, "x1": 398.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "only", "x0": 402.0, "x1": 426.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "for", "x0": 430.0, "x1": 446.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "NSA", "x0": 450.0, "x1": 474.0, "top": 252.0, "bottom": 263.0},
+                ]
+            ],
+        ), patch(
+            "extractor.tables._internal_grid_counts",
+            return_value=(0, 0),
+        ), patch(
+            "extractor.tables._note_border_signature",
+            return_value=(False, {"reason": "no_border"}),
+        ), patch(
+            "extractor.tables._select_note_anchor_for_bbox",
+            return_value=None,
+        ):
+            kind, meta = _classify_single_column_region(rows, page=page, bbox=bbox)
+
+        self.assertEqual("table", kind)
+        self.assertEqual("single_row_without_note_geometry", meta["reason"])
+
+    def test_geometry_aware_single_row_uses_note_anchor_signal(self) -> None:
+        from unittest.mock import patch
+
+        rows = [["The counter of F1-U DL Interface per QCI is provided only for NSA operation."]]
+        page = SimpleNamespace()
+        bbox = (127.22, 249.26, 524.85, 272.45)
+
+        with patch(
+            "extractor.tables._extract_region_words",
+            return_value=[
+                {"text": "The", "x0": 150.0, "x1": 172.0, "top": 252.0, "bottom": 263.0},
+                {"text": "counter", "x0": 176.0, "x1": 220.0, "top": 252.0, "bottom": 263.0},
+                {"text": "of", "x0": 224.0, "x1": 236.0, "top": 252.0, "bottom": 263.0},
+                {"text": "F1-U", "x0": 240.0, "x1": 268.0, "top": 252.0, "bottom": 263.0},
+                {"text": "DL", "x0": 272.0, "x1": 286.0, "top": 252.0, "bottom": 263.0},
+                {"text": "Interface", "x0": 290.0, "x1": 344.0, "top": 252.0, "bottom": 263.0},
+                {"text": "provided", "x0": 348.0, "x1": 398.0, "top": 252.0, "bottom": 263.0},
+                {"text": "only", "x0": 402.0, "x1": 426.0, "top": 252.0, "bottom": 263.0},
+                {"text": "for", "x0": 430.0, "x1": 446.0, "top": 252.0, "bottom": 263.0},
+                {"text": "NSA", "x0": 450.0, "x1": 474.0, "top": 252.0, "bottom": 263.0},
+            ],
+        ), patch(
+            "extractor.tables._extract_region_lines",
+            return_value=[
+                [
+                    {"text": "The", "x0": 150.0, "x1": 172.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "counter", "x0": 176.0, "x1": 220.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "of", "x0": 224.0, "x1": 236.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "F1-U", "x0": 240.0, "x1": 268.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "DL", "x0": 272.0, "x1": 286.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "Interface", "x0": 290.0, "x1": 344.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "provided", "x0": 348.0, "x1": 398.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "only", "x0": 402.0, "x1": 426.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "for", "x0": 430.0, "x1": 446.0, "top": 252.0, "bottom": 263.0},
+                    {"text": "NSA", "x0": 450.0, "x1": 474.0, "top": 252.0, "bottom": 263.0},
+                ]
+            ],
+        ), patch(
+            "extractor.tables._internal_grid_counts",
+            return_value=(0, 0),
+        ), patch(
+            "extractor.tables._note_border_signature",
+            return_value=(False, {"reason": "no_border"}),
+        ), patch(
+            "extractor.tables._select_note_anchor_for_bbox",
+            return_value=(128.65, 252.0, 147.5, 269.75),
+        ):
+            kind, meta = _classify_single_column_region(rows, page=page, bbox=bbox)
+
+        self.assertEqual("note", kind)
+        self.assertEqual("single_row_note_anchor", meta["reason"])
 
     def test_continuation_regions_require_shared_axes_and_empty_gap(self) -> None:
         self.assertTrue(
@@ -522,6 +628,120 @@ class TableModuleTests(unittest.TestCase):
 
         self.assertEqual([expected_table], tables)
 
+    def test_extract_tables_excludes_full_note_bbox_when_splitting_table_region(self) -> None:
+        from unittest.mock import patch
+
+        page = SimpleNamespace(
+            width=600.0,
+            height=800.0,
+            horizontal_edges=[],
+            vertical_edges=[],
+            filter=lambda fn: page,
+        )
+        seen_split_bboxes: list[tuple[float, float, float, float]] = []
+
+        def fake_extract_tables_from_crop(page_obj, crop_bbox, fallback_to_text_rows=False, strategy_debug=None, strategy_source=None, strategy_source_name=None):
+            seen_split_bboxes.append(tuple(float(value) for value in crop_bbox))
+            return []
+
+        with patch(
+            "extractor.tables._table_regions",
+            return_value=[(40.0, 540.0, [{"top": 100.0}, {"top": 220.0}])],
+        ), patch(
+            "extractor.tables._collect_single_column_candidates_for_notes",
+            return_value=[
+                {
+                    "bbox": (40.0, 120.0, 540.0, 170.0),
+                    "raw_bbox": (40.0, 120.0, 540.0, 135.0),
+                    "rows": [["Merged note body"]],
+                    "is_white_content": False,
+                    "is_note_like": True,
+                    "note_anchor": (50.0, 122.0, 60.0, 132.0),
+                    "note_band": (120.0, 135.0),
+                }
+            ],
+        ), patch(
+            "extractor.tables._extract_tables_from_crop",
+            side_effect=fake_extract_tables_from_crop,
+        ):
+            _extract_tables(page)
+
+        self.assertEqual(
+            [
+                (40.0, 98.0, 540.0, 120.0),
+                (40.0, 170.0, 540.0, 222.0),
+            ],
+            seen_split_bboxes,
+        )
+
+    def test_extract_tables_uses_expanded_note_bbox_for_standalone_note(self) -> None:
+        from unittest.mock import patch
+
+        page = SimpleNamespace(
+            width=600.0,
+            height=800.0,
+            horizontal_edges=[],
+            vertical_edges=[],
+            filter=lambda fn: page,
+        )
+
+        with patch(
+            "extractor.tables._table_regions",
+            return_value=[],
+        ), patch(
+            "extractor.tables._collect_single_column_candidates_for_notes",
+            return_value=[
+                {
+                    "bbox": (40.0, 120.0, 540.0, 170.0),
+                    "raw_bbox": (40.0, 120.0, 540.0, 135.0),
+                    "rows": [["Merged note body"]],
+                    "is_white_content": False,
+                    "is_note_like": True,
+                    "note_anchor": (50.0, 122.0, 60.0, 132.0),
+                    "note_band": (120.0, 135.0),
+                }
+            ],
+        ), patch(
+            "extractor.tables._extract_tables_from_crop",
+            return_value=[],
+        ):
+            tables = _extract_tables(page)
+
+        self.assertEqual(
+            [([["Merged note body"]], (40.0, 120.0, 540.0, 170.0))],
+            tables,
+        )
+
+    def test_collect_single_column_candidates_refreshes_rows_for_expanded_note_bbox(self) -> None:
+        from unittest.mock import patch
+
+        page = SimpleNamespace(width=600.0, height=800.0)
+
+        with patch(
+            "extractor.tables._single_column_box_region_candidates",
+            return_value=[{"bbox": (40.0, 120.0, 540.0, 135.0), "is_white_content": False}],
+        ), patch(
+            "extractor.tables._extract_text_from_box_region",
+            return_value="tail only",
+        ), patch(
+            "extractor.tables._looks_like_single_column_note",
+            side_effect=[True, True],
+        ), patch(
+            "extractor.tables._select_note_anchor_for_bbox",
+            return_value=(50.0, 122.0, 60.0, 132.0),
+        ), patch(
+            "extractor.tables._candidate_note_band_for_bbox",
+            return_value=(120.0, 170.0),
+        ), patch(
+            "extractor.tables._extract_region_line_rows",
+            return_value=[["Line one"], ["Line two"]],
+        ):
+            candidates = _collect_single_column_candidates_for_notes(page)
+
+        self.assertEqual(1, len(candidates))
+        self.assertEqual((40.0, 120.0, 540.0, 170.0), candidates[0]["bbox"])
+        self.assertEqual([["Line one"], ["Line two"]], candidates[0]["rows"])
+
     def test_single_column_boxes_share_index_when_aligned(self) -> None:
         self.assertTrue(
             _single_column_boxes_share_index(
@@ -633,15 +853,14 @@ class TableModuleTests(unittest.TestCase):
         ]
         self.assertTrue(_looks_like_single_column_note(rows))
         self.assertEqual(
-            "For F1-U/Xn-U interface, GTP SN marking & Loss/OOS counting is always activated.",
+            "Note: For F1-U/Xn-U interface, GTP SN marking & Loss/OOS counting is always activated.",
             _single_column_note_body_text(rows),
         )
 
     def test_single_column_note_body_text_uses_first_non_empty_cell(self) -> None:
         rows = [["", "", "Escalation lane summary"], ["", "", "Owner confirmed"]]
-        self.assertTrue(_looks_like_single_column_note(rows))
         self.assertEqual(
-            "Escalation lane summary Owner confirmed",
+            "Note: Escalation lane summary Owner confirmed",
             _single_column_note_body_text(rows),
         )
 
@@ -652,9 +871,15 @@ class TableModuleTests(unittest.TestCase):
                 "Backup approver stays on the same visual box and must not become a second table row.",
             ],
         ]
-        self.assertTrue(_looks_like_single_column_note(rows))
         self.assertEqual(
-            "Escalation lane summary Owner confirmed for regional review and exception routing. Backup approver stays on the same visual box and must not become a second table row.",
+            "Note: Escalation lane summary Owner confirmed for regional review and exception routing. Backup approver stays on the same visual box and must not become a second table row.",
+            _single_column_note_body_text(rows),
+        )
+
+    def test_single_column_note_body_text_does_not_duplicate_existing_prefix(self) -> None:
+        rows = [["Note: Escalation lane summary"], ["Owner confirmed"]]
+        self.assertEqual(
+            "Note: Escalation lane summary Owner confirmed",
             _single_column_note_body_text(rows),
         )
 

--- a/graph_pdf/tests/test_tables.py
+++ b/graph_pdf/tests/test_tables.py
@@ -15,6 +15,7 @@ from extractor.tables import (
     _to_rect_entry,
     _merge_single_column_fragment_rows,
     _single_column_box_regions,
+    _single_column_box_region_candidates,
     _single_column_boxes_share_index,
     _split_repeated_header,
     _single_column_note_body_text,
@@ -23,6 +24,7 @@ from extractor.tables import (
     _looks_like_single_column_note,
     _table_rejection_reason,
     _table_text_from_rows,
+    _header_row_count,
 )
 
 
@@ -69,6 +71,134 @@ class TableModuleTests(unittest.TestCase):
         self.assertEqual(
             [["A", "B"], ["C", "D"], ["E", "F"]],
             _collapse_structural_triplet_columns(table),
+        )
+
+    def test_collapse_structural_triplet_columns_collapses_sparse_split_pairs(self) -> None:
+        table = [
+            ["", "Family Displa", "y Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "X2-U Interfa QCI", "ce per eNB IP per", "", "", "X2URxPacketLossCnt", "", "", "Lost packets", ""],
+            ["", "", "", "", "", "X2URxPacketOosCnt", "", "", "OOS packets", ""],
+        ]
+        self.assertEqual(
+            [
+                ["Family Display Name", "Type Name", "Type Description"],
+                ["X2-U Interface per eNB IP per QCI", "X2URxPacketLossCnt", "Lost packets"],
+                ["", "X2URxPacketOosCnt", "OOS packets"],
+            ],
+            _collapse_structural_triplet_columns(table),
+        )
+
+    def test_collapse_structural_triplet_columns_keeps_space_for_full_word_companion(self) -> None:
+        table = [
+            ["", "Family Displa", "y Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "N3 Interface", "per UPF IP", "", "", "N3RxPacketLossCnt", "", "", "Lost packets", ""],
+        ]
+        self.assertEqual(
+            [
+                ["Family Display Name", "Type Name", "Type Description"],
+                ["N3 Interface per UPF IP", "N3RxPacketLossCnt", "Lost packets"],
+            ],
+            _collapse_structural_triplet_columns(table),
+        )
+
+    def test_collapse_structural_triplet_columns_reorders_collected_suffix_phrase(self) -> None:
+        table = [
+            ["", "Family Displa", "y Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "N3 Interface UPF IP", "collected in UP per", "", "", "N3RxPacketLossCnt", "", "", "Lost packets", ""],
+        ]
+        self.assertEqual(
+            [
+                ["Family Display Name", "Type Name", "Type Description"],
+                ["N3 Interface collected in UP per UPF IP", "N3RxPacketLossCnt", "Lost packets"],
+            ],
+            _collapse_structural_triplet_columns(table),
+        )
+
+    def test_collapse_structural_triplet_columns_reorders_collected_suffix_with_tail_qualifier(self) -> None:
+        table = [
+            ["", "Family Displa", "y Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "F1-U Interfa per gNB-DU", "ce collected in UP per 5QI", "", "", "F1URxPacketLossCnt", "", "", "Lost packets", ""],
+        ]
+        self.assertEqual(
+            [
+                ["Family Display Name", "Type Name", "Type Description"],
+                ["F1-U Interface collected in UP per 5QI per gNB-DU", "F1URxPacketLossCnt", "Lost packets"],
+            ],
+            _collapse_structural_triplet_columns(table),
+        )
+
+    def test_collapse_structural_triplet_columns_compresses_mixed_width_chunks(self) -> None:
+        table = [
+            ["", "Family Display Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "S1-U Interface collected in UP per sGW IP per QCI", "", "", "S1URxPacketLossCnt", "", "", "Lost packets", ""],
+            ["", "", "", "", "S1URxPacketOosCnt", "", "", "OOS packets", ""],
+            ["", "F1-U Interfa per gNB-DU", "ce collected in UP per QCI", "", "", "F1URxPacketLossCnt", "", "", "Lost packets", ""],
+            ["", "", "", "", "", "F1URxPacketOosCnt", "", "", "OOS packets", ""],
+            ["", "X2-U Interfa per eNB IP p", "ce collected in UP er QCI", "", "", "X2URxPacketLossCnt", "", "", "Lost packets", ""],
+            ["", "", "", "", "", "X2URxPacketOosCnt", "", "", "OOS packets", ""],
+        ]
+        self.assertEqual(
+            [
+                ["Family Display Name", "Type Name", "Type Description"],
+                ["S1-U Interface collected in UP per sGW IP per QCI", "S1URxPacketLossCnt", "Lost packets"],
+                ["", "S1URxPacketOosCnt", "OOS packets"],
+                ["F1-U Interface collected in UP per QCI per gNB-DU", "F1URxPacketLossCnt", "Lost packets"],
+                ["", "F1URxPacketOosCnt", "OOS packets"],
+                ["X2-U Interface collected in UP per eNB IP per QCI", "X2URxPacketLossCnt", "Lost packets"],
+                ["", "X2URxPacketOosCnt", "OOS packets"],
+            ],
+            _collapse_structural_triplet_columns(table),
+        )
+
+    def test_collapse_structural_triplet_columns_builds_family_type_description_layout_from_four_columns(self) -> None:
+        table = [
+            [
+                "F1-U, XN-U collected in SNSSAI F1-U, XN-U collected in SNSSAI",
+                "UL Interface UPC per 5QI per UL Interface UPP per 5QI per",
+                "PacketLossCntUL",
+                "Lost packets",
+            ],
+            ["", "", "PacketOosCntUL", "OOS packets"],
+        ]
+        self.assertEqual(
+            [
+                ["Family Display Name", "Type Name", "Type Description"],
+                [
+                    "F1-U, XN-U collected in UL Interface UPC per 5QI per SNSSAI\nF1-U, XN-U collected in UL Interface UPP per 5QI per SNSSAI",
+                    "PacketLossCntUL",
+                    "Lost packets",
+                ],
+                ["", "PacketOosCntUL", "OOS packets"],
+            ],
+            _collapse_structural_triplet_columns(table),
+        )
+
+    def test_collapse_structural_triplet_columns_normalizes_dl_family_display_name(self) -> None:
+        table = [
+            ["", "Family Displa", "y Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "DL F1-U, Xn PRC per 5Q", "-U Interface per I per S-NSSAI", "", "", "PacketLossCntDL", "", "", "Lost packets", ""],
+        ]
+        self.assertEqual(
+            [
+                ["Family Display Name", "Type Name", "Type Description"],
+                ["DL F1-U, Xn-U Interface per PRC per 5QI per S-NSSAI", "PacketLossCntDL", "Lost packets"],
+            ],
+            _collapse_structural_triplet_columns(table),
+        )
+
+    def test_table_text_from_rows_preserves_explicit_multiline_cells(self) -> None:
+        rows = [
+            ["Family Display Name", "Type Name", "Type Description"],
+            [
+                "F1-U, XN-U collected in UL Interface UPC per 5QI per SNSSAI\nF1-U, XN-U collected in UL Interface UPP per 5QI per SNSSAI",
+                "PacketLossCntUL",
+                "Lost packets",
+            ],
+        ]
+        markdown = _table_text_from_rows(rows)
+        self.assertIn(
+            "F1-U, XN-U collected in UL Interface UPC per 5QI per SNSSAI<br>F1-U, XN-U collected in UL Interface UPP per 5QI per SNSSAI",
+            markdown,
         )
 
     def test_geometry_aware_single_row_requires_note_signal(self) -> None:
@@ -184,18 +314,18 @@ class TableModuleTests(unittest.TestCase):
                 curr_axes=[180.4, 279.8],
                 body_top=72.0,
                 body_bottom=722.0,
-                gap_text_boxes=[],
+                has_gap_text=[],
             )
         )
         self.assertFalse(
             _continuation_regions_should_merge(
-                prev_bbox=(100.0, 620.0, 400.0, 705.0),
-                curr_bbox=(102.0, 88.0, 402.0, 190.0),
+                prev_bbox=(100.0, 520.0, 400.0, 620.0),
+                curr_bbox=(102.0, 180.0, 402.0, 280.0),
                 prev_axes=[180.0, 280.0],
                 curr_axes=[180.4, 279.8],
                 body_top=72.0,
                 body_bottom=722.0,
-                gap_text_boxes=[(40.0, 730.0, 80.0, 742.0)],
+                has_gap_text=[(40.0, 730.0, 80.0, 742.0)],
             )
         )
 
@@ -408,7 +538,14 @@ class TableModuleTests(unittest.TestCase):
 
         expected_bbox = (40.0, 119.0, 540.0, 150.0)
         table_regions.assert_called_once_with(page)
-        extract_from_crop.assert_called_once_with(page, expected_bbox, fallback_to_text_rows=True)
+        extract_from_crop.assert_called_once_with(
+            page,
+            expected_bbox,
+            fallback_to_text_rows=False,
+            strategy_debug=None,
+            strategy_source="table_region",
+            strategy_source_name="table_region#0:split#0",
+        )
 
     def test_extract_tables_filters_single_column_box_overlapping_detected_table(self) -> None:
         table_bbox = (40.0, 119.0, 540.0, 150.0)
@@ -493,7 +630,8 @@ class TableModuleTests(unittest.TestCase):
         ):
             tables = _extract_tables(page)
 
-        self.assertEqual([], tables)
+        self.assertEqual(1, len(tables))
+        self.assertEqual(table_bbox, tables[0][1])
 
     def test_extract_tables_keeps_layout_candidate_if_not_note(self) -> None:
         table_bbox = (40.0, 119.0, 540.0, 150.0)
@@ -831,7 +969,67 @@ class TableModuleTests(unittest.TestCase):
         markdown = _table_text_from_rows(rows)
 
         self.assertIn("| Stage<br>Group | Team<br>Function | Notes<br>Deliverable |", markdown)
-        self.assertIn("| Phase A | Discovery | Kickoff scope lock |", markdown)
+        self.assertIn("| Phase A", markdown)
+        self.assertIn("Kickoff scope lock", markdown)
+
+    def test_header_row_count_does_not_promote_first_data_row_to_header(self) -> None:
+        rows = [
+            ["Interface / Direction", "Sender", "Receiver"],
+            ["S1-U / Downlink", "S-GW", "CU-UP"],
+            ["F1-U / Uplink", "DU", "CU-UP"],
+        ]
+
+        self.assertEqual(1, _header_row_count(rows))
+
+    def test_collapse_structural_triplet_columns_normalizes_ul_family_display_variants(self) -> None:
+        table = [
+            ["", "Family Displa", "y Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "F1-U UL Inte", "rface per QCI", "", "", "F1UPacketLossCntUL_QC I", "", "", "Lost packets", ""],
+            ["", "F1-U UL Inte UP per QCI", "rface collected in", "", "", "F1UPacketLossRateUL_Q CI", "", "", "Lost packets", ""],
+            ["", "F1-U UL Inte UP per UP", "rface collected in", "", "", "F1UPacketLossCntUL", "", "", "Lost packets", ""],
+        ]
+
+        self.assertEqual(
+            [
+                ["Family Display Name", "Type Name", "Type Description"],
+                ["F1-U UL Interface per QCI", "F1UPacketLossCntUL_QCI", "Lost packets"],
+                ["F1-U UL Interface collected in UP per QCI", "F1UPacketLossRateUL_QCI", "Lost packets"],
+                ["F1-U UL Interface collected in UP per UP", "F1UPacketLossCntUL", "Lost packets"],
+            ],
+            _collapse_structural_triplet_columns(table),
+        )
+
+    def test_collapse_structural_triplet_columns_repairs_shifted_family_type_rows(self) -> None:
+        table = [
+            ["", "Family Display Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "F1-U DL Interface per QCI F1-U DL Interface per PRC per QCI", "", "", "F1UPacketLossCntDL_QC I", "", "", "Lost packets", ""],
+            ["", "", "F1UPacketOosCntDL_QCI", "OOS packets"],
+            ["", "", "F1UPacketLossRateDL_Q CI", "Loss-rate packets"],
+        ]
+
+        self.assertEqual(
+            [
+                ["Family Display Name", "Type Name", "Type Description"],
+                ["F1-U DL Interface per QCI\nF1-U DL Interface per PRC per QCI", "F1UPacketLossCntDL_QCI", "Lost packets"],
+                ["", "F1UPacketOosCntDL_QCI", "OOS packets"],
+                ["", "F1UPacketLossRateDL_QCI", "Loss-rate packets"],
+            ],
+            _collapse_structural_triplet_columns(table),
+        )
+
+    def test_collapse_structural_triplet_columns_normalizes_dl_du_family_display_name(self) -> None:
+        table = [
+            ["", "Family Displa", "y Name", "", "", "Type Name", "", "", "Type Description", ""],
+            ["", "F1-U DL Inte F1-U DL Inte DU", "rface per DU rface per PRC per", "", "", "F1UPacketLossCntDL", "", "", "Lost packets", ""],
+        ]
+
+        self.assertEqual(
+            [
+                ["Family Display Name", "Type Name", "Type Description"],
+                ["F1-U DL Interface per DU\nF1-U DL Interface per PRC per DU", "F1UPacketLossCntDL", "Lost packets"],
+            ],
+            _collapse_structural_triplet_columns(table),
+        )
 
     def test_table_text_from_rows_treats_long_single_column_as_note_content(self) -> None:
         rows = [
@@ -841,9 +1039,9 @@ class TableModuleTests(unittest.TestCase):
 
         markdown = _table_text_from_rows(rows)
 
-        self.assertIn("| Column 1 |", markdown)
-        self.assertIn("| F1-U path is not present in the integrated CU-DU shape. Hence, the counters for |", markdown)
-        self.assertIn("| F1-U are not provided in this shape. |", markdown)
+        self.assertIn("| Column 1", markdown)
+        self.assertIn("F1-U path is not present in the integrated CU-DU shape. Hence, the counters for", markdown)
+        self.assertIn("F1-U are not provided in this shape.", markdown)
         self.assertNotIn("| F1-U path is not present in the integrated CU-DU shape. Hence, the counters for | --- |", markdown)
 
     def test_single_column_note_body_text_is_single_line(self) -> None:
@@ -945,9 +1143,9 @@ class TableModuleTests(unittest.TestCase):
 
         markdown = _table_text_from_rows(rows)
 
-        self.assertIn("| Status |", markdown)
-        self.assertIn("| --- |", markdown)
-        self.assertIn("| Ready |", markdown)
+        self.assertIn("| Column 1", markdown)
+        self.assertIn("Status", markdown)
+        self.assertIn("Ready", markdown)
 
     def test_split_repeated_header_removes_repeated_two_row_header_block(self) -> None:
         prev_rows = [


### PR DESCRIPTION
## Summary
- tighten cross-page table continuation and remove stem-based document-id fallback artifacts
- normalize fragmented table family/type columns and preserve multiline family display cells in markdown output
- expand extraction regression coverage for note handling, header detection, continuation loading, and raw dump output naming

## Verification
- `python3 -m unittest tests.test_tables`
- `python3 -m unittest tests.test_pipeline.PipelineExtractionTests.test_h2_document_id_heading_drives_output_file_names_without_stem_fallback tests.test_raw.RawDumpTests.test_cli_raw_and_from_raw_options_work_end_to_end`