### PR TITLE
Remove markdown table width padding

### DIFF
--- a/graph_pdf/extractor/tables.py
+++ b/graph_pdf/extractor/tables.py
@@ -2850,21 +2850,11 @@ def _table_text_from_rows(rows: Sequence[Sequence[str]]) -> str:
         padded_row = list(row) + [""] * max(0, len(header) - len(row))
         formatted_body.append([_format_markdown_cell(str(value or "")) for value in padded_row])
 
-    column_widths = [
-        max(
-            len(formatted_header[idx]),
-            *(len(row[idx]) for row in formatted_body),
-            3,
-        )
-        for idx in range(len(header))
-    ]
-    header_line = "| " + " | ".join(
-        formatted_header[idx].ljust(column_widths[idx]) for idx in range(len(header))
-    ) + " |"
-    divider_line = "| " + " | ".join("-" * column_widths[idx] for idx in range(len(header))) + " |"
+    header_line = "| " + " | ".join(formatted_header) + " |"
+    divider_line = "| " + " | ".join("---" for _ in header) + " |"
     body_lines = []
     for row in formatted_body:
-        body_lines.append("| " + " | ".join(row[idx].ljust(column_widths[idx]) for idx in range(len(header))) + " |")
+        body_lines.append("| " + " | ".join(row) + " |")
     return "\n".join([header_line, divider_line, *body_lines])
 
 

--- a/graph_pdf/samples/raw-32-37_table.md
+++ b/graph_pdf/samples/raw-32-37_table.md
@@ -1,0 +1,31 @@
+### FGR-BC0008 table 1
+| Parameter | Description |
+| --- | --- |
+| dscp-bypass-enable | This determines whether to enable or disable this feature:<br>off: This feature is not used.<br>on: This feature is used. |
+
+### FGR-BC0008 table 2
+| Parameter | Description |
+| --- | --- |
+| slice-index | This leaf indicates the supported slice index. |
+| qos-5qi | This leaf indicates a 5G QoS Identifier(5QI) used to map NR bearer traffic and DSCP. |
+| dscp-bypass-mcg | This leaf indicates dscp-bypass function for DL packets on MCG leg.<br>0: off 1: It inserts outer IP DSCP value to DL packets.<br>2: It inserts inner IP DSCP value to DL packets |
+| dscp-bypass-scg | This leaf indicates dscp-bypass function for DL packets on SCG leg.<br>0: off 1: It inserts outer IP DSCP value to DL packets.<br>2: It inserts inner IP DSCP value to DL packets |
+
+### FGR-BC0008 table 3
+| Parameter | Description |
+| --- | --- |
+| qci | This leaf indicates a QoS Class Identifier(QCI). |
+| dscp-bypass-mcg | This leaf indicates dscp-bypass function for DL packets on MCG leg.<br>0: off 1: It inserts outer IP DSCP value to DL packets 2: It inserts inner IP DSCP value to DL packets |
+| dscp-bypass-scg | This leaf indicates dscp-bypass function for DL packets on SCG leg.<br>0: off 1: It inserts outer IP DSCP value to DL packets.<br>2: It inserts inner IP DSCP value to DL packets |
+
+### FGR-BC0008 table 4
+| Parameter | Description |
+| --- | --- |
+| dscp-index-ul | This indicates the DSCP index used in the UL scheduler. |
+| ul-preschedule-group | This indicates the latency group per DSCP for UL Prescheduling. |
+
+### FGR-BC0008 table 5
+| Parameter | Description |
+| --- | --- |
+| dscp-index-dl | This indicates the DSCP index used in the DL scheduler. |
+| non-gbr-pf-weight-dscp-dl | This indicates the relative weight index per DSCP in DL Proportional Fairness (PF) scheduler. As the value increases, the scheduling opportunity for the corresponding DSCP increases. |

--- a/graph_pdf/samples/raw-38-50_table.md
+++ b/graph_pdf/samples/raw-38-50_table.md
@@ -1,0 +1,61 @@
+### FGR-BC0201 table 1
+| Parameter | Description |
+| --- | --- |
+| srb-id | The ID of SRB to retrieve. 1: Information on SRB1. 2: Information on SRB2.<br>3: Information on SRB3 for NSA. |
+| gnb-timer-poll-retransmit | This parameter is the gNB timer to retransmit the poll in a transmitting AM RLC entity. |
+| ue-timer-poll-retransmit | This parameter is the UE timer to retransmit the poll in a transmitting AM RLC entity. |
+| gnb-poll-pdu | This parameter is the threshold to trigger the poll for pollPDU in an AM RLC entity at gNB side. |
+| ue-poll-pdu | This parameter is the threshold to trigger the poll for pollPDU in an AM RLC entity at UE side. |
+| gnb-poll-byte | This parameter is the threshold used to trigger the poll for pollByte in an AM_RLC entity at gNB side. |
+| ue-poll-byte | This parameter is the threshold used to trigger the poll for pollByte in an AM_RLC entity at UE side. |
+| gnb-max-retransmission-threshold | This parameter is the threshold used to limit the number of the AMD PDU retransmission in a transmitting AM_RLC entity at gNB side. |
+| ue-max-retransmission-threshold | This parameter is the threshold used to limit the number of the AMD PDU retransmission in a transmitting AM_RLC entity at UE side. |
+| gnb-t-reassembly | This parameter is the timer to reassemble of RLC PDUs in a receiving RLC entity at gNB side. |
+| ue-t-reassembly | This parameter is the timer to reassemble of RLC PDUs in a receiving RLC entity at UE side. |
+| gnb-timer-status-prohibit | This parameter is the timer to prohibit the transmission of STATUS_PDU in a receiving AM_RLC entity at gNB side. |
+| ue-timer-status-prohibit | This parameter is the timer to prohibit the transmission of STATUS_PDU in a receiving AM_RLC entity at UE side. |
+| sn-field-length-ul-am | RLC AM mode SN field length. |
+
+### FGR-BC0201 table 2
+| Parameter | Description |
+| --- | --- |
+| qci | This parameter is the QoS Class Identifier(QCI).<br>The standard QCI defined in the standard is 1 to 9. 0 and 10 to 255 can be used by an operator. |
+| gnb-timer-poll-retransmit | This parameter is the timer to retransmit the poll in a transmitting AM RLC entity. |
+| gnb-poll-pdu | This parameter is the threshold to trigger the poll for pollPDU in an AM RLC entity. |
+| gnb-poll-byte | This parameter is the threshold used to trigger the poll for pollByte in an AM_RLC entity. |
+| gnb-max-retransmission-threshold | This parameter is the threshold used to limit the number of AMD PDU retransmissions in a transmitting AM_RLC entity. |
+| gnb-t-reassembly | This parameter is the timer to reassemble of RLC PDUs in a receiving RLC entity |
+| gnb-timer-status-prohibit | This parameter is the timer to prohibit the transmission of STATUS_PDU in a receiving AM_RLC entity. |
+| ue-timer-poll-retransmit | This parameter is the timer to retransmit the poll in a UE transmitting the AM RLC entity. |
+| ue-poll-pdu | This parameter is the threshold to trigger the poll for pollPDU in an UE AM RLC entity. |
+| ue-poll-byte | This parameter is the threshold used to trigger the poll for pollByte in an UE side AM_RLC entity. |
+
+### FGR-BC0201 table 3
+| Parameter | Description |
+| --- | --- |
+| qos-5qi | This parameter is the 5G QoS Identifier(5QI).<br>The standard 5QI defined in standard is 1 to 9. 0 and 10 to 255 can be used by an operator. |
+| gnb-timer-poll-retransmit | This parameter is the timer to retransmit the poll in a transmitting AM RLC entity. |
+| gnb-poll-pdu | This parameter is the threshold to trigger the poll for pollPDU in an AM RLC entity. |
+| gnb-poll-byte | This parameter is the threshold used to trigger the poll for pollByte in an AM_RLC entity. |
+| gnb-max-retransmission-threshold | This parameter is the threshold used to limit the number of the AMD PDU retransmission in a transmitting AM_RLC entity. |
+| gnb-t-reassembly | This parameter is the timer to reassemble of RLC PDUs in a receiving RLC entity |
+| gnb-timer-status-prohibit | This parameter is the timer to prohibit the transmission of STATUS_PDU in a receiving AM_RLC entity. |
+| ue-timer-poll-retransmit | This parameter is the timer to retransmit poll in a UE transmitting the AM RLC entity. |
+| ue-poll-pdu | This parameter is the threshold to trigger the poll for pollPDU in an UE AM RLC entity. |
+| ue-poll-byte | This parameter is the threshold used to trigger the poll for pollByte in a UE side AM_RLC entity. |
+| ue-max-retransmission-threshold | This parameter is the threshold used to limit the number of AMD PDU retransmission in a UE side transmitting AM_RLC entity. |
+| ue-t-reassembly | This parameter is the timer to reassemble of RLC PDUs in a UE side receiving the RLC entity. |
+| ue-timer-status-prohibit | This parameter is the timer to prohibit the transmission of STATUS_PDU in a UE side receiving the AM_RLC entity. |
+| sn-field-length-ul-um | This parameter is the RLC configuration of UM mode per QCI for sequence number size of uplink UM RLC entity(6 bit or 12 bit) |
+| sn-field-length-ul-am | This parameter is the RLC Configurations of AM mode per QCI for the sequence number size of uplink AM RLC entity(12 bit or 18 bit) |
+| sn-field-length-dl-um | This parameter is the RLC Configurations of UM mode per QCI for sequence number size of downlink UM RLC entity(6 bit or 12 bit) |
+| sn-field-length-dl-am | This parameter is the RLC Configurations of UM mode per QCI for sequence number size of downlink AM RLC entity(12 bit or 18 bit) |
+
+### FGR-BC0201 table 4
+| Parameter | Description |
+| --- | --- |
+| adaptive-rlc-poll-retx-dl-enable | This parameter is used to enable/disable the adaptive RLC poll retransmission function. |
+| adaptive-retx-point-dl | This parameter is used for the configuration of the adaptive retransmission timer application point. The adaptive timer value starts to be applied from the number of retransmissions of this setting value. |
+| adaptive-first-rlc-poll-timer | This parameter is used to configure the poll timer that is first applied during adaptive retransmission. |
+| adaptive-second-rlc-poll-timer | This parameter is used to configure the poll timer that is applied second during adaptive retransmission. |
+| adaptive-last-rlc-poll-timer | This parameter is used to configure the poll timer that is lastly applied at the adaptive retransmission point. |

--- a/graph_pdf/samples/raw-93-114_table.md
+++ b/graph_pdf/samples/raw-93-114_table.md
@@ -1,0 +1,204 @@
+### FGR-BC0401 table 1
+| Interface / Direction | Sender | Receiver |
+| --- | --- | --- |
+| S1-U / Downlink | S-GW | CU-UP |
+| F1-U / Uplink | DU | CU-UP |
+| F1-U / Downlink | CU-UP | DU |
+
+### FGR-BC0401 table 2
+| Interface / Direction | Sender | Receiver |
+| --- | --- | --- |
+| N3 / Downlink | UPF | CU-UP |
+| F1-U / Uplink | DU | CU-UP |
+| F1-U / Downlink | CU-UP | DU |
+
+### FGR-BC0401 table 3
+| Parameter | Description |
+| --- | --- |
+| sequence-number-flag | This parameter indicates whether to configure the GTP sequence number of the GTP Packet.<br>false: The GTP sequence number is not configured to the GTP header information of a GTP packet that is transmitted by a gNB.<br>true: The GTP sequence number is configured to the GTP header information of a GTP packet that is transmitted by a gNB. |
+
+### FGR-BC0401 table 4
+| Parameter | Description |
+| --- | --- |
+| sgw-gtp-ip-index | This leaf indicates sGW's GTP IP Index. |
+| sgw-gtp-ip | This leaf indicates the sGW's GTP IP address. |
+
+### FGR-BC0401 table 5
+| Parameter | Description |
+| --- | --- |
+| upf-gtp-ip-index | This leaf indicates UPF's GTP IP Index. |
+| upf-gtp-ip | This leaf indicates the UPF's GTP IP address. |
+
+### FGR-BC0401 table 6
+| Parameter | Description |
+| --- | --- |
+| enb-gtp-ip-index | This leaf indicates eNB's GTP IP Index. |
+| enb-gtp-ip | This leaf indicates the eNB's GTP IP address. |
+
+### FGR-BC0401 table 7
+| Parameter | Description |
+| --- | --- |
+| xn-gtp-ip-index | This leaf indicates peer gNB's GTP IP Index. |
+| xn-gtp-ip | This leaf indicates the gNB's GTP IP address. |
+
+### FGR-BC0401 table 8
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| F1-U UL Interface per QCI | F1UPacketLossCntUL_QCI | This counter is the number of uplink GTP packets that have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+|  | F1UPacketOosCntUL_QCI | This counter is the number of Out of Sequence downlink packets (that is, the accumulated count of packets which order of the GTP Sequence Number is reversed) |
+|  | F1UPacketCntUL_QCI | This counter is the total number of the uplink GTP packets received until the time of counting the statistic. Count includes good packets received in sequence and OOS. |
+|  | F1UPacketLossRateUL_QCI | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for uplink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+
+### FGR-BC0401 table 9
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| F1-U UL Interface collected in UP per QCI | F1UPacketLossCntUL_QCI | This counter is the number of uplink GTP packets which have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+|  | F1UPacketOosCntUL_QCI | This counter is the number of out-of-sequence downlink packets (that is, the accumulated count of packets whose order of the GTP Sequence Number is reversed) |
+|  | F1UPacketCntUL_QCI | This counter is the total number of the uplink GTP packets received until the time of counting the statistic. Count includes good packets received in sequence and OOS. |
+|  | F1UPacketLossRateUL_QCI | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for uplink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+
+### FGR-BC0401 table 10
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| F1-U UL Interface per UPC | F1UPacketLossCntUL | This counter is the number of uplink GTP packets that have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+|  | F1UPacketOosCntUL | This counter is the number of out-of-sequence downlink packets (that is, the accumulated count of packets which order of the GTP Sequence Number is reversed) |
+|  | F1UPacketCntUL | This counter is the total number of the uplink GTP packets received until the time of counting the statistic. Count includes good packets received in sequence and OOS. |
+|  | F1UPacketLossRateUL | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for uplink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+
+### FGR-BC0401 table 11
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| F1-U UL Interface collected in UP per UP | F1UPacketLossCntUL | This counter is the number of uplink GTP packets which have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+|  | F1UPacketOosCntUL | This counter is the number of Out of Sequence downlink packets (that is, the accumulated count of packets which order of the GTP Sequence Number is reversed) |
+|  | F1UPacketCntUL | This counter is the total number of the uplink GTP packets received until the time of counting the statistic. Count includes good packets received in sequence and OOS. |
+|  | F1UPacketLossRateUL | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for uplink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+
+### FGR-BC0401 table 12
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| F1-U DL Interface per QCI<br>F1-U DL Interface per PRC per QCI | F1UPacketLossCntDL_QCI | This counter is the number of downlink GTP packets which have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+|  | F1UPacketOosCntDL_QCI | This counter is the number of Out of Sequence downlink packets (that is, the accumulated count of packets which order of the GTP Sequence Number is reversed) |
+|  | F1UPacketCntDL_QCI | This counter is the number of the downlink GTP packets received until the time of counting the statistic. Count includes good packets received in sequence and OOS. |
+|  | F1UPacketLossRateDL_Q CI | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for downlink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+
+### FGR-BC0401 table 13
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| F1-U DL Interface per DU<br> F1-U DL Interface per PRC per DU | F1UPacketLossCntDL | This counter is the number of downlink GTP packets which have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+|  | F1UPacketOosCntDL | This counter is the number of Out of Sequence downlink packets (that is, the accumulated count of packets which order of the GTP Sequence Number is reversed) |
+|  | F1UPacketCntDL | This counter is the number of the downlink GTP packets received until the time of counting the statistic. Count includes good packets received in sequence and OOS. |
+|  | F1UPacketLossRateDL | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for downlink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+
+### FGR-BC0401 table 14
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| S1-U Interface per sGW IP per QCI | S1URxPacketLossCnt | This counter is the number of the lost downlink GTP packets. A negative number of counter value indicates that the packets, which were lost in the previous collection cycle, are out-of-sequence inflow packets for the current collection cycle. |
+|  | S1URxPacketOosCnt | This counter is the number of downlink GTP packets that are out of sequence in the order of the GTP sequence number. |
+|  | S1URxPacketLossRate | This counter is the ratio of lost downlink GTP packets to received downlink GTP packets.<br>A negative number of the counter value indicates that the packets lost in the previous collection cycle are out-of-sequence inflow packets for the current collection cycle. |
+|  | S1URxPacketCnt | This counter is the total number of received downlink GTP packets, which include both in-order packets and out-of-sequence packets. |
+|  | S1UTxPacketCnt | This counter is the total number of transmitted uplink GTP packets. |
+| F1-U Interface per gNB DU per QCI | F1URxPacketLossCnt | This counter is the number of uplink GTP packets which have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequenceinflow packet for the current collection cycle. |
+|  | F1URxPacketOosCnt | This counter is the number of Out of Sequence uplink packets (that is, the accumulated count of packets which order of the GTP Sequence Number is reversed) |
+|  | F1URxPacketLossRate | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for uplink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+|  | F1URxPacketCnt | This counter is the total number of received uplink GTP packets, which include both in-order packets and out-of-sequence packets. |
+|  | F1UTxPacketCnt | This counter is the total number of transmitted downlink GTP packets. |
+
+### FGR-BC0401 table 15
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| X2-U Interface per eNB IP per QCI | X2URxPacketLossCnt | This counter is the number of uplink GTP packets which have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequenceinflow packet for the current collection cycle. |
+|  | X2URxPacketOosCnt | This counter is the number of Out of Sequence uplink packets (that is, the accumulated count of packets which order of the GTP Sequence Number is reversed) |
+|  | X2URxPacketLossRate | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for uplink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+|  | X2URxPacketCnt | This counter is the total number of the uplink GTP packets received until the time of counting the statistic. Count includes good packets received in sequence and OOS. |
+|  | X2UTxPacketCnt | This counter is the total number of transmitted downlink GTP packets. |
+
+### FGR-BC0401 table 16
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| S1-U Interface collected in UP per sGW IP per QCI | S1URxPacketLossCnt | This counter is the number of the lost downlink GTP packets. A negative number of counter value indicates that the packets, which were lost in the previous collection cycle, are out-of-sequence inflow packets for the current collection cycle. |
+|  | S1URxPacketOosCnt | This counter is the number of downlink GTP packets that are out of sequence in the order of the GTP sequence number. |
+|  | S1URxPacketLossRate | This counter is the ratio of lost downlink GTP packets to received downlink GTP packets.<br>A negative number of the counter value indicates that the packets lost in the previous collection cycle are out-of-sequence inflow packets for the current collection cycle. |
+|  | S1URxPacketCnt | This counter is the total number of received downlink GTP packets, which include both in-order packets and out-of-sequence packets. |
+|  | S1UTxPacketCnt | This counter is the total number of transmitted uplink GTP packets. |
+| F1-U Interface collected in UP per QCI per gNB-DU | F1URxPacketLossCnt | This counter is the number of uplink GTP packets which have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequenceinflow packet for the current collection cycle. |
+|  | F1URxPacketOosCnt | This counter is the number of Out of Sequence uplink packets (that is, the accumulated count of packets which order of the GTP Sequence Number is reversed) |
+|  | F1URxPacketLossRate | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for uplink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, isan out-of-sequence inflow packet for the current collection cycle. |
+|  | F1URxPacketCnt | This counter is the total number of received uplink GTP packets, which include both in-order packets and out-of-sequence packets. |
+|  | F1UTxPacketCnt | This counter is the total number of transmitted downlink GTP packets. |
+| X2-U Interface collected in UP per eNB IP per QCI | X2URxPacketLossCnt | This counter is the number of uplink GTP packets which have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequenceinflow packet for the current collection cycle. |
+|  | X2URxPacketOosCnt | This counter is the number of Out of Sequence uplink packets (that is, the accumulated count of packets which order of the GTP Sequence Number is reversed) |
+|  | X2URxPacketLossRate | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for uplink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+|  | X2URxPacketCnt | This counter is the total number of the uplink GTP packets received until the time of counting the statistic. Count includes good packets received in sequence and OOS. |
+|  | X2UTxPacketCnt | This counter is the total number of transmitted downlink GTP packets. |
+
+### FGR-BC0401 table 17
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| N3 Interface per UPF IP | N3RxPacketLossCnt | This counter is the number of the lost downlink GTP packets. A negative number of counter value indicates that the packets, which were lost in the previous collection cycle, are out-of-sequence inflow packets for the current collection cycle. |
+|  | N3RxPacketOosCnt | This counter is the number of downlink GTP packets that are out of sequence in the order of the GTP sequence number. |
+|  | N3RxPacketLossRate | This counter is the ratio of lost downlink GTP packets to received downlink GTP packets.<br>A negative number of the counter value indicates that the packets lost in the previous collection cycle are out-of-sequence inflow packets for the current collection cycle. |
+|  | N3RxPacketCnt | This counter is the total number of received downlink GTP packets, which include both in-order packets and out-of-sequence packets. |
+|  | N3TxPacketCnt | This counter is the total number of transmitted uplink GTP packets. |
+| F1-U Interface per gNB DU per 5QI | F1URxPacketLossCnt | This counter is the number of uplink GTP packets which have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequenceinflow packet for the current collection cycle. |
+|  | F1URxPacketOosCnt | This counter is the number of Out of Sequence uplink packets (that is, the accumulated count of packets which order of the GTP Sequence Number is reversed) |
+|  | F1URxPacketLossRate | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for uplink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, isan out-of-sequence inflow packet for the current collection cycle. |
+|  | F1URxPacketCnt | This counter is the total number of received uplink GTP packets, which include both in-order packets and out-of-sequence packets. |
+|  | F1UTxPacketCnt | This counter is the total number of transmitted downlink GTP packets. |
+
+### FGR-BC0401 table 18
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| N3 Interface collected in UP per UPF IP | N3RxPacketLossCnt | This counter is the number of the lost downlink GTP packets. A negative number of counter value indicates that the packets, which were lost in the previous collection cycle, are out-of-sequence inflow packets for the current collection cycle. |
+|  | N3RxPacketOosCnt | This counter is the number of downlink GTP packets that are out of sequence in the order of the GTP sequence number. |
+|  | N3RxPacketLossRate | This counter is the ratio of lost downlink GTP packets to received downlink GTP packets.<br>A negative number of the counter value indicates that the packets lost in the previous collection cycle are out-of-sequence inflow packets for the current collection cycle. |
+|  | N3RxPacketCnt | This counter is the total number of received downlink GTP packets, which include both in-order packets and out-of-sequence packets. |
+|  | N3TxPacketCnt | This counter is the total number of transmitted uplink GTP packets. |
+| F1-U Interface collected in UP per 5QI  per gNB-DU | F1URxPacketLossCnt | This counter is the number of uplink GTP packets which have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequenceinflow packet for the current collection cycle. |
+|  | F1URxPacketOosCnt | This counter is the number of Out of Sequence uplink packets (that is, the accumulated count of packets which order of the GTP Sequence Number is reversed) |
+|  | F1URxPacketLossRate | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for uplink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+|  | F1URxPacketCnt | This counter is the total number of received uplink GTP packets, which include both in-order packets and out-of-sequence packets. |
+|  | F1UTxPacketCnt | This counter is the total number of transmitted downlink GTP packets. |
+
+### FGR-BC0401 table 19
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| N3 Interface collected in UP per UPF IP | N3RxPacketLossCnt | This counter is the number of the lost downlink GTP packets. A negative number of counter value indicates that the packets, which were lost in the previous collection cycle, are out-of-sequence inflow packets for the current collection cycle. |
+|  | N3RxPacketOosCnt | This counter is the number of downlink GTP packets that are out of sequence in the order of the GTP sequence number. |
+|  | N3RxPacketLossRate | This counter is the ratio of lost downlink GTP packets to received downlink GTP packets.<br>A negative number of the counter value indicates that the packets lost in the previous collection cycle are out-of-sequence inflow packets for the current collection cycle. |
+|  | N3RxPacketCnt | This counter is the total number of received downlink GTP packets, which include both in-order packets and out-of-sequence packets. |
+|  | N3TxPacketCnt | This counter is the total number of transmitted uplink GTP packets. |
+| F1-U Interface collected in UP per 5QI per gNB-DU | F1URxPacketLossCnt | This counter is the number of uplink GTP packets which have been lost until the statistics collection time. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequenceinflow packet for the current collection cycle. |
+|  | F1URxPacketOosCnt | This counter is the number of Out of Sequence uplink packets (that is, the accumulated count of packets which order of the GTP Sequence Number is reversed) |
+|  | F1URxPacketLossRate | This counter is the ratio of actually lost packets to all packets by the time statistics are collected for uplink GTP packets. A negative value denotes that the packets which were lost in the previous collection cycle, is an out-of-sequence inflow packet for the current collection cycle. |
+|  | F1URxPacketCnt | This counter is the total number of received uplink GTP packets, which include both in-order packets and out-of-sequence packets. |
+|  | F1UTxPacketCnt | This counter is the total number of transmitted downlink GTP packets. |
+
+### FGR-BC0401 table 20
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| F1-U, XN-U collected in UL Interface UPC per 5QI per SNSSAI<br>F1-U, XN-U collected in UL Interface UPP per 5QI per SNSSAI | PacketLossCntUL | This counter is the number of lost uplink GTP packets. A negative number of the counter value indicates that the packets, which were lost in the previous collection cycle, are out-of-sequence inflow packets for the current collection cycle. |
+|  | PacketOosCntUL | This counter is the number of uplink GTP packets that are out of sequence in the order of the GTP sequence number. |
+|  | PacketCntUL | This counter is the total number of received uplink GTP packets. |
+|  | PacketLossRateUL | This counter is the ratio of lost uplink GTP packets to received uplink GTP packets. A negative number of the counter value indicates that the packets lost in the previous collection cycle are out-of-sequence inflow packets for the current collection cycle. |
+
+### FGR-BC0401 table 21
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| DL F1-U, Xn-U Interface per PRC per 5QI per S-NSSAI | PacketLossCntDL | This counter is the number of the lost downlink GTP packets. A negative number of the counter value indicates that the packets, which were lost in the previous collection cycle, are out-of-sequence inflow packets for the current collection cycle. |
+|  | PacketOosCntDL | This counter is the number of downlink GTP packets that are out of sequence in the order of the GTP sequence number. |
+|  | PacketCntDL | This counter is the total number of received downlink GTP packets. |
+|  | PacketLossRateDL | This counter is the ratio of lost downlink GTP packets to received downlink GTP packets.<br>A negative number of the counter value indicates that the packets lost in the previous collection cycle are out-of-sequence inflow packets for the current collection cycle. |
+
+### FGR-BC0401 table 22
+| Family Display Name | Type Name | Type Description |
+| --- | --- | --- |
+| XN-U Interface per UPC_ID per peer gNB per 5QI | XNURxPacketLossCnt | This counter is the number of lost uplink GTP packets. A negative number of the counter value indicates that the packets, which were lost in the previous collection cycle, are out-of-sequence inflow packets for the current collection cycle. |
+|  | XNURxPacketOosCnt | This counter is the number of uplink GTP packets that are out of sequence in the order of the GTP sequence number. |
+|  | XNURxPacketCnt | This counter is the total number of received uplink GTP packets, which include both in-order packets and out-of-sequence packets. |
+|  | XNURxPacketLossRate | This counter is the ratio of lost uplink GTP packets to received uplink GTP packets. A negative number of the counter value indicates that the packets lost in the previous collection cycle are out-of-sequence inflow packets for the current collection cycle. |
+|  | XNUTxPacketCnt | This counter is the total number of transmitted downlink GTP packets. |
+| XN-U Interface per UP_ID per peer gNB per 5QI | XNURxPacketLossCnt | This counter is the number of lost uplink GTP packets. A negative number of the counter value indicates that the packets, which were lost in the previous collection cycle, are out-of-sequence inflow packets for the current collection cycle. |
+|  | XNURxPacketOosCnt | This counter is the number of uplink GTP packets that are out of sequence in the order of the GTP sequence number. |
+|  | XNURxPacketCnt | This counter is the total number of received uplink GTP packets, which include both in-order packets and out-of-sequence packets. |
+|  | XNURxPacketLossRate | This counter is the ratio of lost uplink GTP packets to received uplink GTP packets. A negative number of the counter value indicates that the packets lost in the previous collection cycle are out-of-sequence inflow packets for the current collection cycle. |
+|  | XNUTxPacketCnt | This counter is the total number of transmitted downlink GTP packets. |

--- a/graph_pdf/tests/test_tables.py
+++ b/graph_pdf/tests/test_tables.py
@@ -972,6 +972,25 @@ class TableModuleTests(unittest.TestCase):
         self.assertIn("| Phase A", markdown)
         self.assertIn("Kickoff scope lock", markdown)
 
+    def test_table_text_from_rows_does_not_pad_cells_to_column_width(self) -> None:
+        rows = [
+            ["Parameter", "Description"],
+            ["qci", "This parameter is the QoS Class Identifier(QCI)."],
+        ]
+
+        markdown = _table_text_from_rows(rows)
+
+        self.assertEqual(
+            "\n".join(
+                [
+                    "| Parameter | Description |",
+                    "| --- | --- |",
+                    "| qci | This parameter is the QoS Class Identifier(QCI). |",
+                ]
+            ),
+            markdown,
+        )
+
     def test_header_row_count_does_not_promote_first_data_row_to_header(self) -> None:
         rows = [
             ["Interface / Direction", "Sender", "Receiver"],


### PR DESCRIPTION
## Summary
- remove width-based padding from generated markdown tables
- add a regression test for unpadded markdown table formatting
- normalize the sample `*_table.md` goldens to the same compact markdown table format

## Verification
- `python3 -m unittest tests.test_tables`
- `python3 -m unittest tests.test_pipeline.PipelineExtractionTests.test_h2_document_id_heading_drives_output_file_names_without_stem_fallback`