### PR TITLE
docs/backend: update demo guide and complete langgraph mock workflow demo

### DIFF
--- a/langgraph_vis/README.md
+++ b/langgraph_vis/README.md
@@ -27,10 +27,10 @@ PYTHONPATH=$(pwd) .venv/bin/python -m uvicorn python_backend.app.main:app --host
 
 참고:
 - 서버 루트(`/`)는 `http://127.0.0.1:8000/ui/`로 이동합니다.
-- run/event를 즉시 넣고 확인하려면:
-  - `POST /api/runs`
-  - `POST /api/runs/{runId}/events`
-- UI에도 `Create run`/`Emit event` 버튼이 추가되어 실시간으로 데이터 입력 후 SSE를 확인할 수 있습니다.
+- PoC 데모에서는 `POST /api/runs`로 내부 런을 생성한 뒤
+  `POST /api/runs/{runId}/demo/run`으로 더미 워크플로우를 실행합니다.
+- 기본 워크플로우는 `langgraph_demo_workflow_v1`이며 3개 노드가 **백엔드에서 3~5초 랜덤 지연**으로 동작합니다.
+  - 3번째 노드에서 일정 확률로 1번 노드로 되돌아가는 루프를 재현합니다.
 
 ### 3) 테스트 실행
 
@@ -41,11 +41,8 @@ npm test
 
 ## 페이지 사용
 
-- `http://127.0.0.1:8000/ui/` 에서 실행 상태/이벤트 조회를 할 수 있습니다.
-- `runId` 와 `threadId` 를 입력하고:
-  - `Load state`: `GET /api/runs/{runId}/state` 조회
-  - `Load events`: `GET /api/runs/{runId}/events` 조회
-  - `Open stream`: `GET /api/runs/{runId}/events/stream` SSE 구독
+- `http://127.0.0.1:8000/ui/`에서 바로 데모를 실행할 수 있습니다.
+- `Run` 버튼 하나만 클릭하면 스키마 조회, 실행 요청, 실시간 노드 하이라이트가 모두 동작합니다.
 
 ## 참고
 

--- a/langgraph_vis/docs/week-01/schema-contract.fixture.json
+++ b/langgraph_vis/docs/week-01/schema-contract.fixture.json
@@ -1,81 +1,153 @@
-{
-  "schemaVersion": "1.0.0",
-  "workflowId": "support_ticket_classifier_v1",
-  "version": "1.0.0",
-  "workflowName": "Support Ticket Classifier",
-  "nodes": [
-    {
-      "id": "intent_parser",
-      "label": "의도 분류",
-      "description": "사용자 질문에서 지원 문의 의도를 추론한다.",
-      "stateKey": "intent",
-      "metadata": {
-        "team": "nlp",
-        "costTier": "standard"
+[
+  {
+    "schemaVersion": "1.0.0",
+    "workflowId": "support_ticket_classifier_v1",
+    "version": "1.0.0",
+    "workflowName": "Support Ticket Classifier",
+    "nodes": [
+      {
+        "id": "intent_parser",
+        "label": "의도 분류",
+        "description": "사용자 질문에서 지원 문의 의도를 추론한다.",
+        "stateKey": "intent",
+        "metadata": {
+          "team": "nlp",
+          "costTier": "standard"
+        },
+        "order": 1
       },
-      "order": 1
-    },
-    {
-      "id": "knowledge_search",
-      "label": "지식 베이스 검색",
-      "description": "의도에 따라 사내 문서 및 FAQ를 조회한다.",
-      "stateKey": "searchResult",
-      "metadata": {
-        "team": "retrieval",
-        "timeoutMs": 3000
+      {
+        "id": "knowledge_search",
+        "label": "지식 베이스 검색",
+        "description": "의도에 따라 사내 문서 및 FAQ를 조회한다.",
+        "stateKey": "searchResult",
+        "metadata": {
+          "team": "retrieval",
+          "timeoutMs": 3000
+        },
+        "order": 2
       },
-      "order": 2
-    },
-    {
-      "id": "response_draft",
-      "label": "응답 초안 생성",
-      "description": "검색 결과를 바탕으로 사용자 응답 초안을 생성한다.",
-      "stateKey": "draft",
-      "metadata": {
-        "team": "llm",
-        "temperature": 0.2
+      {
+        "id": "response_draft",
+        "label": "응답 초안 생성",
+        "description": "검색 결과를 바탕으로 사용자 응답 초안을 생성한다.",
+        "stateKey": "draft",
+        "metadata": {
+          "team": "llm",
+          "temperature": 0.2
+        },
+        "order": 3
       },
-      "order": 3
-    },
-    {
-      "id": "postprocess",
-      "label": "후처리",
-      "description": "응답 마무리와 포맷 정규화를 수행한다.",
-      "stateKey": "finalPayload",
-      "metadata": {
-        "team": "formatter",
-        "requiresReview": false
-      },
-      "order": 4
-    }
-  ],
-  "edges": [
-    {
-      "id": "e1",
-      "from": "intent_parser",
-      "to": "knowledge_search",
-      "label": "intent -> search",
-      "metadata": {
-        "type": "default"
+      {
+        "id": "postprocess",
+        "label": "후처리",
+        "description": "응답 마무리와 포맷 정규화를 수행한다.",
+        "stateKey": "finalPayload",
+        "metadata": {
+          "team": "formatter",
+          "requiresReview": false
+        },
+        "order": 4
       }
-    },
-    {
-      "id": "e2",
-      "from": "knowledge_search",
-      "to": "response_draft",
-      "label": "search -> draft",
-      "metadata": {
-        "type": "default"
+    ],
+    "edges": [
+      {
+        "id": "e1",
+        "from": "intent_parser",
+        "to": "knowledge_search",
+        "label": "intent -> search",
+        "metadata": {
+          "type": "default"
+        }
+      },
+      {
+        "id": "e2",
+        "from": "knowledge_search",
+        "to": "response_draft",
+        "label": "search -> draft",
+        "metadata": {
+          "type": "default"
+        }
+      },
+      {
+        "id": "e3",
+        "from": "response_draft",
+        "to": "postprocess",
+        "label": "draft -> postprocess",
+        "metadata": {
+          "type": "default"
+        }
       }
-    },
-    {
-      "id": "e3",
-      "from": "response_draft",
-      "to": "postprocess",
-      "label": "draft -> postprocess",
-      "metadata": {
-        "type": "default"
+    ]
+  },
+  {
+    "schemaVersion": "1.0.0",
+    "workflowId": "langgraph_demo_workflow_v1",
+    "version": "1.0.0",
+    "workflowName": "LangGraph Demo Loop Workflow",
+    "nodes": [
+      {
+        "id": "dummy_node_1",
+        "label": "Dummy Node 1",
+        "description": "첫 번째 더미 노드: 입력 처리 블록",
+        "stateKey": "dummyNode1",
+        "metadata": {
+          "team": "demo",
+          "kind": "start"
+        },
+        "order": 1
+      },
+      {
+        "id": "dummy_node_2",
+        "label": "Dummy Node 2",
+        "description": "두 번째 더미 노드: 검증/가공 블록",
+        "stateKey": "dummyNode2",
+        "metadata": {
+          "team": "demo",
+          "kind": "process"
+        },
+        "order": 2
+      },
+      {
+        "id": "dummy_node_3",
+        "label": "Dummy Node 3",
+        "description": "세 번째 더미 노드: 라우팅/분기 블록",
+        "stateKey": "dummyNode3",
+        "metadata": {
+          "team": "demo",
+          "kind": "decision"
+        },
+        "order": 3
       }
-    }
-  ]
-}
+    ],
+    "edges": [
+      {
+        "id": "loop_edge_1",
+        "from": "dummy_node_1",
+        "to": "dummy_node_2",
+        "label": "1 -> 2",
+        "metadata": {
+          "type": "default"
+        }
+      },
+      {
+        "id": "loop_edge_2",
+        "from": "dummy_node_2",
+        "to": "dummy_node_3",
+        "label": "2 -> 3",
+        "metadata": {
+          "type": "default"
+        }
+      },
+      {
+        "id": "loop_edge_3",
+        "from": "dummy_node_3",
+        "to": "dummy_node_1",
+        "label": "3 -> 1 (loop)",
+        "metadata": {
+          "type": "loop"
+        }
+      }
+    ]
+  }
+]

--- a/langgraph_vis/frontend/index.html
+++ b/langgraph_vis/frontend/index.html
@@ -1,541 +1,330 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>LangGraph Vis Week 04</title>
+    <title>LangGraph Demo</title>
     <style>
-      body {
-        font-family: "Noto Sans KR", Arial, sans-serif;
-        margin: 0;
-        padding: 24px;
-        background: #0b1020;
-        color: #e5e7eb;
+      :root {
+        --bg: #050d1e;
+        --text: #e5e7eb;
+        --muted: #9ca3af;
+        --idle: #1f2937;
+        --ready: #0f766e;
+        --running: #0ea5e9;
+        --done: #16a34a;
       }
-      .panel {
-        margin-bottom: 16px;
-      }
-      label {
-        margin-right: 8px;
-      }
-      input,
-      button {
-        margin-right: 8px;
-      }
-      textarea,
-      pre {
-        width: 100%;
+
+      * {
         box-sizing: border-box;
       }
-      textarea,
-      pre {
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: "Pretendard", "Noto Sans KR", Arial, sans-serif;
+        color: var(--text);
+        background:
+          radial-gradient(circle at 20% 0%, #1f4f6e2b, transparent 35%),
+          radial-gradient(circle at 80% 20%, #0f766e2b, transparent 35%),
+          var(--bg);
+      }
+
+      .wrap {
+        max-width: 680px;
+        margin: 0 auto;
+        padding: 28px 20px;
+      }
+
+      h1 {
+        margin: 0 0 14px;
+        font-size: 22px;
+      }
+
+      .lead {
+        color: var(--muted);
+        margin: 0 0 20px;
+      }
+
+      .workflow {
+        display: grid;
+        gap: 10px;
+        margin-bottom: 18px;
+      }
+
+      .node-card {
         background: #111827;
-        color: #f9fafb;
-        border: 1px solid #374151;
-        border-radius: 8px;
-      }
-      textarea {
-        min-height: 140px;
-        resize: vertical;
-      }
-      .row {
-        margin-top: 8px;
-      }
-      .error {
-        color: #f87171;
-      }
-      button {
-        padding: 6px 12px;
-      }
-      .guide {
-        margin: 0 0 16px;
+        border: 1px solid var(--idle);
+        border-radius: 10px;
         padding: 12px;
-        border: 1px solid #334155;
-        border-radius: 8px;
-        background: #0f172a;
       }
-      .guide h2,
-      .guide h3 {
-        margin-top: 0;
+
+      .node-card.ready {
+        border-color: color-mix(in oklab, var(--ready), #ffffff 20%);
+        box-shadow: 0 0 0 2px #14b8a633;
+        background: #072a2b;
       }
-      .guide ul {
-        margin: 4px 0 0 20px;
+
+      .node-card.running {
+        border-color: var(--running);
+        background: #0c2e46;
+        box-shadow: 0 0 0 2px #38bdf822;
       }
-      .inline-code {
-        background: #111827;
-        color: #93c5fd;
-        padding: 1px 6px;
-        border-radius: 4px;
+
+      .node-card.done {
+        border-color: var(--done);
+        background: #092a18;
       }
-      .status-box {
-        margin-bottom: 8px;
+
+      .node-label {
+        margin: 0;
+        font-weight: 700;
       }
-      .muted {
-        color: #cbd5e1;
+
+      .node-meta {
+        margin: 8px 0 0;
+        color: var(--muted);
+        font-size: 12px;
       }
-      pre {
-        white-space: pre-wrap;
-        word-break: break-word;
-      }
-      .hidden {
-        display: none;
-      }
-      .node-panel {
-        margin-top: 16px;
-        padding: 12px;
-        border: 1px solid #334155;
-        border-radius: 8px;
-        background: #0f172a;
-      }
-      .node-list {
-        list-style: none;
-        padding: 0;
-        margin: 4px 0 0;
-      }
-      .node-item {
-        margin-bottom: 6px;
-        padding: 8px 10px;
-        border-radius: 6px;
-        border: 1px solid #334155;
+
+      .controls {
         display: flex;
-        justify-content: space-between;
-        gap: 12px;
+        justify-content: flex-start;
       }
-      .node-item.active {
-        border-color: #22d3ee;
-        box-shadow: 0 0 0 2px rgba(34, 211, 238, 0.2);
-        background: #082f49;
+
+      button {
+        appearance: none;
+        border: 0;
+        padding: 10px 24px;
+        border-radius: 10px;
+        background: #0f766e;
+        color: #e2f8f7;
+        font-weight: 700;
+        cursor: pointer;
       }
-      .node-item .node-name {
-        color: #e2e8f0;
-        font-weight: 600;
+
+      button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
       }
-      .node-item .node-meta {
-        color: #94a3b8;
-        font-size: 13px;
+
+      .empty {
+        color: var(--muted);
       }
-      .active-chip {
-        margin: 0 0 6px;
-        padding: 6px 10px;
-        border-radius: 999px;
-        border: 1px solid #0f766e;
-        background: #042f2e;
-        width: fit-content;
-        color: #5eead4;
+
+      .arrow {
+        text-align: center;
+        color: #718096;
       }
     </style>
   </head>
   <body>
-    <h1>LangGraph Vis Week 04</h1>
-    <p class="muted">백엔드 API + SSE 스트림 데모 페이지</p>
-
-    <section class="guide">
-      <h2>사용 방법</h2>
-      <ol>
-        <li>아래 <span class="inline-code">Backend URL</span>에 현재 실행 중인 서버 주소를 넣습니다.</li>
-        <li><span class="inline-code">runId</span>와 <span class="inline-code">threadId</span>를 넣습니다.</li>
-        <li>
-          <span class="inline-code">Load state</span> → <code>/api/runs/{runId}/state</code> 조회
-        </li>
-        <li>
-          <span class="inline-code">Load events</span> → <code>/api/runs/{runId}/events</code> 조회
-        </li>
-        <li>
-          <span class="inline-code">Open stream</span> → SSE
-          <code>/api/runs/{runId}/events/stream</code> 구독
-        </li>
-      </ol>
-      <h3>주의</h3>
-      <ul>
-        <li>조회 전용만 쓰던 흐름에서 <span class="inline-code">Create run</span>과
-          <span class="inline-code">Emit event</span>를 통해 실시간 입력 데모로 확장했습니다.</li>
-        <li>입력한 <span class="inline-code">runId</span>가 존재하지 않으면
-          <span class="inline-code">404</span>가 나옵니다.
-        </li>
-        <li><span class="inline-code">runId</span>는 영문 소문자 시작, 소문자/숫자/_,- 조합이어야 합니다.</li>
-      </ul>
-      <p>
-        API 문서: <a href="/docs" target="_blank" rel="noreferrer">/docs</a> ,
-        루트 접속: <a href="/" id="root-link">/ → /ui/</a>
+    <main class="wrap">
+      <h1>LangGraph Demo</h1>
+      <p class="lead">
+        3개 더미 노드의 워크플로우를 실행하고 실시간으로 진행 노드를 확인합니다.
       </p>
-    </section>
-
-    <div class="panel">
-      <label for="base-url">Backend URL</label>
-      <input id="base-url" value="http://127.0.0.1:8000" size="36" />
-      <label for="run-id">runId</label>
-      <input id="run-id" value="run_api" />
-      <label for="thread-id">threadId</label>
-      <input id="thread-id" value="thread-1" />
-    </div>
-
-    <div class="panel">
-      <button id="btn-create-run">Create run</button>
-      <label for="event-type">eventType</label>
-      <input id="event-type" value="node_started" size="16" />
-      <label for="event-payload">event payload</label>
-      <input id="event-payload" size="46" value='{"nodeId":"intent_parser"}' />
-      <button id="btn-emit">Emit event</button>
-    </div>
-
-    <div class="panel">
-      <label for="from-seq">fromSeq</label>
-      <input id="from-seq" value="1" size="8" />
-      <label for="last-event-id">last-event-id</label>
-      <input id="last-event-id" placeholder="선택" size="20" />
-    </div>
-
-    <div class="panel row">
-      <button id="btn-state">Load state</button>
-      <button id="btn-events">Load events</button>
-      <button id="btn-stream">Open stream</button>
-      <button id="btn-stop">Close stream</button>
-    </div>
-
-    <div class="status-box">
-      <pre id="status" class="error"></pre>
-      <pre id="help" class="muted">버튼을 누르면 선택한 API의 응답 JSON이 아래에 표시됩니다.</pre>
-    </div>
-    <h3>State</h3>
-    <pre id="state-output">-</pre>
-    <h3>Events</h3>
-    <pre id="events-output">-</pre>
-
-    <div class="node-panel">
-      <h3>Active Node</h3>
-      <div id="active-node" class="active-chip">활성 노드 없음</div>
-      <h3>Node Activity</h3>
-      <ul id="node-list" class="node-list"></ul>
-    </div>
+      <section id="workflow" class="workflow">
+        <div class="empty">workflow를 불러오는 중…</div>
+      </section>
+      <div class="controls">
+        <button id="run-btn" type="button">Run</button>
+      </div>
+    </main>
 
     <script>
-      const baseUrlInput = document.getElementById("base-url");
-      const runIdInput = document.getElementById("run-id");
-      const threadIdInput = document.getElementById("thread-id");
-      const fromSeqInput = document.getElementById("from-seq");
-      const lastEventIdInput = document.getElementById("last-event-id");
-      const eventTypeInput = document.getElementById("event-type");
-      const eventPayloadInput = document.getElementById("event-payload");
-      const statusOutput = document.getElementById("status");
-      const helpOutput = document.getElementById("help");
-      const stateOutput = document.getElementById("state-output");
-      const eventsOutput = document.getElementById("events-output");
-      const activeNodeOutput = document.getElementById("active-node");
-      const nodeListOutput = document.getElementById("node-list");
+      const API_ORIGIN = window.location.origin;
+      const WORKFLOW_ID = "langgraph_demo_workflow_v1";
 
-      const runIdPattern = /^[a-z][a-z0-9_-]{1,63}$/;
-      let eventHistory = [];
+      const runButton = document.getElementById("run-btn");
+      const workflowContainer = document.getElementById("workflow");
+      const nodeCardById = new Map();
+      const orderedNodeIds = [];
+      let eventSource = null;
+      let isRunning = false;
 
-      document.getElementById("root-link").addEventListener("click", (event) => {
-        event.preventDefault();
-        window.location.replace(`${window.location.origin}/ui/`);
-      });
-
-      let streamHandle = null;
-
-      function runApiUrl(path, query) {
-        const base = new URL(baseUrlInput.value.replace(/\/$/, ""));
-        const url = new URL(path, `${base.href}/`);
-        Object.entries(query || {}).forEach(([key, value]) => {
-          if (value !== undefined && value !== null && `${value}` !== "") {
-            url.searchParams.set(key, value);
-          }
-        });
-        return url.toString();
-      }
-
-      function getRunId() {
-        const runId = runIdInput.value.trim();
-        if (!runId) {
-          throw new Error("runId is required");
-        }
-        if (!runIdPattern.test(runId)) {
-          throw new Error(
-            "runId 형식이 올바르지 않습니다. 영문 소문자로 시작하고 영문 소문자/숫자/_- 만 허용합니다."
-          );
-        }
-        return runId;
-      }
-
-      function normalizeThreadId() {
-        return threadIdInput.value.trim();
-      }
-
-      function parsePayload(raw) {
-        if (!raw || `${raw}`.trim() === "") {
-          return {};
-        }
-        try {
-          const parsed = JSON.parse(raw);
-          if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
-            throw new Error("payload must be an object");
-          }
-          return parsed;
-        } catch (error) {
-          throw new Error(`payload parse error: ${error.message}`);
-        }
-      }
-
-      function normalizeEvents(rawEvents) {
-        if (!Array.isArray(rawEvents)) {
-          return [];
-        }
-        return rawEvents
-          .filter((event) => event && typeof event === "object")
-          .map((event) => ({
-            ...event,
-            eventSeq: Number(event.eventSeq || 0),
-            nodeId: event.nodeId,
-            eventType: String(event.eventType || ""),
-          }));
-      }
-
-      function updateNodeHighlights(rawEvents) {
-        const events = normalizeEvents(rawEvents);
-        const nodeStats = new Map();
-        let activeNode = "";
-        let activeSeq = -1;
-
-        for (const event of events) {
-          if (!event.nodeId) {
-            continue;
-          }
-          const nodeId = String(event.nodeId);
-          const existing = nodeStats.get(nodeId) || {
-            eventCount: 0,
-            lastSeq: -1,
-            lastEventType: "",
-            isRunning: false,
-          };
-          existing.eventCount += 1;
-          if (Number.isFinite(event.eventSeq)) {
-            existing.lastSeq = event.eventSeq;
-          }
-          existing.lastEventType = event.eventType;
-
-          if (event.eventType === "node_started" || event.eventType === "node_token") {
-            existing.isRunning = true;
-          } else if (event.eventType === "node_completed") {
-            existing.isRunning = false;
-          }
-
-          if (existing.isRunning && existing.lastSeq >= activeSeq) {
-            activeNode = nodeId;
-            activeSeq = existing.lastSeq;
-          }
-          nodeStats.set(nodeId, existing);
-        }
-
-        activeNodeOutput.textContent = activeNode || "활성 노드 없음";
-        nodeListOutput.textContent = "";
-
-        if (nodeStats.size === 0) {
-          const empty = document.createElement("li");
-          empty.className = "node-item";
-          empty.textContent = "아직 node 이벤트가 없습니다";
-          nodeListOutput.appendChild(empty);
+      function setNodeState(nodeId, nextState) {
+        const card = nodeCardById.get(nodeId);
+        if (!card) {
           return;
         }
 
-        for (const [nodeId, stats] of Array.from(nodeStats.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
-          const item = document.createElement("li");
-          item.className = "node-item";
-          if (nodeId === activeNode) {
-            item.classList.add("active");
+        card.classList.remove("ready", "running", "done");
+        if (nextState) {
+          card.classList.add(nextState);
+        }
+      }
+
+      function resetNodeStates() {
+        for (const nodeId of orderedNodeIds) {
+          setNodeState(nodeId);
+        }
+        const startNodeId = orderedNodeIds[0];
+        if (startNodeId) {
+          setNodeState(startNodeId, "ready");
+        }
+      }
+
+      function renderWorkflow(schema) {
+        workflowContainer.innerHTML = "";
+        nodeCardById.clear();
+        orderedNodeIds.length = 0;
+
+        const nodes = Array.isArray(schema.nodes)
+          ? [...schema.nodes].sort((a, b) => Number(a.order || 0) - Number(b.order || 0))
+          : [];
+
+        if (nodes.length === 0) {
+          workflowContainer.innerHTML = "<div class=\"empty\">노드를 찾을 수 없습니다.</div>";
+          return;
+        }
+
+        nodes.forEach((node, index) => {
+          const nodeId = String(node.id);
+          orderedNodeIds.push(nodeId);
+
+          const card = document.createElement("article");
+          card.className = "node-card";
+          card.dataset.nodeId = nodeId;
+
+          const label = document.createElement("h2");
+          label.className = "node-label";
+          label.textContent = `${index + 1}. ${node.label}`;
+
+          const meta = document.createElement("p");
+          meta.className = "node-meta";
+          meta.textContent = node.description || "";
+
+          card.appendChild(label);
+          card.appendChild(meta);
+          workflowContainer.appendChild(card);
+
+          if (index + 1 < nodes.length) {
+            const arrow = document.createElement("div");
+            arrow.className = "arrow";
+            arrow.textContent = "↓";
+            workflowContainer.appendChild(arrow);
           }
 
-          const left = document.createElement("span");
-          left.className = "node-name";
-          left.textContent = nodeId;
+          nodeCardById.set(nodeId, card);
+        });
 
-          const right = document.createElement("span");
-          right.className = "node-meta";
-          right.textContent = `events: ${stats.eventCount}, last: ${stats.lastEventType || "unknown"} (seq ${stats.lastSeq})`;
+        resetNodeStates();
+      }
 
-          item.appendChild(left);
-          item.appendChild(right);
-          nodeListOutput.appendChild(item);
+      function stopStream() {
+        if (eventSource) {
+          eventSource.close();
+          eventSource = null;
         }
       }
 
-      function setEventHistory(events, append = false) {
-        const normalized = normalizeEvents(events);
-        if (append) {
-          eventHistory = eventHistory.concat(normalized);
-        } else {
-          eventHistory = normalized;
-        }
-        eventsOutput.textContent = JSON.stringify(eventHistory, null, 2);
-        updateNodeHighlights(eventHistory);
-      }
-
-      function setStatus(message, isError = false) {
-        statusOutput.textContent = message || "";
-        statusOutput.classList.toggle("error", isError);
-      }
-
-      async function doGet(path, query) {
-        const runId = getRunId();
-        const threadId = normalizeThreadId();
-        const url = runApiUrl(path.replace("{runId}", runId).replace("{threadId}", threadId), query);
-        const response = await fetch(url, { headers: { "Accept": "application/json" } });
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(`${response.status}: ${errorText || response.statusText}`);
-        }
-        return response.json();
-      }
-
-      async function loadState() {
-        helpOutput.classList.add("hidden");
-        setStatus("요청 중...");
-        try {
-          const payload = await doGet("/api/runs/{runId}/state");
-          stateOutput.textContent = JSON.stringify(payload, null, 2);
-          setStatus("state 조회 완료");
-        } catch (error) {
-          setStatus(String(error), true);
-        }
-      }
-
-      async function loadEvents() {
-        helpOutput.classList.add("hidden");
-        setStatus("요청 중...");
-        try {
-          const payload = await doGet("/api/runs/{runId}/events", { lastEventId: lastEventIdInput.value.trim() });
-          setEventHistory(Array.isArray(payload.events) ? payload.events : []);
-          setStatus("events 조회 완료");
-        } catch (error) {
-          setStatus(String(error), true);
-        }
-      }
-
-      function openStream() {
-        helpOutput.classList.add("hidden");
-        try {
-          setStatus("SSE 연결 시도 중...");
-          const runId = getRunId();
-          const threadId = normalizeThreadId();
-          if (!threadId) {
-            setStatus("threadId를 입력하세요.", true);
-            return;
-          }
-          if (streamHandle) {
-            streamHandle.close();
-          }
-
-          const url = runApiUrl(`/api/runs/${encodeURIComponent(runId)}/events/stream`, {
-            fromSeq: fromSeqInput.value.trim(),
-            lastEventId: lastEventIdInput.value.trim(),
-          });
-
-          const source = new EventSource(url);
-          streamHandle = source;
-          setEventHistory([]);
-          source.addEventListener("open", () => {
-            setStatus("SSE 연결됨");
-          });
-
-          source.addEventListener("run-event", (event) => {
-            try {
-              const data = JSON.parse(event.data);
-              setEventHistory([data], true);
-            } catch (err) {
-              setStatus(`SSE parse error: ${err.message}`, true);
+      function applyEvent(event) {
+        if (event.eventType === "node_started" && event.nodeId) {
+          for (const nodeId of orderedNodeIds) {
+            if (nodeCardById.get(nodeId).classList.contains("running")) {
+              setNodeState(nodeId, "done");
             }
-          });
-          source.addEventListener("error", () => {
-            setStatus("SSE 연결이 종료되었거나 오류가 발생했습니다.", true);
-            source.close();
-            streamHandle = null;
-          });
-        } catch (error) {
-          setStatus(String(error), true);
+          }
+          setNodeState(String(event.nodeId), "running");
+          return;
+        }
+
+        if (event.eventType === "node_completed" && event.nodeId) {
+          setNodeState(String(event.nodeId), "done");
+          return;
+        }
+
+        if (event.eventType === "run_completed") {
+          isRunning = false;
+          runButton.disabled = false;
+          runButton.textContent = "Run";
+          stopStream();
         }
       }
 
-      function closeStream() {
-        if (streamHandle) {
-          streamHandle.close();
-          streamHandle = null;
-          setStatus("SSE 연결 종료");
-        }
+      function subscribeEvents(runId) {
+        stopStream();
+        eventSource = new EventSource(`${API_ORIGIN}/api/runs/${encodeURIComponent(runId)}/events/stream`);
+        eventSource.addEventListener("run-event", (event) => {
+          applyEvent(JSON.parse(event.data));
+        });
+        eventSource.addEventListener("error", () => {
+          if (isRunning) {
+            stopStream();
+          }
+        });
       }
 
-      async function createRun() {
-        helpOutput.classList.add("hidden");
-        setStatus("run 생성 중...");
+      async function startRun() {
+        if (isRunning) {
+          return;
+        }
+
+        if (runButton.disabled) {
+          return;
+        }
+
         try {
-          const body = {};
-          const runId = runIdInput.value.trim();
-          const threadId = threadIdInput.value.trim();
-          if (runId) {
-            body.runId = runId;
-          }
-          if (threadId) {
-            body.threadId = threadId;
+          isRunning = true;
+          runButton.disabled = true;
+          runButton.textContent = "실행 중…";
+          resetNodeStates();
+
+          const runId = `run_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+          const threadId = `thread_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+
+          const createResponse = await fetch(`${API_ORIGIN}/api/runs`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              runId,
+              threadId,
+              workflowId: WORKFLOW_ID,
+            }),
+          });
+          if (!createResponse.ok) {
+            const message = await createResponse.text();
+            throw new Error(`run 생성 실패: ${createResponse.status} ${message}`);
           }
 
-          const response = await fetch(runApiUrl("/api/runs"), {
+          subscribeEvents(runId);
+
+          const runResponse = await fetch(`${API_ORIGIN}/api/runs/${encodeURIComponent(runId)}/demo/run`, {
             method: "POST",
-            headers: { "Content-Type": "application/json", Accept: "application/json" },
-            body: JSON.stringify(body),
           });
-          if (!response.ok) {
-            const errorText = await response.text();
-            throw new Error(`${response.status}: ${errorText || response.statusText}`);
+          if (!runResponse.ok) {
+            const message = await runResponse.text();
+            throw new Error(`demo 실행 실패: ${runResponse.status} ${message}`);
           }
-          const payload = await response.json();
-          runIdInput.value = payload.runId;
-          threadIdInput.value = payload.threadId;
-          stateOutput.textContent = JSON.stringify(payload.state, null, 2);
-          setEventHistory([]);
-          setStatus("run 생성 완료");
         } catch (error) {
-          setStatus(String(error), true);
+          isRunning = false;
+          runButton.disabled = false;
+          runButton.textContent = "Run";
+          stopStream();
+          console.error(error);
+          alert(error.message || "실행 중 오류가 발생했습니다.");
         }
       }
 
-      async function emitEvent() {
-        helpOutput.classList.add("hidden");
-        setStatus("이벤트 emit 중...");
-        try {
-          const runId = getRunId();
-          const eventType = eventTypeInput.value.trim();
-          if (!eventType) {
-            throw new Error("eventType is required");
-          }
-          const payload = parsePayload(eventPayloadInput.value);
-          const response = await fetch(runApiUrl(`/api/runs/${encodeURIComponent(runId)}/events`), {
-            method: "POST",
-            headers: { "Content-Type": "application/json", Accept: "application/json" },
-            body: JSON.stringify({ eventType, payload }),
-          });
-          if (!response.ok) {
-            const errorText = await response.text();
-            throw new Error(`${response.status}: ${errorText || response.statusText}`);
-          }
-          const result = await response.json();
-          if (result.state) {
-            stateOutput.textContent = JSON.stringify(result.state, null, 2);
-          }
-          if (result.event) {
-            setEventHistory([result.event], true);
-          } else {
-            setEventHistory(eventHistory, false);
-          }
-          setStatus("이벤트 emit 완료");
-        } catch (error) {
-          setStatus(String(error), true);
+      async function init() {
+        const response = await fetch(`${API_ORIGIN}/api/workflows/${WORKFLOW_ID}/schema`);
+        if (!response.ok) {
+          throw new Error(`workflow 로드 실패: ${response.status}`);
         }
+        const schema = await response.json();
+        renderWorkflow(schema);
       }
 
-      document.getElementById("btn-state").addEventListener("click", loadState);
-      document.getElementById("btn-events").addEventListener("click", loadEvents);
-      document.getElementById("btn-stream").addEventListener("click", openStream);
-      document.getElementById("btn-stop").addEventListener("click", closeStream);
-      document.getElementById("btn-create-run").addEventListener("click", createRun);
-      document.getElementById("btn-emit").addEventListener("click", emitEvent);
+      runButton.addEventListener("click", () => {
+        startRun();
+      });
+
+      init().catch((error) => {
+        workflowContainer.innerHTML = "<div class=\"empty\">workflow를 불러오지 못했습니다.</div>";
+        runButton.disabled = true;
+        alert(error.message || "초기화 실패");
+      });
     </script>
   </body>
 </html>

--- a/langgraph_vis/python_backend/app/__init__.py
+++ b/langgraph_vis/python_backend/app/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "history_api",
     "history_store",
     "run_orchestrator",
+    "demo_workflow_runner",
     "schema_registry",
     "schema_api",
     "run_state_api",

--- a/langgraph_vis/python_backend/app/demo_workflow_runner.py
+++ b/langgraph_vis/python_backend/app/demo_workflow_runner.py
@@ -1,0 +1,144 @@
+"""Simple demo workflow runner for LangGraph-shaped executions."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Awaitable, Callable
+
+from .run_error_contract import RunApiError, RUN_ERROR_CODES, RUN_ERROR_MESSAGES
+from .run_orchestrator import RunOrchestrator
+from .schema_registry import WorkflowSchemaRegistry
+
+SleepFn = Callable[[float], Awaitable[None]]
+RandomFn = Callable[[], float]
+
+
+class DemoWorkflowRunner:
+    """Generate `node_started`/`node_completed` events in sequence for a workflow."""
+
+    def __init__(
+        self,
+        *,
+        orchestrator: RunOrchestrator,
+        schema_registry: WorkflowSchemaRegistry | None = None,
+        *,
+        random_fn: RandomFn | None = None,
+        delay_fn: SleepFn | None = None,
+        loop_probability: float = 0.35,
+        max_steps: int = 24,
+        min_node_delay_seconds: float = 3.0,
+        max_node_delay_seconds: float = 5.0,
+    ):
+        self.orchestrator = orchestrator
+        self.schema_registry = schema_registry or WorkflowSchemaRegistry()
+        self.random_fn = random_fn or __import__("random").random
+        self.delay_fn = delay_fn or asyncio.sleep
+        self.loop_probability = loop_probability
+        self.max_steps = max_steps
+        self.min_node_delay_seconds = min_node_delay_seconds
+        self.max_node_delay_seconds = max_node_delay_seconds
+
+    async def run_workflow(self, run_id: str, *, workflow_id: str | None = None) -> None:
+        """Run a workflow by emitting events to the run store."""
+        run_state = self.orchestrator.state(run_id)
+        effective_workflow_id = workflow_id or run_state.get("workflowId")
+
+        if not effective_workflow_id:
+            raise RunApiError(
+                400,
+                RUN_ERROR_CODES["INVALID_RUN_PAYLOAD"],
+                f"{RUN_ERROR_MESSAGES[RUN_ERROR_CODES['INVALID_RUN_PAYLOAD']]}: workflowId is required",
+            )
+
+        request_id = str(uuid.uuid4())
+        workflow = await self.schema_registry.get_by_id(effective_workflow_id, {"requestId": request_id})
+        nodes = self._sorted_nodes(workflow.get("nodes", []))
+        if not nodes:
+            raise RunApiError(
+                400,
+                RUN_ERROR_CODES["INVALID_RUN_PAYLOAD"],
+                f"{RUN_ERROR_MESSAGES[RUN_ERROR_CODES['INVALID_RUN_PAYLOAD']]}: workflow has no nodes",
+            )
+
+        next_by_from = self._build_next_by_from(workflow.get("edges", []))
+        start_node_id = nodes[0]["id"]
+        end_node_id = nodes[-1]["id"]
+        current_node_id = start_node_id
+        next_node_fallback = None
+
+        step = 0
+        for step in range(1, self.max_steps + 1):
+            run_state = self.orchestrator.state(run_id)
+            if run_state["state"] != "running":
+                return
+
+            self.orchestrator.node_started(
+                run_id,
+                current_node_id,
+                {
+                    "iteration": step,
+                    "workflowId": effective_workflow_id,
+                },
+            )
+            await self.delay_fn(self._next_delay_seconds())
+
+            run_state = self.orchestrator.state(run_id)
+            if run_state["state"] != "running":
+                return
+
+            self.orchestrator.node_completed(
+                run_id,
+                current_node_id,
+                {
+                    "iteration": step,
+                    "workflowId": effective_workflow_id,
+                },
+            )
+
+            if current_node_id == end_node_id:
+                if self._should_loop_back() and step < self.max_steps:
+                    current_node_id = start_node_id
+                    continue
+                break
+
+            next_node_fallback = next_by_from.get(current_node_id)
+            if next_node_fallback is None:
+                break
+            current_node_id = next_node_fallback
+
+        self.orchestrator.complete_run(
+            run_id,
+            {
+                "workflowId": effective_workflow_id,
+                "steps": step,
+                "status": "completed",
+            },
+        )
+
+    def _next_delay_seconds(self) -> float:
+        delay_ratio = self.random_fn()
+        low = min(self.min_node_delay_seconds, self.max_node_delay_seconds)
+        high = max(self.min_node_delay_seconds, self.max_node_delay_seconds)
+        normalized = max(0.0, min(1.0, delay_ratio))
+        return low + (high - low) * normalized
+
+    def _should_loop_back(self) -> bool:
+        return self.random_fn() < self.loop_probability
+
+    def _sorted_nodes(self, nodes):
+        return sorted(
+            nodes,
+            key=lambda node: int(node.get("order", 0)),
+        )
+
+    def _build_next_by_from(self, edges):
+        next_by_from = {}
+        for edge in edges:
+            if not isinstance(edge, dict):
+                continue
+            source = edge.get("from")
+            target = edge.get("to")
+            if isinstance(source, str) and isinstance(target, str) and source and target:
+                next_by_from.setdefault(source, target)
+        return next_by_from

--- a/langgraph_vis/python_backend/app/run_state_api.py
+++ b/langgraph_vis/python_backend/app/run_state_api.py
@@ -19,7 +19,9 @@ from .run_error_contract import (
     normalize_run_error,
 )
 from .resync_controller import resolve_replay_from
+from .demo_workflow_runner import DemoWorkflowRunner
 from .run_orchestrator import RunOrchestrator
+from .schema_registry import WorkflowSchemaRegistry
 from .run_state_machine import is_terminal_state
 
 HEARTBEAT_MS = 20_000
@@ -99,9 +101,14 @@ def _heartbeat(now: datetime | None = None) -> str:
     return f": heartbeat {now_iso}\n\n"
 
 
-def create_run_state_router(*, store):
+def create_run_state_router(*, store, workflow_registry: WorkflowSchemaRegistry | None = None, demo_runner: DemoWorkflowRunner | None = None):
     router = APIRouter()
     orchestrator = RunOrchestrator(store=store)
+    workflow_registry = workflow_registry or WorkflowSchemaRegistry()
+    demo_runner = demo_runner or DemoWorkflowRunner(
+        orchestrator=orchestrator,
+        schema_registry=workflow_registry,
+    )
 
     def _validation_error(request_id: str, message: str):
         return JSONResponse(
@@ -293,6 +300,38 @@ def create_run_state_router(*, store):
             }
         except ValueError as error:
             return _validation_error(request_id, str(error))
+        except Exception as error:
+            return await _on_error(error, request_id)
+
+    @router.post("/api/runs/{run_id}/demo/run")
+    async def run_demo_workflow(run_id: str):
+        request_id = str(uuid.uuid4())
+        try:
+            run_state = store.get_run_state(run_id)
+            if is_terminal_state(run_state["state"]):
+                return JSONResponse(
+                    status_code=409,
+                    content={
+                        "code": RUN_ERROR_CODES["INVALID_RUN_TRANSITION"],
+                        "message": RUN_ERROR_MESSAGES[RUN_ERROR_CODES["INVALID_RUN_TRANSITION"]],
+                        "requestId": request_id,
+                    },
+                    headers={"Cache-Control": "no-cache"},
+                )
+
+            workflow_id = run_state.get("workflowId")
+            if not workflow_id:
+                return _validation_error(
+                    request_id,
+                    "workflowId is required for demo run",
+                )
+
+            asyncio.create_task(demo_runner.run_workflow(run_id, workflow_id=workflow_id))
+            return {
+                "runId": run_id,
+                "workflowId": workflow_id,
+                "status": "running",
+            }
         except Exception as error:
             return await _on_error(error, request_id)
 

--- a/langgraph_vis/python_backend/tests/test_demo_workflow_runner.py
+++ b/langgraph_vis/python_backend/tests/test_demo_workflow_runner.py
@@ -1,0 +1,88 @@
+import asyncio
+
+from python_backend.app.demo_workflow_runner import DemoWorkflowRunner
+from python_backend.app.run_orchestrator import RunOrchestrator
+from python_backend.app.run_state_store import RunStateStore
+from python_backend.app.schema_registry import WorkflowSchemaRegistry
+
+
+class _SequenceRandom:
+    def __init__(self, values):
+        self.values = list(values)
+        self._index = 0
+
+    def __call__(self):
+        value = self.values[self._index]
+        self._index += 1
+        return value
+
+
+async def _sleep_noop(_seconds: float) -> None:
+    return None
+
+
+def test_runner_completes_after_expected_three_node_path():
+    store = RunStateStore()
+    orchestrator = RunOrchestrator(store=store)
+    orchestrator.create_run(
+        run_id="run_demo",
+        thread_id="thread_demo",
+        workflow_id="langgraph_demo_workflow_v1",
+    )
+
+    runner = DemoWorkflowRunner(
+        orchestrator=orchestrator,
+        schema_registry=WorkflowSchemaRegistry(manifest_path="docs/week-01/schema-contract.fixture.json"),
+        random_fn=_SequenceRandom([0.2, 0.2, 0.2, 0.9]).__call__,
+        delay_fn=_sleep_noop,
+        loop_probability=0.35,
+        max_steps=12,
+    )
+
+    asyncio.run(runner.run_workflow("run_demo"))
+
+    events = store.list_events("run_demo")
+    run_completed = [event for event in events if event["eventType"] == "run_completed"]
+    node_starts = [event for event in events if event["eventType"] == "node_started"]
+    node_completions = [event for event in events if event["eventType"] == "node_completed"]
+
+    assert len(node_starts) == 3
+    assert len(node_completions) == 3
+    assert len(run_completed) == 1
+
+    node_order = [event["nodeId"] for event in node_starts]
+    assert node_order == ["dummy_node_1", "dummy_node_2", "dummy_node_3"]
+
+    final_state = store.get_run_state("run_demo")
+    assert final_state["state"] == "completed"
+
+
+def test_runner_supports_loop_back_to_first_node():
+    store = RunStateStore()
+    orchestrator = RunOrchestrator(store=store)
+    orchestrator.create_run(
+        run_id="run_loop_demo",
+        thread_id="thread_loop_demo",
+        workflow_id="langgraph_demo_workflow_v1",
+    )
+
+    runner = DemoWorkflowRunner(
+        orchestrator=orchestrator,
+        schema_registry=WorkflowSchemaRegistry(manifest_path="docs/week-01/schema-contract.fixture.json"),
+        random_fn=_SequenceRandom([0.1] * 20).__call__,
+        delay_fn=_sleep_noop,
+        loop_probability=1.0,
+        max_steps=6,
+    )
+
+    asyncio.run(runner.run_workflow("run_loop_demo"))
+
+    events = store.list_events("run_loop_demo")
+    node_starts = [event for event in events if event["eventType"] == "node_started"]
+    node_completions = [event for event in events if event["eventType"] == "node_completed"]
+
+    assert len(node_starts) == 6
+    assert len(node_completions) == 6
+    assert node_starts[0]["nodeId"] == "dummy_node_1"
+    assert node_starts[-1]["nodeId"] == "dummy_node_3"
+    assert store.get_run_state("run_loop_demo")["state"] == "completed"


### PR DESCRIPTION
## 변경 사항

- Python 백엔드 데모 워크플로우 실행 지연을 3~5초 랜덤으로 고정하고, 프론트는 이벤트 기반 하이라이트만 담당하도록 정리.
- `langgraph_demo_workflow_v1` 더미 워크플로우 실행을 위한 런 생성/실행 엔드포인트와 테스트를 연동.
- UI는 workflow 노드 + Run 버튼만 남긴 최소 UI로 정리.
- 실행 가이드(README)에서 데모 동작(3~5초 랜덤 지연, 루프 동작 포함) 반영.

## 포함 커밋
- `32314c03` README 실행 가이드 업데이트
- `02d3a4fd` 데모 런너/테스트/백엔드 라우터/프론트 반영