### PR TITLE
Add runnable UI page and execution docs for langgraph_vis

### DIFF
--- a/langgraph_vis/README.md
+++ b/langgraph_vis/README.md
@@ -1,0 +1,44 @@
+# LangGraph Vis (Week 04)
+
+이 프로젝트는 `langgraph_vis` 경로에서 백엔드(Python/FastAPI)와 간단한 웹 페이지를 함께 실행할 수 있습니다.
+
+## 실행 방법
+
+### 1) 환경 준비
+
+```bash
+cd langgraph_vis
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -r python_backend/requirements.txt
+```
+
+### 2) 백엔드 실행
+
+```bash
+PYTHONPATH=. .venv/bin/python python_backend/run_server.py
+```
+
+- API 서버: `http://127.0.0.1:8000`
+- API 문서: `http://127.0.0.1:8000/docs`
+- 테스트 페이지: `http://127.0.0.1:8000/ui/`
+
+### 3) 테스트 실행
+
+```bash
+cd langgraph_vis
+npm test
+```
+
+## 페이지 사용
+
+- `http://127.0.0.1:8000/ui/` 에서 실행 상태/이벤트 조회를 할 수 있습니다.
+- `runId` 와 `threadId` 를 입력하고:
+  - `Load state`: `GET /api/runs/{runId}/state` 조회
+  - `Load events`: `GET /api/runs/{runId}/events` 조회
+  - `Open stream`: `GET /api/runs/{runId}/events/stream` SSE 구독
+
+## 참고
+
+- 실행 시 이벤트 데이터가 없다면 API 응답이 비어 있을 수 있습니다.
+- 실제 런 데이터 준비용 UI(등록/전송 기능)는 이번 버전에서 별도 미구현입니다.

--- a/langgraph_vis/frontend/index.html
+++ b/langgraph_vis/frontend/index.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>LangGraph Vis Week 04</title>
+    <style>
+      body {
+        font-family: Inter, system-ui, sans-serif;
+        margin: 0;
+        padding: 24px;
+        background: #0b1020;
+        color: #e5e7eb;
+      }
+      .panel {
+        margin-bottom: 16px;
+      }
+      label {
+        margin-right: 8px;
+      }
+      input,
+      button {
+        margin-right: 8px;
+      }
+      textarea,
+      pre {
+        width: 100%;
+        box-sizing: border-box;
+      }
+      textarea,
+      pre {
+        background: #111827;
+        color: #f9fafb;
+        border: 1px solid #374151;
+        border-radius: 8px;
+      }
+      textarea {
+        min-height: 140px;
+        resize: vertical;
+      }
+      .row {
+        margin-top: 8px;
+      }
+      .error {
+        color: #f87171;
+      }
+      button {
+        padding: 6px 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>LangGraph Vis Week 04</h1>
+    <p>백엔드 API + SSE 스트림 데모 페이지</p>
+
+    <div class="panel">
+      <label for="base-url">Backend URL</label>
+      <input id="base-url" value="http://127.0.0.1:8000" size="36" />
+      <label for="run-id">runId</label>
+      <input id="run-id" value="run_api" />
+      <label for="thread-id">threadId</label>
+      <input id="thread-id" value="thread-1" />
+    </div>
+
+    <div class="panel">
+      <label for="from-seq">fromSeq</label>
+      <input id="from-seq" value="1" size="8" />
+      <label for="last-event-id">last-event-id</label>
+      <input id="last-event-id" placeholder="선택" size="20" />
+    </div>
+
+    <div class="panel row">
+      <button id="btn-state">Load state</button>
+      <button id="btn-events">Load events</button>
+      <button id="btn-stream">Open stream</button>
+      <button id="btn-stop">Close stream</button>
+    </div>
+
+    <pre id="status" class="error"></pre>
+    <h3>State</h3>
+    <pre id="state-output">-</pre>
+    <h3>Events</h3>
+    <pre id="events-output">-</pre>
+
+    <script>
+      const baseUrlInput = document.getElementById("base-url");
+      const runIdInput = document.getElementById("run-id");
+      const threadIdInput = document.getElementById("thread-id");
+      const fromSeqInput = document.getElementById("from-seq");
+      const lastEventIdInput = document.getElementById("last-event-id");
+      const statusOutput = document.getElementById("status");
+      const stateOutput = document.getElementById("state-output");
+      const eventsOutput = document.getElementById("events-output");
+
+      let streamHandle = null;
+
+      function runApiUrl(path, query) {
+        const base = new URL(baseUrlInput.value.replace(/\\/$/, ""));
+        const url = new URL(path, `${base.href}/`);
+        Object.entries(query || {}).forEach(([key, value]) => {
+          if (value !== undefined && value !== null && `${value}` !== "") {
+            url.searchParams.set(key, value);
+          }
+        });
+        return url.toString();
+      }
+
+      function getRunId() {
+        const runId = runIdInput.value.trim();
+        if (!runId) {
+          throw new Error("runId is required");
+        }
+        return runId;
+      }
+
+      function normalizeThreadId() {
+        return threadIdInput.value.trim();
+      }
+
+      async function doGet(path, query) {
+        const runId = getRunId();
+        const threadId = normalizeThreadId();
+        const url = runApiUrl(path.replace("{runId}", runId).replace("{threadId}", threadId), query);
+        const response = await fetch(url, { headers: { "Accept": "application/json" } });
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new Error(`${response.status}: ${errorText || response.statusText}`);
+        }
+        return response.json();
+      }
+
+      async function loadState() {
+        statusOutput.textContent = "";
+        try {
+          const payload = await doGet("/api/runs/{runId}/state");
+          stateOutput.textContent = JSON.stringify(payload, null, 2);
+        } catch (error) {
+          statusOutput.textContent = String(error);
+        }
+      }
+
+      async function loadEvents() {
+        statusOutput.textContent = "";
+        try {
+          const payload = await doGet("/api/runs/{runId}/events", { lastEventId: lastEventIdInput.value.trim() });
+          eventsOutput.textContent = JSON.stringify(payload, null, 2);
+        } catch (error) {
+          statusOutput.textContent = String(error);
+        }
+      }
+
+      function openStream() {
+        statusOutput.textContent = "";
+        const runId = getRunId();
+        const threadId = normalizeThreadId();
+        if (!threadId) {
+          statusOutput.textContent = "threadId를 입력하세요.";
+          return;
+        }
+
+        if (streamHandle) {
+          streamHandle.close();
+        }
+
+        const url = runApiUrl(`/api/runs/${encodeURIComponent(runId)}/events/stream`, {
+          fromSeq: fromSeqInput.value.trim(),
+          lastEventId: lastEventIdInput.value.trim(),
+        });
+
+        const source = new EventSource(url);
+        streamHandle = source;
+
+        const output = [];
+        eventsOutput.textContent = "";
+        source.addEventListener("run-event", (event) => {
+          try {
+            const data = JSON.parse(event.data);
+            output.push(data);
+            eventsOutput.textContent = JSON.stringify(output, null, 2);
+          } catch (err) {
+            statusOutput.textContent = `SSE parse error: ${err.message}`;
+          }
+        });
+        source.addEventListener("error", () => {
+          statusOutput.textContent = "SSE 연결이 종료되었거나 오류가 발생했습니다.";
+          source.close();
+          streamHandle = null;
+        });
+      }
+
+      function closeStream() {
+        if (streamHandle) {
+          streamHandle.close();
+          streamHandle = null;
+        }
+      }
+
+      document.getElementById("btn-state").addEventListener("click", loadState);
+      document.getElementById("btn-events").addEventListener("click", loadEvents);
+      document.getElementById("btn-stream").addEventListener("click", openStream);
+      document.getElementById("btn-stop").addEventListener("click", closeStream);
+    </script>
+  </body>
+</html>

--- a/langgraph_vis/package.json
+++ b/langgraph_vis/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "start:backend": "PYTHONPATH=. .venv/bin/python python_backend/run_server.py",
+    "start": "npm run start:backend",
     "test:backend": "PYTHONPATH=. .venv/bin/pytest -q python_backend/tests",
     "test:frontend": "node --test tests/week-04/*.test.js",
     "test": "npm run test:backend && npm run test:frontend"

--- a/langgraph_vis/python_backend/app/main.py
+++ b/langgraph_vis/python_backend/app/main.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 
 from .schema_api import create_workflow_schema_router
 from .run_state_api import create_run_state_router
@@ -13,10 +17,21 @@ from .run_state_store import RunStateStore
 def create_app(*, run_store: RunStateStore | None = None):
     store = run_store or RunStateStore()
     app = FastAPI(title="langgraph_vis Python API", version="1.0.0")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+        allow_credentials=True,
+    )
 
     app.include_router(create_workflow_schema_router())
     app.include_router(create_run_state_router(store=store))
     app.include_router(create_run_history_router(store=store))
+
+    frontend_dir = Path(__file__).resolve().parent.parent.parent / "frontend"
+    if frontend_dir.exists():
+        app.mount("/ui", StaticFiles(directory=frontend_dir, html=True), name="ui")
     return app
 
 


### PR DESCRIPTION
## Summary
- Add a runnable frontend page for week-04 (`langgraph_vis/frontend/index.html`) served from backend `/ui/`.
- Serve static UI and enable CORS in FastAPI app (`python_backend/app/main.py`) so browser-based test usage works.
- Add run guide in `langgraph_vis/README.md` with backend run/test commands.
- Add convenience `npm` scripts for starting backend in `langgraph_vis/package.json`.

## Notes
- This PR is based on the already merged week4 readiness content in `dev` and adds missing execution usability artifacts the user requested.