### PR TITLE
feat: support optional npm mirror registry in Docker build

### DIFF
--- a/chat_front/.env.example
+++ b/chat_front/.env.example
@@ -1,0 +1,6 @@
+# npm mirror registry (optional — leave empty to use public npmjs.org)
+NPM_REGISTRY=https://your-company-registry.example.com
+
+# Backend URLs (used by docker-compose build args → Vite env vars)
+VITE_WORKFLOW_WS_URL=ws://192.168.1.5:10001/ws/connect
+VITE_WORKFLOW_GRAPH_URL=http://192.168.1.5:10001/graph

--- a/chat_front/Dockerfile
+++ b/chat_front/Dockerfile
@@ -1,7 +1,9 @@
 FROM node:20-alpine
 WORKDIR /app
+ARG NPM_REGISTRY
+RUN if [ -n "$NPM_REGISTRY" ]; then npm config set registry "$NPM_REGISTRY"; fi
 COPY package.json package-lock.json* ./
-RUN npm install
+RUN npm ci --include=dev
 COPY . .
 ARG VITE_WORKFLOW_WS_URL
 ARG VITE_WORKFLOW_GRAPH_URL

--- a/chat_front/docker-compose.yml
+++ b/chat_front/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     build:
       context: .
       args:
+        NPM_REGISTRY: ${NPM_REGISTRY:-}
         VITE_WORKFLOW_WS_URL: ws://192.168.1.5:10001/ws/connect
         VITE_WORKFLOW_GRAPH_URL: http://192.168.1.5:10001/graph
     ports:


### PR DESCRIPTION
## Summary
- Add `NPM_REGISTRY` build arg to Dockerfile — sets npm registry only when provided
- Switch `npm install` → `npm ci --include=dev` for deterministic, dev-dep-inclusive builds
- Pass `NPM_REGISTRY` from `.env` via docker-compose build args
- Add `.env.example` documenting all configurable variables

## Test plan
- [ ] Build without `NPM_REGISTRY` set — should use public npmjs.org
- [ ] Build with `NPM_REGISTRY=https://your-mirror` set in `.env` — should use mirror
- [ ] Verify `docker compose ps` shows both services `Up`
- [ ] Hit `http://localhost:10000` to confirm frontend loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)