### PR TITLE
refactor: update BaseTool to async ainvoke interface

### DIFF
--- a/chat_front/backend/tools/registry.py
+++ b/chat_front/backend/tools/registry.py
@@ -1,14 +1,26 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any, Dict
 
 
 class BaseTool(ABC):
+    def __init__(self, name: str, description: str) -> None:
+        self.name = name
+        self.description = description
+
     @abstractmethod
-    def run(self, query: str) -> str:
+    async def ainvoke(self, input_data: Dict[str, Any]) -> Any:
         ...
 
 
 class RetrieverTool(BaseTool):
-    def run(self, query: str) -> str:
+    def __init__(self) -> None:
+        super().__init__(
+            name="retriever",
+            description="Retrieves relevant documents for a given query",
+        )
+
+    async def ainvoke(self, input_data: Dict[str, Any]) -> Any:
+        query = input_data.get("query", "")
         return f"[retriever] {query}"


### PR DESCRIPTION
## Summary
- Replace sync `run(query: str)` with abstract `async ainvoke(input_data: Dict[str, Any]) -> Any`
- Add `__init__(name, description)` to `BaseTool`
- Update `RetrieverTool` to implement new interface

## Test plan
- [ ] Verify `RetrieverTool().ainvoke({"query": "test"})` returns expected string
- [ ] Verify subclasses must implement `ainvoke` (abstract enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)