### PR TITLE
feat: enable run creation and event emission for UI live demo

### DIFF
--- a/langgraph_vis/README.md
+++ b/langgraph_vis/README.md
@@ -16,12 +16,21 @@ python -m pip install -r python_backend/requirements.txt
 ### 2) 백엔드 실행
 
 ```bash
-PYTHONPATH=. .venv/bin/python python_backend/run_server.py
+# Linux/macOS
+cd /path/to/remote_work/langgraph_vis
+PYTHONPATH=$(pwd) .venv/bin/python -m uvicorn python_backend.app.main:app --host 0.0.0.0 --port 8000
 ```
 
 - API 서버: `http://127.0.0.1:8000`
 - API 문서: `http://127.0.0.1:8000/docs`
 - 테스트 페이지: `http://127.0.0.1:8000/ui/`
+
+참고:
+- 서버 루트(`/`)는 `http://127.0.0.1:8000/ui/`로 이동합니다.
+- run/event를 즉시 넣고 확인하려면:
+  - `POST /api/runs`
+  - `POST /api/runs/{runId}/events`
+- UI에도 `Create run`/`Emit event` 버튼이 추가되어 실시간으로 데이터 입력 후 SSE를 확인할 수 있습니다.
 
 ### 3) 테스트 실행
 

--- a/langgraph_vis/frontend/index.html
+++ b/langgraph_vis/frontend/index.html
@@ -80,6 +80,49 @@
       .hidden {
         display: none;
       }
+      .node-panel {
+        margin-top: 16px;
+        padding: 12px;
+        border: 1px solid #334155;
+        border-radius: 8px;
+        background: #0f172a;
+      }
+      .node-list {
+        list-style: none;
+        padding: 0;
+        margin: 4px 0 0;
+      }
+      .node-item {
+        margin-bottom: 6px;
+        padding: 8px 10px;
+        border-radius: 6px;
+        border: 1px solid #334155;
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .node-item.active {
+        border-color: #22d3ee;
+        box-shadow: 0 0 0 2px rgba(34, 211, 238, 0.2);
+        background: #082f49;
+      }
+      .node-item .node-name {
+        color: #e2e8f0;
+        font-weight: 600;
+      }
+      .node-item .node-meta {
+        color: #94a3b8;
+        font-size: 13px;
+      }
+      .active-chip {
+        margin: 0 0 6px;
+        padding: 6px 10px;
+        border-radius: 999px;
+        border: 1px solid #0f766e;
+        background: #042f2e;
+        width: fit-content;
+        color: #5eead4;
+      }
     </style>
   </head>
   <body>
@@ -158,6 +201,13 @@
     <h3>Events</h3>
     <pre id="events-output">-</pre>
 
+    <div class="node-panel">
+      <h3>Active Node</h3>
+      <div id="active-node" class="active-chip">활성 노드 없음</div>
+      <h3>Node Activity</h3>
+      <ul id="node-list" class="node-list"></ul>
+    </div>
+
     <script>
       const baseUrlInput = document.getElementById("base-url");
       const runIdInput = document.getElementById("run-id");
@@ -170,8 +220,11 @@
       const helpOutput = document.getElementById("help");
       const stateOutput = document.getElementById("state-output");
       const eventsOutput = document.getElementById("events-output");
+      const activeNodeOutput = document.getElementById("active-node");
+      const nodeListOutput = document.getElementById("node-list");
 
       const runIdPattern = /^[a-z][a-z0-9_-]{1,63}$/;
+      let eventHistory = [];
 
       document.getElementById("root-link").addEventListener("click", (event) => {
         event.preventDefault();
@@ -223,6 +276,99 @@
         }
       }
 
+      function normalizeEvents(rawEvents) {
+        if (!Array.isArray(rawEvents)) {
+          return [];
+        }
+        return rawEvents
+          .filter((event) => event && typeof event === "object")
+          .map((event) => ({
+            ...event,
+            eventSeq: Number(event.eventSeq || 0),
+            nodeId: event.nodeId,
+            eventType: String(event.eventType || ""),
+          }));
+      }
+
+      function updateNodeHighlights(rawEvents) {
+        const events = normalizeEvents(rawEvents);
+        const nodeStats = new Map();
+        let activeNode = "";
+        let activeSeq = -1;
+
+        for (const event of events) {
+          if (!event.nodeId) {
+            continue;
+          }
+          const nodeId = String(event.nodeId);
+          const existing = nodeStats.get(nodeId) || {
+            eventCount: 0,
+            lastSeq: -1,
+            lastEventType: "",
+            isRunning: false,
+          };
+          existing.eventCount += 1;
+          if (Number.isFinite(event.eventSeq)) {
+            existing.lastSeq = event.eventSeq;
+          }
+          existing.lastEventType = event.eventType;
+
+          if (event.eventType === "node_started" || event.eventType === "node_token") {
+            existing.isRunning = true;
+          } else if (event.eventType === "node_completed") {
+            existing.isRunning = false;
+          }
+
+          if (existing.isRunning && existing.lastSeq >= activeSeq) {
+            activeNode = nodeId;
+            activeSeq = existing.lastSeq;
+          }
+          nodeStats.set(nodeId, existing);
+        }
+
+        activeNodeOutput.textContent = activeNode || "활성 노드 없음";
+        nodeListOutput.textContent = "";
+
+        if (nodeStats.size === 0) {
+          const empty = document.createElement("li");
+          empty.className = "node-item";
+          empty.textContent = "아직 node 이벤트가 없습니다";
+          nodeListOutput.appendChild(empty);
+          return;
+        }
+
+        for (const [nodeId, stats] of Array.from(nodeStats.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+          const item = document.createElement("li");
+          item.className = "node-item";
+          if (nodeId === activeNode) {
+            item.classList.add("active");
+          }
+
+          const left = document.createElement("span");
+          left.className = "node-name";
+          left.textContent = nodeId;
+
+          const right = document.createElement("span");
+          right.className = "node-meta";
+          right.textContent = `events: ${stats.eventCount}, last: ${stats.lastEventType || "unknown"} (seq ${stats.lastSeq})`;
+
+          item.appendChild(left);
+          item.appendChild(right);
+          nodeListOutput.appendChild(item);
+        }
+      }
+
+      function setEventHistory(events, append = false) {
+        const normalized = normalizeEvents(events);
+        if (append) {
+          eventHistory = eventHistory.concat(normalized);
+        } else {
+          eventHistory = normalized;
+        }
+        eventsOutput.textContent = JSON.stringify(eventHistory, null, 2);
+        updateNodeHighlights(eventHistory);
+      }
+
       function setStatus(message, isError = false) {
         statusOutput.textContent = message || "";
         statusOutput.classList.toggle("error", isError);
@@ -257,7 +403,7 @@
         setStatus("요청 중...");
         try {
           const payload = await doGet("/api/runs/{runId}/events", { lastEventId: lastEventIdInput.value.trim() });
-          eventsOutput.textContent = JSON.stringify(payload, null, 2);
+          setEventHistory(Array.isArray(payload.events) ? payload.events : []);
           setStatus("events 조회 완료");
         } catch (error) {
           setStatus(String(error), true);
@@ -285,17 +431,15 @@
 
           const source = new EventSource(url);
           streamHandle = source;
+          setEventHistory([]);
           source.addEventListener("open", () => {
             setStatus("SSE 연결됨");
           });
 
-          const output = [];
-          eventsOutput.textContent = "";
           source.addEventListener("run-event", (event) => {
             try {
               const data = JSON.parse(event.data);
-              output.push(data);
-              eventsOutput.textContent = JSON.stringify(output, null, 2);
+              setEventHistory([data], true);
             } catch (err) {
               setStatus(`SSE parse error: ${err.message}`, true);
             }
@@ -345,6 +489,7 @@
           runIdInput.value = payload.runId;
           threadIdInput.value = payload.threadId;
           stateOutput.textContent = JSON.stringify(payload.state, null, 2);
+          setEventHistory([]);
           setStatus("run 생성 완료");
         } catch (error) {
           setStatus(String(error), true);
@@ -375,10 +520,9 @@
             stateOutput.textContent = JSON.stringify(result.state, null, 2);
           }
           if (result.event) {
-            eventsOutput.textContent = JSON.stringify(result.event, null, 2);
+            setEventHistory([result.event], true);
           } else {
-            const existing = eventsOutput.textContent === "-" ? [] : [eventsOutput.textContent];
-            eventsOutput.textContent = JSON.stringify(existing, null, 2);
+            setEventHistory(eventHistory, false);
           }
           setStatus("이벤트 emit 완료");
         } catch (error) {

--- a/langgraph_vis/frontend/index.html
+++ b/langgraph_vis/frontend/index.html
@@ -6,7 +6,7 @@
     <title>LangGraph Vis Week 04</title>
     <style>
       body {
-        font-family: Inter, system-ui, sans-serif;
+        font-family: "Noto Sans KR", Arial, sans-serif;
         margin: 0;
         padding: 24px;
         background: #0b1020;
@@ -47,11 +47,75 @@
       button {
         padding: 6px 12px;
       }
+      .guide {
+        margin: 0 0 16px;
+        padding: 12px;
+        border: 1px solid #334155;
+        border-radius: 8px;
+        background: #0f172a;
+      }
+      .guide h2,
+      .guide h3 {
+        margin-top: 0;
+      }
+      .guide ul {
+        margin: 4px 0 0 20px;
+      }
+      .inline-code {
+        background: #111827;
+        color: #93c5fd;
+        padding: 1px 6px;
+        border-radius: 4px;
+      }
+      .status-box {
+        margin-bottom: 8px;
+      }
+      .muted {
+        color: #cbd5e1;
+      }
+      pre {
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .hidden {
+        display: none;
+      }
     </style>
   </head>
   <body>
     <h1>LangGraph Vis Week 04</h1>
-    <p>백엔드 API + SSE 스트림 데모 페이지</p>
+    <p class="muted">백엔드 API + SSE 스트림 데모 페이지</p>
+
+    <section class="guide">
+      <h2>사용 방법</h2>
+      <ol>
+        <li>아래 <span class="inline-code">Backend URL</span>에 현재 실행 중인 서버 주소를 넣습니다.</li>
+        <li><span class="inline-code">runId</span>와 <span class="inline-code">threadId</span>를 넣습니다.</li>
+        <li>
+          <span class="inline-code">Load state</span> → <code>/api/runs/{runId}/state</code> 조회
+        </li>
+        <li>
+          <span class="inline-code">Load events</span> → <code>/api/runs/{runId}/events</code> 조회
+        </li>
+        <li>
+          <span class="inline-code">Open stream</span> → SSE
+          <code>/api/runs/{runId}/events/stream</code> 구독
+        </li>
+      </ol>
+      <h3>주의</h3>
+      <ul>
+        <li>조회 전용만 쓰던 흐름에서 <span class="inline-code">Create run</span>과
+          <span class="inline-code">Emit event</span>를 통해 실시간 입력 데모로 확장했습니다.</li>
+        <li>입력한 <span class="inline-code">runId</span>가 존재하지 않으면
+          <span class="inline-code">404</span>가 나옵니다.
+        </li>
+        <li><span class="inline-code">runId</span>는 영문 소문자 시작, 소문자/숫자/_,- 조합이어야 합니다.</li>
+      </ul>
+      <p>
+        API 문서: <a href="/docs" target="_blank" rel="noreferrer">/docs</a> ,
+        루트 접속: <a href="/" id="root-link">/ → /ui/</a>
+      </p>
+    </section>
 
     <div class="panel">
       <label for="base-url">Backend URL</label>
@@ -60,6 +124,15 @@
       <input id="run-id" value="run_api" />
       <label for="thread-id">threadId</label>
       <input id="thread-id" value="thread-1" />
+    </div>
+
+    <div class="panel">
+      <button id="btn-create-run">Create run</button>
+      <label for="event-type">eventType</label>
+      <input id="event-type" value="node_started" size="16" />
+      <label for="event-payload">event payload</label>
+      <input id="event-payload" size="46" value='{"nodeId":"intent_parser"}' />
+      <button id="btn-emit">Emit event</button>
     </div>
 
     <div class="panel">
@@ -76,7 +149,10 @@
       <button id="btn-stop">Close stream</button>
     </div>
 
-    <pre id="status" class="error"></pre>
+    <div class="status-box">
+      <pre id="status" class="error"></pre>
+      <pre id="help" class="muted">버튼을 누르면 선택한 API의 응답 JSON이 아래에 표시됩니다.</pre>
+    </div>
     <h3>State</h3>
     <pre id="state-output">-</pre>
     <h3>Events</h3>
@@ -88,14 +164,24 @@
       const threadIdInput = document.getElementById("thread-id");
       const fromSeqInput = document.getElementById("from-seq");
       const lastEventIdInput = document.getElementById("last-event-id");
+      const eventTypeInput = document.getElementById("event-type");
+      const eventPayloadInput = document.getElementById("event-payload");
       const statusOutput = document.getElementById("status");
+      const helpOutput = document.getElementById("help");
       const stateOutput = document.getElementById("state-output");
       const eventsOutput = document.getElementById("events-output");
+
+      const runIdPattern = /^[a-z][a-z0-9_-]{1,63}$/;
+
+      document.getElementById("root-link").addEventListener("click", (event) => {
+        event.preventDefault();
+        window.location.replace(`${window.location.origin}/ui/`);
+      });
 
       let streamHandle = null;
 
       function runApiUrl(path, query) {
-        const base = new URL(baseUrlInput.value.replace(/\\/$/, ""));
+        const base = new URL(baseUrlInput.value.replace(/\/$/, ""));
         const url = new URL(path, `${base.href}/`);
         Object.entries(query || {}).forEach(([key, value]) => {
           if (value !== undefined && value !== null && `${value}` !== "") {
@@ -110,11 +196,36 @@
         if (!runId) {
           throw new Error("runId is required");
         }
+        if (!runIdPattern.test(runId)) {
+          throw new Error(
+            "runId 형식이 올바르지 않습니다. 영문 소문자로 시작하고 영문 소문자/숫자/_- 만 허용합니다."
+          );
+        }
         return runId;
       }
 
       function normalizeThreadId() {
         return threadIdInput.value.trim();
+      }
+
+      function parsePayload(raw) {
+        if (!raw || `${raw}`.trim() === "") {
+          return {};
+        }
+        try {
+          const parsed = JSON.parse(raw);
+          if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+            throw new Error("payload must be an object");
+          }
+          return parsed;
+        } catch (error) {
+          throw new Error(`payload parse error: ${error.message}`);
+        }
+      }
+
+      function setStatus(message, isError = false) {
+        statusOutput.textContent = message || "";
+        statusOutput.classList.toggle("error", isError);
       }
 
       async function doGet(path, query) {
@@ -130,68 +241,148 @@
       }
 
       async function loadState() {
-        statusOutput.textContent = "";
+        helpOutput.classList.add("hidden");
+        setStatus("요청 중...");
         try {
           const payload = await doGet("/api/runs/{runId}/state");
           stateOutput.textContent = JSON.stringify(payload, null, 2);
+          setStatus("state 조회 완료");
         } catch (error) {
-          statusOutput.textContent = String(error);
+          setStatus(String(error), true);
         }
       }
 
       async function loadEvents() {
-        statusOutput.textContent = "";
+        helpOutput.classList.add("hidden");
+        setStatus("요청 중...");
         try {
           const payload = await doGet("/api/runs/{runId}/events", { lastEventId: lastEventIdInput.value.trim() });
           eventsOutput.textContent = JSON.stringify(payload, null, 2);
+          setStatus("events 조회 완료");
         } catch (error) {
-          statusOutput.textContent = String(error);
+          setStatus(String(error), true);
         }
       }
 
       function openStream() {
-        statusOutput.textContent = "";
-        const runId = getRunId();
-        const threadId = normalizeThreadId();
-        if (!threadId) {
-          statusOutput.textContent = "threadId를 입력하세요.";
-          return;
-        }
-
-        if (streamHandle) {
-          streamHandle.close();
-        }
-
-        const url = runApiUrl(`/api/runs/${encodeURIComponent(runId)}/events/stream`, {
-          fromSeq: fromSeqInput.value.trim(),
-          lastEventId: lastEventIdInput.value.trim(),
-        });
-
-        const source = new EventSource(url);
-        streamHandle = source;
-
-        const output = [];
-        eventsOutput.textContent = "";
-        source.addEventListener("run-event", (event) => {
-          try {
-            const data = JSON.parse(event.data);
-            output.push(data);
-            eventsOutput.textContent = JSON.stringify(output, null, 2);
-          } catch (err) {
-            statusOutput.textContent = `SSE parse error: ${err.message}`;
+        helpOutput.classList.add("hidden");
+        try {
+          setStatus("SSE 연결 시도 중...");
+          const runId = getRunId();
+          const threadId = normalizeThreadId();
+          if (!threadId) {
+            setStatus("threadId를 입력하세요.", true);
+            return;
           }
-        });
-        source.addEventListener("error", () => {
-          statusOutput.textContent = "SSE 연결이 종료되었거나 오류가 발생했습니다.";
-          source.close();
-          streamHandle = null;
-        });
+          if (streamHandle) {
+            streamHandle.close();
+          }
+
+          const url = runApiUrl(`/api/runs/${encodeURIComponent(runId)}/events/stream`, {
+            fromSeq: fromSeqInput.value.trim(),
+            lastEventId: lastEventIdInput.value.trim(),
+          });
+
+          const source = new EventSource(url);
+          streamHandle = source;
+          source.addEventListener("open", () => {
+            setStatus("SSE 연결됨");
+          });
+
+          const output = [];
+          eventsOutput.textContent = "";
+          source.addEventListener("run-event", (event) => {
+            try {
+              const data = JSON.parse(event.data);
+              output.push(data);
+              eventsOutput.textContent = JSON.stringify(output, null, 2);
+            } catch (err) {
+              setStatus(`SSE parse error: ${err.message}`, true);
+            }
+          });
+          source.addEventListener("error", () => {
+            setStatus("SSE 연결이 종료되었거나 오류가 발생했습니다.", true);
+            source.close();
+            streamHandle = null;
+          });
+        } catch (error) {
+          setStatus(String(error), true);
+        }
       }
 
       function closeStream() {
         if (streamHandle) {
           streamHandle.close();
           streamHandle = null;
+          setStatus("SSE 연결 종료");
+        }
+      }
+
+      async function createRun() {
+        helpOutput.classList.add("hidden");
+        setStatus("run 생성 중...");
+        try {
+          const body = {};
+          const runId = runIdInput.value.trim();
+          const threadId = threadIdInput.value.trim();
+          if (runId) {
+            body.runId = runId;
+          }
+          if (threadId) {
+            body.threadId = threadId;
+          }
+
+          const response = await fetch(runApiUrl("/api/runs"), {
+            method: "POST",
+            headers: { "Content-Type": "application/json", Accept: "application/json" },
+            body: JSON.stringify(body),
+          });
+          if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`${response.status}: ${errorText || response.statusText}`);
+          }
+          const payload = await response.json();
+          runIdInput.value = payload.runId;
+          threadIdInput.value = payload.threadId;
+          stateOutput.textContent = JSON.stringify(payload.state, null, 2);
+          setStatus("run 생성 완료");
+        } catch (error) {
+          setStatus(String(error), true);
+        }
+      }
+
+      async function emitEvent() {
+        helpOutput.classList.add("hidden");
+        setStatus("이벤트 emit 중...");
+        try {
+          const runId = getRunId();
+          const eventType = eventTypeInput.value.trim();
+          if (!eventType) {
+            throw new Error("eventType is required");
+          }
+          const payload = parsePayload(eventPayloadInput.value);
+          const response = await fetch(runApiUrl(`/api/runs/${encodeURIComponent(runId)}/events`), {
+            method: "POST",
+            headers: { "Content-Type": "application/json", Accept: "application/json" },
+            body: JSON.stringify({ eventType, payload }),
+          });
+          if (!response.ok) {
+            const errorText = await response.text();
+            throw new Error(`${response.status}: ${errorText || response.statusText}`);
+          }
+          const result = await response.json();
+          if (result.state) {
+            stateOutput.textContent = JSON.stringify(result.state, null, 2);
+          }
+          if (result.event) {
+            eventsOutput.textContent = JSON.stringify(result.event, null, 2);
+          } else {
+            const existing = eventsOutput.textContent === "-" ? [] : [eventsOutput.textContent];
+            eventsOutput.textContent = JSON.stringify(existing, null, 2);
+          }
+          setStatus("이벤트 emit 완료");
+        } catch (error) {
+          setStatus(String(error), true);
         }
       }
 
@@ -199,6 +390,8 @@
       document.getElementById("btn-events").addEventListener("click", loadEvents);
       document.getElementById("btn-stream").addEventListener("click", openStream);
       document.getElementById("btn-stop").addEventListener("click", closeStream);
+      document.getElementById("btn-create-run").addEventListener("click", createRun);
+      document.getElementById("btn-emit").addEventListener("click", emitEvent);
     </script>
   </body>
 </html>

--- a/langgraph_vis/package.json
+++ b/langgraph_vis/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start:backend": "PYTHONPATH=. .venv/bin/python python_backend/run_server.py",
+    "start:backend": "PYTHONPATH=. .venv/bin/python -m uvicorn python_backend.app.main:app --host 0.0.0.0 --port 8000",
     "start": "npm run start:backend",
     "test:backend": "PYTHONPATH=. .venv/bin/pytest -q python_backend/tests",
     "test:frontend": "node --test tests/week-04/*.test.js",

--- a/langgraph_vis/python_backend/app/main.py
+++ b/langgraph_vis/python_backend/app/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
@@ -28,6 +29,10 @@ def create_app(*, run_store: RunStateStore | None = None):
     app.include_router(create_workflow_schema_router())
     app.include_router(create_run_state_router(store=store))
     app.include_router(create_run_history_router(store=store))
+
+    @app.get("/")
+    def redirect_root_to_ui() -> RedirectResponse:
+        return RedirectResponse(url="/ui/")
 
     frontend_dir = Path(__file__).resolve().parent.parent.parent / "frontend"
     if frontend_dir.exists():

--- a/langgraph_vis/python_backend/app/run_state_api.py
+++ b/langgraph_vis/python_backend/app/run_state_api.py
@@ -19,6 +19,7 @@ from .run_error_contract import (
     normalize_run_error,
 )
 from .resync_controller import resolve_replay_from
+from .run_orchestrator import RunOrchestrator
 from .run_state_machine import is_terminal_state
 
 HEARTBEAT_MS = 20_000
@@ -100,6 +101,17 @@ def _heartbeat(now: datetime | None = None) -> str:
 
 def create_run_state_router(*, store):
     router = APIRouter()
+    orchestrator = RunOrchestrator(store=store)
+
+    def _validation_error(request_id: str, message: str):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "code": RUN_ERROR_CODES["INVALID_RUN_PAYLOAD"],
+                "message": message,
+                "requestId": request_id,
+            },
+        )
 
     def _method_not_allowed_payload():
         return {
@@ -257,6 +269,86 @@ def create_run_state_router(*, store):
                 "X-Accel-Buffering": "no",
             },
         )
+
+    @router.post("/api/runs")
+    async def create_run(request: Request):
+        request_id = str(uuid.uuid4())
+        try:
+            payload = await request.json()
+            if not isinstance(payload, dict):
+                return _validation_error(request_id, RUN_ERROR_MESSAGES[RUN_ERROR_CODES["INVALID_RUN_PAYLOAD"]])
+
+            created = orchestrator.create_run(
+                run_id=payload.get("runId"),
+                thread_id=payload.get("threadId"),
+                workflow_id=payload.get("workflowId"),
+                workflow_version=payload.get("workflowVersion"),
+            )
+            state = store.get_run_state(created["runId"])
+            return {
+                "runId": created["runId"],
+                "threadId": created["threadId"],
+                "event": created["event"],
+                "state": state,
+            }
+        except ValueError as error:
+            return _validation_error(request_id, str(error))
+        except Exception as error:
+            return await _on_error(error, request_id)
+
+    @router.api_route("/api/runs", methods=["GET", "PUT", "PATCH", "DELETE"])
+    async def create_run_not_allowed():
+        request_id = str(uuid.uuid4())
+        payload = {**_method_not_allowed_payload(), "requestId": request_id}
+        return JSONResponse(status_code=405, content=payload, headers={"Allow": "POST"})
+
+    @router.post("/api/runs/{run_id}/events")
+    async def append_event(run_id: str, request: Request):
+        request_id = str(uuid.uuid4())
+        try:
+            payload = await request.json()
+            if not isinstance(payload, dict):
+                return _validation_error(request_id, RUN_ERROR_MESSAGES[RUN_ERROR_CODES["INVALID_RUN_PAYLOAD"]])
+
+            event_type = payload.get("eventType")
+            if not isinstance(event_type, str) or not event_type.strip():
+                return _validation_error(request_id, "eventType is required")
+
+            event_payload = payload.get("payload")
+            if event_payload is None:
+                event_payload = {}
+            if not isinstance(event_payload, dict):
+                return _validation_error(request_id, "payload must be an object")
+
+            options = {}
+            if "eventId" in payload and payload.get("eventId") is not None:
+                options["eventId"] = payload["eventId"]
+            if "checkpoint" in payload and payload.get("checkpoint") is not None:
+                options["checkpoint"] = payload["checkpoint"]
+
+            event = orchestrator.emit(
+                run_id=run_id,
+                event_type=event_type,
+                payload=event_payload,
+                options=options,
+            )
+
+            state = store.get_run_state(run_id)
+            return {
+                "runId": run_id,
+                "event": event,
+                "state": state,
+            }
+        except ValueError as error:
+            return _validation_error(request_id, str(error))
+        except Exception as error:
+            return await _on_error(error, request_id)
+
+    @router.api_route("/api/runs/{run_id}/events", methods=["PUT", "PATCH", "DELETE"])
+    async def append_event_not_allowed(run_id: str):
+        request_id = str(uuid.uuid4())
+        payload = {**_method_not_allowed_payload(), "requestId": request_id}
+        return JSONResponse(status_code=405, content=payload, headers={"Allow": "POST"})
 
     @router.get("/api/runs/{run_id}/events/stream")
     async def event_stream(

--- a/langgraph_vis/python_backend/tests/test_run_state_api.py
+++ b/langgraph_vis/python_backend/tests/test_run_state_api.py
@@ -26,6 +26,69 @@ def _create_sample_store():
     return store
 
 
+def test_create_run_api_generates_run():
+    store = RunStateStore()
+    with _create_client_with_store(store) as client:
+        response = client.post(
+            "/api/runs",
+            json={
+                "runId": "run_new",
+                "threadId": "thread_new",
+                "workflowId": "support_ticket_classifier_v1",
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["runId"] == "run_new"
+    assert body["threadId"] == "thread_new"
+    assert body["state"]["runId"] == "run_new"
+    assert body["state"]["threadId"] == "thread_new"
+    assert body["state"]["state"] == "running"
+
+
+def test_create_run_api_returns_bad_request_for_invalid_payload():
+    store = RunStateStore()
+    with _create_client_with_store(store) as client:
+        response = client.post("/api/runs", data="not-json", headers={"Content-Type": "application/json"})
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["code"] == RUN_ERROR_CODES["INVALID_RUN_PAYLOAD"]
+
+
+def test_append_event_api_accepts_event():
+    store = _create_sample_store()
+    with _create_client_with_store(store) as client:
+        response = client.post(
+            "/api/runs/run_api/events",
+            json={"eventType": "node_token", "payload": {"nodeId": "intent_parser", "token": "test"}},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["event"]["eventType"] == "node_token"
+    assert body["state"]["state"] == "running"
+
+
+def test_append_event_api_rejects_missing_event_type():
+    store = _create_sample_store()
+    with _create_client_with_store(store) as client:
+        response = client.post("/api/runs/run_api/events", json={"payload": {}})
+
+    assert response.status_code == 400
+    assert response.json()["code"] == RUN_ERROR_CODES["INVALID_RUN_PAYLOAD"]
+
+
+def test_append_event_api_returns_405_for_non_post():
+    store = _create_sample_store()
+    with _create_client_with_store(store) as client:
+        response = client.put("/api/runs/run_api/events", json={"eventType": "node_started"})
+
+    assert response.status_code == 405
+    assert response.json()["code"] == RUN_ERROR_CODES["INVALID_RUN_PAYLOAD"]
+
+
 def test_get_state_returns_cursor_and_state():
     store = _create_sample_store()
     with _create_client_with_store(store) as client:


### PR DESCRIPTION
## Summary
- Add backend endpoints to create runs and emit events from the Python API so UI can produce live data.
  - POST 
  - POST 
- Update frontend page with actionable usage guidance and controls.
- Update README with real-time usage and keep root redirect in backend.

## Testing
- Not run in this step.