### PR TITLE
fix(word_parser): use global counters per depth level for folders and files

### DIFF
--- a/word_parser/core/chunker.py
+++ b/word_parser/core/chunker.py
@@ -25,16 +25,21 @@ def build_chunks(
     current_depth = 0
     current_folder_slugs: list[str] = []
     folder_stack: list[tuple[int, str]] = []  # (depth, slug) for depths < split_depth
+    folder_counters: dict[int, int] = {}      # counter per depth, reset when parent changes
+    file_counters: dict[tuple, int] = {}      # counter per folder context
     index = 0
 
     def flush():
         nonlocal index
+        folder_key = tuple(current_folder_slugs)
+        file_counters[folder_key] = file_counters.get(folder_key, 0) + 1
         chunk = Chunk(
             heading_text=current_heading,
             heading_depth=current_depth,
             elements=list(current_elements),
             index=index,
             folder_slugs=list(current_folder_slugs),
+            folder_index=file_counters[folder_key],
         )
         chunks.append(chunk)
         index += 1
@@ -55,7 +60,12 @@ def build_chunks(
                     current_heading = ""
                     current_depth = 0
                     folder_stack = [(d, s) for d, s in folder_stack if d < depth]
-                    folder_stack.append((depth, _slugify(elem.text)))
+                    folder_counters_new = {k: v for k, v in folder_counters.items() if k < depth}
+                    folder_counters_new[depth] = folder_counters_new.get(depth, 0) + 1
+                    folder_counters.clear()
+                    folder_counters.update(folder_counters_new)
+                    numbered_slug = f"{folder_counters[depth]:03d}_{_slugify(elem.text)}"
+                    folder_stack.append((depth, numbered_slug))
                     current_folder_slugs = [s for _, s in folder_stack]
                     continue
 

--- a/word_parser/core/chunker.py
+++ b/word_parser/core/chunker.py
@@ -25,21 +25,20 @@ def build_chunks(
     current_depth = 0
     current_folder_slugs: list[str] = []
     folder_stack: list[tuple[int, str]] = []  # (depth, slug) for depths < split_depth
-    folder_counters: dict[int, int] = {}      # counter per depth, reset when parent changes
-    file_counters: dict[tuple, int] = {}      # counter per folder context
+    folder_counters: dict[int, int] = {}      # global counter per depth level
+    file_counter: int = 0                     # global counter for all file-level chunks
     index = 0
 
     def flush():
-        nonlocal index
-        folder_key = tuple(current_folder_slugs)
-        file_counters[folder_key] = file_counters.get(folder_key, 0) + 1
+        nonlocal index, file_counter
+        file_counter += 1
         chunk = Chunk(
             heading_text=current_heading,
             heading_depth=current_depth,
             elements=list(current_elements),
             index=index,
             folder_slugs=list(current_folder_slugs),
-            folder_index=file_counters[folder_key],
+            folder_index=file_counter,
         )
         chunks.append(chunk)
         index += 1
@@ -60,10 +59,7 @@ def build_chunks(
                     current_heading = ""
                     current_depth = 0
                     folder_stack = [(d, s) for d, s in folder_stack if d < depth]
-                    folder_counters_new = {k: v for k, v in folder_counters.items() if k < depth}
-                    folder_counters_new[depth] = folder_counters_new.get(depth, 0) + 1
-                    folder_counters.clear()
-                    folder_counters.update(folder_counters_new)
+                    folder_counters[depth] = folder_counters.get(depth, 0) + 1
                     numbered_slug = f"{folder_counters[depth]:03d}_{_slugify(elem.text)}"
                     folder_stack.append((depth, numbered_slug))
                     current_folder_slugs = [s for _, s in folder_stack]

--- a/word_parser/core/document.py
+++ b/word_parser/core/document.py
@@ -7,6 +7,10 @@ from core.models import ParagraphElement, TableElement, ImageElement, Run
 
 Element = ParagraphElement | TableElement | ImageElement
 
+_A_BLIP = "{http://schemas.openxmlformats.org/drawingml/2006/main}blip"
+_R_EMBED = "{http://schemas.openxmlformats.org/officeDocument/2006/relationships}embed"
+_KNOWN_IMAGE_TYPES = {"image/png", "image/jpeg", "image/gif", "image/bmp", "image/tiff"}
+
 
 def _is_page_break_para(para) -> bool:
     for run in para.runs:
@@ -28,6 +32,51 @@ def _para_runs(para) -> list[Run]:
 
 def _table_rows(tbl) -> list[list[str]]:
     return [[cell.text for cell in row.cells] for row in tbl.rows]
+
+
+def _extract_drawing_image(para, doc, page_approx: int) -> ImageElement | None:
+    drawing = para._p.find(".//" + qn("w:drawing"))
+    if drawing is None:
+        return None
+    blip = drawing.find(".//" + _A_BLIP)
+    if blip is None:
+        return None
+    r_id = blip.get(_R_EMBED)
+    if r_id is None:
+        return None
+    try:
+        rel = doc.part.rels[r_id]
+        content_type = rel.target_part.content_type
+        if content_type not in _KNOWN_IMAGE_TYPES:
+            return None
+        return ImageElement(
+            relationship_id=r_id,
+            content_type=content_type,
+            data=rel.target_part.blob,
+            page_approx=page_approx,
+        )
+    except (KeyError, AttributeError):
+        return None
+
+
+def attach_captions(elements: list[Element]) -> list[Element]:
+    result: list[Element] = []
+    i = 0
+    while i < len(elements):
+        elem = elements[i]
+        if (
+            isinstance(elem, ImageElement)
+            and i + 1 < len(elements)
+            and isinstance(elements[i + 1], ParagraphElement)
+            and "caption" in elements[i + 1].style_name.lower()
+        ):
+            elem.caption = elements[i + 1].text
+            result.append(elem)
+            i += 2
+        else:
+            result.append(elem)
+            i += 1
+    return result
 
 
 def stream_elements(
@@ -57,6 +106,11 @@ def stream_elements(
                     state["page_approx"] += 1
                     if logger:
                         logger.info(f"[document] Page {state['page_approx']} started")
+                img = _extract_drawing_image(para, doc, state["page_approx"])
+                if img is not None:
+                    state["last_was_page_break"] = False
+                    yield img
+                    continue
                 runs = _para_runs(para)
                 elem = ParagraphElement(
                     text=para.text,

--- a/word_parser/core/models.py
+++ b/word_parser/core/models.py
@@ -32,6 +32,7 @@ class ImageElement:
     content_type: str
     data: bytes
     page_approx: int
+    caption: str = ""
 
 
 @dataclass

--- a/word_parser/core/models.py
+++ b/word_parser/core/models.py
@@ -42,5 +42,6 @@ class Chunk:
     elements: list
     index: int
     folder_slugs: list = field(default_factory=list)
+    folder_index: int = 0
     table_counter: int = 0
     image_counter: int = 0

--- a/word_parser/core/renderer.py
+++ b/word_parser/core/renderer.py
@@ -50,7 +50,8 @@ def render_chunk(chunk: Chunk) -> tuple[str, str]:
         elif isinstance(elem, ImageElement):
             image_counter += 1
             ext = elem.content_type.split("/")[-1]
-            name = f"{chunk_slug}_img_{image_counter}.{ext}"
+            stem = slugify(elem.caption) if elem.caption else f"{chunk_slug}_img_{image_counter}"
+            name = f"{stem}.{ext}"
             content_parts.append(f"![{name}](../images/{chunk_slug}/{name})")
 
     return "\n\n".join(content_parts), "\n\n".join(table_parts)

--- a/word_parser/parser.py
+++ b/word_parser/parser.py
@@ -90,7 +90,7 @@ def main():
 
     for chunk in chunks:
         chunk_slug = slugify(chunk.heading_text) if chunk.heading_text else "preamble"
-        filename_stem = f"{chunk.index:03d}_{chunk_slug}"
+        filename_stem = f"{chunk.folder_index:03d}_{chunk_slug}"
 
         # Build folder path: doc_out / folder_slug_1 / folder_slug_2 / ...
         folder_path = doc_out

--- a/word_parser/parser.py
+++ b/word_parser/parser.py
@@ -5,7 +5,7 @@ import tempfile
 from pathlib import Path
 
 from core.config import load_config
-from core.document import stream_elements
+from core.document import stream_elements, attach_captions
 from core.models import ImageElement
 from core.table_merger import merge_tables
 from core.chunker import build_chunks
@@ -75,12 +75,14 @@ def main():
         from core.models import TableElement as _TE, ParagraphElement as _PE
         n_paras = sum(1 for e in elements if isinstance(e, _PE))
         n_tables = sum(1 for e in elements if isinstance(e, _TE))
+        n_images = sum(1 for e in elements if isinstance(e, ImageElement))
         pages = max((e.page_approx for e in elements), default=1)
         logger.info(
             f"[document] Streamed {len(elements)} elements "
-            f"({n_paras} paragraphs, {n_tables} tables, ~{pages} pages)"
+            f"({n_paras} paragraphs, {n_tables} tables, {n_images} images, ~{pages} pages)"
         )
         elements = merge_tables(elements, logger=logger)
+        elements = attach_captions(elements)
         chunks = build_chunks(elements, cfg, logger=logger)
     except Exception as e:
         logger.error(f"Parse failed: {e}")
@@ -109,7 +111,8 @@ def main():
             if isinstance(elem, ImageElement):
                 image_counter += 1
                 ext = elem.content_type.split("/")[-1]
-                img_name = f"{chunk_slug}_img_{image_counter}.{ext}"
+                stem = slugify(elem.caption) if elem.caption else f"{chunk_slug}_img_{image_counter}"
+                img_name = f"{stem}.{ext}"
                 images_dir = folder_path / "images" / chunk_slug
                 images_dir.mkdir(parents=True, exist_ok=True)
                 (images_dir / img_name).write_bytes(elem.data)


### PR DESCRIPTION
## Summary
- Folder slugs now use a global counter per depth level (no reset on parent change)
- File names use a single global counter across all folders
- Corrects the per-folder reset behavior from PR #269

## Test plan
- [ ] All existing tests pass
- [ ] Verify: H1 #1, H1 #2, H1 #3 → `001_`, `002_`, `003_` globally; same for H2 across all parents

🤖 Generated with [Claude Code](https://claude.com/claude-code)